### PR TITLE
Add an ema decay schedule

### DIFF
--- a/axlearn/common/schedule.py
+++ b/axlearn/common/schedule.py
@@ -338,3 +338,27 @@ def linear_schedule_with_warmup(
         ],
         start_step=[warmup_steps],
     )
+
+
+def ema_schedule(decay: float = 0.9999, *, warmup_steps: int = 1) -> ScheduleFn:
+    """Ema decay schedule with warm-up.
+
+    The ema decay is 0, 1/2, 2/3, 3/4, 4/5, ... during warm-up, and then is constant at decay.
+
+    Args:
+        decay: ema decay.
+        warmup_steps: The number of steps of the warm-up schedule.
+
+    Returns:
+        A ema decay schedule.
+
+    Raises:
+        ValueError: If warmup_steps <= 0.
+    """
+    if warmup_steps <= 0:
+        raise ValueError("warmup_steps must be > 0.")
+
+    def fn(step):
+        return step / (1.0 + step) * (step < warmup_steps) + decay * (step >= warmup_steps)
+
+    return fn

--- a/axlearn/common/schedule_test.py
+++ b/axlearn/common/schedule_test.py
@@ -209,6 +209,24 @@ class ScheduleTest(absltest.TestCase):
         self.assertAlmostEqual(fn(100), 0)
         self.assertAlmostEqual(fn(200), 1 - (101) ** (-0.8))
 
+    def test_ema_schedule(self):
+        warmup_steps = 5
+        s = jax.jit(
+            schedule.ema_schedule(
+                warmup_steps=warmup_steps,
+            )
+        )
+        expected_warmup = [0.0, 1.0 / 2, 2.0 / 3, 3.0 / 4, 4.0 / 5]
+        expected_decay = 0.9999
+        for step in range(10):
+            value = s(step)
+            if step < warmup_steps:
+                # Test warmup.
+                self.assertAlmostEqual(expected_warmup[step], value)
+            else:
+                # Test inverse sqrt schedule.
+                self.assertAlmostEqual(expected_decay, value)
+
 
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
The ema decay is 0, 1/2, 2/3, 3/4, 4/5, ... during warm-up, and then stays constant at decay.

In particular, this is useful when we load a pre-trained checkpoint into model weights and want to set ema to model weight at step 0.