### PR TITLE
add EfficientNetV2 implementation

### DIFF
--- a/axlearn/vision/efficientdet.py
+++ b/axlearn/vision/efficientdet.py
@@ -264,6 +264,7 @@ class BoxClassHead(BaseLayer):
 def set_efficientdet_config(
     *,
     backbone_variant: str = "b0",
+    backbone_version: str = "V1",
     num_head_layers: int = 3,
     min_level: int = 3,
     max_level: int = 7,
@@ -274,6 +275,8 @@ def set_efficientdet_config(
 
     Args:
         backbone_variant: The EfficientNet backbone variant, e.g., "b0", "lite0".
+        backbone_version: The EfficientNet backbone version, i.e.,
+            "V1" (https://arxiv.org/abs/1905.11946) or "V2" (https://arxiv.org/abs/2104.00298).
         num_head_layers: The number of layers in the box and class head.
         min_level: The minimum feature level in the BiFPN and prediction heads.
         max_level: The maximum feature level in the BiFPN and prediction heads.
@@ -285,7 +288,11 @@ def set_efficientdet_config(
     """
     base_cfg = RetinaNetModel.default_config()
 
-    backbone_cfg = named_model_configs(ModelNames.EFFICIENTNET, backbone_variant)
+    backbone_cfg = named_model_configs(
+        ModelNames.EFFICIENTNET,
+        backbone_variant,
+        efficientnet_version=backbone_version,
+    )
     backbone_cfg = backbone_cfg.set(
         embedding_layer=None,
         endpoints_mode=EndpointsMode.LASTBLOCKS,

--- a/axlearn/vision/image_classification_test.py
+++ b/axlearn/vision/image_classification_test.py
@@ -2,9 +2,12 @@
 
 """Tests image classification models."""
 import difflib
+from functools import partial
+from typing import Callable
 
 import jax.random
 import numpy as np
+import timm
 import torch
 from absl import logging
 from absl.testing import absltest, parameterized
@@ -13,88 +16,26 @@ from torchvision.models.resnet import resnet18, resnet34, resnet50, resnet101, r
 
 from axlearn.common import utils
 from axlearn.common.config import InstantiableConfig
-from axlearn.common.module import NestedTensor
 from axlearn.common.module import functional as F
 from axlearn.common.test_utils import TestCase
 from axlearn.common.utils import as_tensor
 from axlearn.common.vision_transformer import build_vit_model_config
 from axlearn.vision.image_classification import ImageClassificationModel
+from axlearn.vision.mobilenets import ModelNames, named_model_configs
+from axlearn.vision.param_converter import MobileNetsParamConverter, ResNetParamConverter
 from axlearn.vision.resnet import ResNet
 
 
-def params_from_conv(ref: torch.nn.Module) -> NestedTensor:
-    return {
-        "weight": ref.weight.permute(2, 3, 1, 0),
-    }
-
-
-def params_from_linear(ref: torch.nn.Module) -> NestedTensor:
-    return {
-        "weight": ref.weight.transpose(1, 0),
-        "bias": ref.bias,
-    }
-
-
-def params_from_bn(ref: torch.nn.Module) -> NestedTensor:
-    return {
-        "scale": ref.weight,
-        "bias": ref.bias,
-        "moving_mean": ref.running_mean,
-        "moving_variance": ref.running_var,
-    }
-
-
-def params_from_downsample(ref: torch.nn.ModuleList) -> NestedTensor:
-    return {
-        "conv": params_from_conv(ref[0]),
-        "norm": params_from_bn(ref[1]),
-    }
-
-
-def params_from_block(ref: torch.nn.Module) -> NestedTensor:
-    params = {
-        "conv1": params_from_conv(ref.conv1),
-        "norm1": params_from_bn(ref.bn1),
-        "conv2": params_from_conv(ref.conv2),
-        "norm2": params_from_bn(ref.bn2),
-    }
-    if hasattr(ref, "conv3"):
-        params["conv3"] = params_from_conv(ref.conv3)
-    if hasattr(ref, "bn3"):
-        params["norm3"] = params_from_bn(ref.bn3)
-    if getattr(ref, "downsample"):
-        params["downsample"] = params_from_downsample(ref.downsample)
-    return params
-
-
-def params_from_stage(ref: torch.nn.ModuleList) -> NestedTensor:
-    return {f"block{i}": params_from_block(block) for i, block in enumerate(ref)}
-
-
-def params_from_stem(ref: torch.nn.ModuleList) -> NestedTensor:
-    return {
-        "conv1": params_from_conv(ref.conv1),
-        "norm1": params_from_bn(ref.bn1),
-    }
-
-
-def params_from_backbone(ref: torch.nn.ModuleList) -> NestedTensor:
-    return {
-        "stem": params_from_stem(ref),
-        **{f"stage{i}": params_from_stage(getattr(ref, f"layer{i + 1}")) for i in range(4)},
-    }
-
-
-def params_from_resnet(ref: torch.nn.Module) -> NestedTensor:
-    return {
-        "backbone": params_from_backbone(ref),
-        "classifier": params_from_linear(ref.fc),
-    }
-
-
 # pylint: disable=no-self-use
-class ResNetClassificationModelTest(parameterized.TestCase):
-    def _base_test(self, cfg: InstantiableConfig, ref: torch.nn.Module, is_training=False):
+class ClassificationModelTest(parameterized.TestCase):
+    def _base_test(
+        self,
+        *,
+        cfg: InstantiableConfig,
+        ref: torch.nn.Module,
+        params_from_model: Callable,
+        is_training: bool = False,
+    ):
         model = cfg.set(name="test", num_classes=1000).instantiate(parent=None)
         init_params = model.initialize_parameters_recursively(jax.random.PRNGKey(1))
 
@@ -107,7 +48,7 @@ class ResNetClassificationModelTest(parameterized.TestCase):
         for name, param in ref.named_parameters():
             logging.info("ref param: %s=%s", name, list(param.shape))
 
-        model_params = jax.tree_util.tree_map(utils.as_tensor, params_from_resnet(ref))
+        model_params = jax.tree_util.tree_map(utils.as_tensor, params_from_model(ref=ref))
         model_param_strs = [
             f"{name}={list(param.shape)}" for name, param in utils.flatten_items(model_params)
         ]
@@ -155,7 +96,71 @@ class ResNetClassificationModelTest(parameterized.TestCase):
     )
     def test_resnets(self, model_depth, is_training):
         cfg, torch_model = self._get_resnet_cfg_model(model_depth)
-        self._base_test(cfg, torch_model(pretrained=True), is_training=is_training)
+        params_from_model = ResNetParamConverter.params_from_model
+        self._base_test(
+            cfg=cfg,
+            ref=torch_model(pretrained=True),
+            params_from_model=params_from_model,
+            is_training=is_training,
+        )
+
+    def _get_mobilenet_cfg_model(self, model_name: ModelNames, variant: str, version: str):
+        backbone_cfg = named_model_configs(model_name, variant, efficientnet_version=version)
+        # Use TF default settings for BN and padding as we compare against TF reference checkpoint.
+        # https://github.com/huggingface/pytorch-image-models/blob/394e8145551191ae60f672556936314a20232a35/timm/models/efficientnet.py#L1926-L2223
+        cfg = ImageClassificationModel.default_config().set(backbone=backbone_cfg)
+
+        timm_model_name = {
+            (ModelNames.EFFICIENTNET, "V1"): "efficientnet",
+            (ModelNames.EFFICIENTNET, "V2"): "efficientnetv2",
+            (ModelNames.MOBILENETV3, None): "mobilenetv3",
+        }[(model_name, version)]
+        timm_variant = variant.replace("-", "_").lower()
+        ref = timm.create_model(f"tf_{timm_model_name}_{timm_variant}", pretrained=True)
+
+        return cfg, ref
+
+    @parameterized.product(
+        model_arch=(
+            (ModelNames.MOBILENETV3, "small-minimal-100", None),
+            (ModelNames.MOBILENETV3, "small-075", None),
+            (ModelNames.MOBILENETV3, "small-100", None),
+            (ModelNames.MOBILENETV3, "large-minimal-100", None),
+            (ModelNames.MOBILENETV3, "large-075", None),
+            (ModelNames.MOBILENETV3, "large-100", None),
+            (ModelNames.EFFICIENTNET, "B0", "V1"),
+            (ModelNames.EFFICIENTNET, "B1", "V1"),
+            (ModelNames.EFFICIENTNET, "B2", "V1"),
+            (ModelNames.EFFICIENTNET, "B3", "V1"),
+            (ModelNames.EFFICIENTNET, "B4", "V1"),
+            (ModelNames.EFFICIENTNET, "B5", "V1"),
+            (ModelNames.EFFICIENTNET, "B6", "V1"),
+            (ModelNames.EFFICIENTNET, "B7", "V1"),
+            (ModelNames.EFFICIENTNET, "B8", "V1"),
+            (ModelNames.EFFICIENTNET, "lite0", "V1"),
+            (ModelNames.EFFICIENTNET, "lite1", "V1"),
+            (ModelNames.EFFICIENTNET, "lite2", "V1"),
+            (ModelNames.EFFICIENTNET, "lite3", "V1"),
+            (ModelNames.EFFICIENTNET, "lite4", "V1"),
+            (ModelNames.EFFICIENTNET, "B0", "V2"),
+            (ModelNames.EFFICIENTNET, "B1", "V2"),
+            (ModelNames.EFFICIENTNET, "B2", "V2"),
+            (ModelNames.EFFICIENTNET, "B3", "V2"),
+            (ModelNames.EFFICIENTNET, "S", "V2"),
+            (ModelNames.EFFICIENTNET, "M", "V2"),
+            (ModelNames.EFFICIENTNET, "L", "V2"),
+        ),
+        is_training=(False, True),
+    )
+    def test_mobilenets(self, model_arch, is_training):
+        cfg, torch_model = self._get_mobilenet_cfg_model(*model_arch)
+        params_from_model = partial(MobileNetsParamConverter.params_from_model, cfg=cfg)
+        self._base_test(
+            cfg=cfg,
+            ref=torch_model,
+            params_from_model=params_from_model,
+            is_training=is_training,
+        )
 
 
 class ViTClassificationModelTest(TestCase):

--- a/axlearn/vision/mobilenets.py
+++ b/axlearn/vision/mobilenets.py
@@ -5,14 +5,22 @@
 # rwightman/efficientnet-jax:
 # Copyright 2020 Ross Wightman.
 # Licensed under the Apache License, Version 2.0 (the "License").
+#
+# huggingface/pytorch-image-models:
+# Copyright 2019 Ross Wightman.
+# Licensed under the Apache License, Version 2.0 (the "License").
 
-"""Implementation of mobile networks containing MobileNetV3, EfficientNet and EfficientNet-Lite.
+"""Implementation of mobile networks containing MobileNetV3,
+EfficientNet, EfficientNetV2 and EfficientNet-Lite.
 
-Reference:
+References:
 https://arxiv.org/abs/1905.02244
 https://arxiv.org/abs/1905.11946
+https://arxiv.org/abs/2104.00298
 
-Implementation adapted from: https://github.com/rwightman/efficientnet-jax/.
+Implementation adapted from:
+https://github.com/rwightman/efficientnet-jax/
+https://github.com/huggingface/pytorch-image-models/blob/main/timm/models/efficientnet.py
 """
 import contextlib
 import enum
@@ -36,8 +44,8 @@ from axlearn.common.module import Module, Tensor
 from axlearn.common.param_init import PARAM_REGEXP_WEIGHT, DefaultInitializer, WeightInitializer
 from axlearn.vision.mobilenets_blocks import (
     ConvBnAct,
-    DepthwiseSeparable,
-    InvertedResidual,
+    MobileBlock,
+    MobileBlockType,
     SamePaddingType,
     SeReduceReference,
     round_features,
@@ -119,23 +127,23 @@ def _mobilenet_linear() -> Linear.Config:
 
 
 def _mobilenet_batchnorm2d() -> BatchNorm.Config:
-    # BatchNorm settings follow
+    # BatchNorm settings follow the PyTorch default,
     # https://github.com/rwightman/efficientnet-jax/blob/20e1b87d04f3588dbc4470701b551ae680ea6177/jeffnet/common/constants.py#L11-L12
-    return BatchNorm.default_config().set(decay=0.9, eps=1e-5)
+    return BatchNorm.default_config().set(decay=0.9, eps=1e-3)
 
 
 class MobileNetV3Embedding(BaseLayer):
-    """Embedding computation for MobileNetV3"""
+    """Embedding computation for MobileNetV3."""
 
     @config_class
     class Config(BaseLayer.Config):
-        # Input dim
+        # Input dim.
         input_dim: Required[int] = REQUIRED
-        # Output dim; number of features
+        # Output dim; number of features.
         output_dim: Required[int] = REQUIRED
-        # Activation function
+        # Activation function.
         activation: str = "nn.relu"
-        # Convolution layer
+        # Convolution layer.
         conv_layer: InstantiableConfig = _mobilenet_conv2d()
 
     def __init__(self, cfg: Config, *, parent: Module):
@@ -154,10 +162,10 @@ class MobileNetV3Embedding(BaseLayer):
         """Computes image embedding.
 
         Args:
-            x: A float tensor of shape [batch_size, height, width, input_dim]
+            x: A float tensor of shape [batch_size, height, width, input_dim].
 
         Returns:
-            A float tensor of shape [batch_size, cfg.output_dim]
+            A float tensor of shape [batch_size, cfg.output_dim].
         """
         cfg = self.config
 
@@ -169,22 +177,22 @@ class MobileNetV3Embedding(BaseLayer):
 
 
 class EfficientNetEmbedding(BaseLayer):
-    """Embedding computation for EfficientNet"""
+    """Embedding computation for EfficientNet."""
 
     @config_class
     class Config(BaseLayer.Config):
         """Configures EfficientNetEmbedding."""
 
-        # Input dim
+        # Input dim.
         input_dim: Required[int] = REQUIRED
-        # Output dim; number of features
+        # Output dim; number of features.
         output_dim: Required[int] = REQUIRED
-        # Activation function
+        # Activation function.
         activation: str = "nn.relu"
 
-        # Convolution layer
+        # Convolution layer.
         conv_layer: InstantiableConfig = _mobilenet_conv2d()
-        # Normalization layer
+        # Normalization layer.
         norm_layer: InstantiableConfig = _mobilenet_batchnorm2d()
 
     def __init__(self, cfg: Config, *, parent: Module):
@@ -207,10 +215,10 @@ class EfficientNetEmbedding(BaseLayer):
         """Computes image embedding.
 
         Args:
-            x: A float tensor of shape [batch_size, height, width, input_dim]
+            x: A float tensor of shape [batch_size, height, width, input_dim].
 
         Returns:
-            A float tensor of shape [batch_size, output_dim]
+            A float tensor of shape [batch_size, output_dim].
         """
         cfg = self.config
         x = self.conv_pw(x)
@@ -229,46 +237,68 @@ class MobileNets(BaseModel):
     class Config(BaseLayer.Config):
         """Configures MobileNets."""
 
+        # Convolution followed by BatchNorm followed by activation.
         conv_bn_act: InstantiableConfig = ConvBnAct.default_config()
-        inverted_residual: InstantiableConfig = InvertedResidual.default_config()
-        depthwise_separable: InstantiableConfig = DepthwiseSeparable.default_config()
+        # Depthwise separable convolution.
+        depthwise_separable: InstantiableConfig = MobileBlock.default_config().set(
+            mobile_block_type=MobileBlockType.DEPTHWISE_SEPARABLE
+        )
+        # Inverted bottleneck block.
+        inverted_bottleneck: InstantiableConfig = MobileBlock.default_config().set(
+            mobile_block_type=MobileBlockType.INVERTED_BOTTLENECK
+        )
+        # Fused inverted bottleneck block.
+        fused_inverted_bottleneck: InstantiableConfig = MobileBlock.default_config().set(
+            mobile_block_type=MobileBlockType.FUSED_INVERTED_BOTTLENECK
+        )
 
+        # Convolution layer.
         conv_layer: InstantiableConfig = _mobilenet_conv2d()
+        # Linear layer.
         linear_layer: InstantiableConfig = _mobilenet_linear()
+        # Normalization layer.
         norm_layer: InstantiableConfig = _mobilenet_batchnorm2d()
+        # Sqeeze excitation layer.
         se_layer: InstantiableConfig = SqueezeExcitation.default_config().set(
             gating="nn.hard_sigmoid"
         )
+        # Drop path regularization.
         drop_path: InstantiableConfig = StochasticDepth.default_config()
         # Activation function applied to all blocks unless overwritten by block-specific args.
         activation: str = "nn.relu"
 
-        output_dim: Required[int] = REQUIRED  # Output dim; number of features.
-        stem_size: int = 16  # Number of features produced by the stem.
-        scale_stem: bool = True  # If true scale stem with feat_multiplier, else use stem_size.
-        # A nested list (stages and blocks per stage) of the block types (one of: inverted_residual,
-        # depthwise_separable, conv_bn_act) and the config arguments to instantiate the block class.
-        block_defs: List[List[Tuple[str, Dict[str, Any]]]] = None
-        feat_multiplier: float = 1.0  # Width multiplier to scale the number of features.
+        # Output dim; number of features.
+        output_dim: Required[int] = REQUIRED
+        # Number of features produced by the stem.
+        stem_size: int = 16
+        # If True scale stem with feat_multiplier, else use stem_size.
+        scale_stem: bool = True
+        # Nested list (stages and blocks per stage) of MobileBlockType
+        # and config args to instantiate the block class.
+        block_defs: List[List[Tuple[MobileBlockType, Dict[str, Any]]]] = None
+        # Width multiplier to scale the number of features.
+        feat_multiplier: float = 1.0
+        # Minimum factor for rounding down the number of features.
+        round_limit: float = 0.9
         drop_path_rate: float = 0.0
 
-        # Embedding layer config
+        # Embedding layer config.
         embedding_layer: InstantiableConfig = MobileNetV3Embedding.default_config()
 
-        # Padding type for the network
+        # Padding type for the network.
         padding_type: SamePaddingType = SamePaddingType.DEFAULT
 
-        # Endpoints mode, i.e., which intermediate representations to return
+        # Endpoints mode, i.e., which intermediate representations to return.
         endpoints_mode: EndpointsMode = EndpointsMode.DEFAULT
 
-        # If specified return only a subset of the intermediate representations
+        # If specified return only a subset of the intermediate representations.
         endpoints_names: Optional[Set[str]] = None
 
     def __init__(self, cfg: Config, *, parent: Module):
         @contextlib.contextmanager
         def _register_endpoint() -> Iterator:
-            # TODO(pdufter) unify endpoint computation for mobilenet, efficientnet, other backbones
-            # Register endpoints
+            # TODO(pdufter) unify endpoint computation for mobilenet, efficientnet, other backbones.
+            # Register endpoints.
             if cfg.endpoints_mode == EndpointsMode.DEFAULT:
                 # Default endpoints index starts from 2.
                 self._endpoints_dims[str(endpoint_idx + 1)] = block_args["output_dim"]
@@ -312,28 +342,29 @@ class MobileNets(BaseModel):
 
         self.vlog(3, f"Building model trunk with {len(cfg.block_defs)} stages...")
         num_blocks = sum([len(x) for x in cfg.block_defs])
-        # start counting endpoint index from 1
+        # Start counting endpoint index from 1.
         flat_idx, endpoint_idx = 0, 1
         self._stages = []
 
-        # Store the mapping from stage and block idx to feature name
+        # Store the mapping from stage and block idx to feature name.
         self._block_to_endpoint_name, self._endpoints_dims = {}, {}
 
-        # Outer list of block_args defines the stacks
+        # Outer list of block_args defines the stacks.
         for stage_idx, stage_defs in enumerate(cfg.block_defs):
             self.vlog(3, f"Stack #{stage_idx}")
             blocks = []
-            # Each stage contains a list of block types and arguments
+            # Each stage contains a list of block types and arguments.
             for block_idx, (block_type, block_args) in enumerate(stage_defs):
-                # Check and adjust stride
+                # Check and adjust stride.
                 if block_args["stride"] not in (1, 2):
                     raise ValueError(f'Invalid value for stride: {block_args["stride"]}.')
-                if block_idx >= 1:  # Only the first block in any stack can have a stride > 1
+                # Only the first block in any stack can have a stride > 1.
+                if block_idx >= 1:
                     block_args["stride"] = 1
-                # store stride value for endpoint registration
+                # Store stride value for endpoint registration.
                 current_stride = block_args["stride"]
 
-                # update block args
+                # Update block args.
                 block_args["input_dim"] = input_dim
                 block_args = self._update_block_args(
                     block_args=block_args,
@@ -341,10 +372,10 @@ class MobileNets(BaseModel):
                     block_type=block_type,
                     drop_path_multiplier=flat_idx / num_blocks,
                 )
-                # Set input_dim of next block to be output_dim of current block
+                # Set input_dim of next block to be output_dim of current block.
                 input_dim = block_args["output_dim"]
 
-                # Create and add the block
+                # Create and add the block.
                 self.vlog(
                     3,
                     f"\tBlock {block_idx},{flat_idx}/{num_blocks}, {block_type}, {str(block_args)}",
@@ -353,9 +384,10 @@ class MobileNets(BaseModel):
                 blocks.append(
                     self._add_child(f"blocks_{stage_idx}_{block_idx}", block_cfg),
                 )
-                flat_idx += 1  # Increment flattened block idx (across all stages)
+                # Increment flattened block idx (across all stages)
+                flat_idx += 1
 
-                # Check if we add the stem to the feature maps
+                # Check if we add the stem to the feature maps.
                 if (
                     cfg.endpoints_mode == EndpointsMode.LASTBLOCKS
                     and stage_idx == block_idx == 0
@@ -370,13 +402,17 @@ class MobileNets(BaseModel):
             self._stages.append(blocks)
 
         if cfg.embedding_layer is not None:
-            self._add_child(
-                "embedding_layer",
-                cfg.embedding_layer.set(
-                    input_dim=input_dim,
-                    output_dim=cfg.output_dim,
-                ),
+            embedding_layer_cfg = cfg.embedding_layer.set(
+                input_dim=input_dim,
+                output_dim=cfg.output_dim,
             )
+            if hasattr(embedding_layer_cfg, "conv_layer"):
+                embedding_layer_cfg.conv_layer = cfg.conv_layer
+            if hasattr(embedding_layer_cfg, "activation"):
+                embedding_layer_cfg.activation = cfg.activation
+            if hasattr(embedding_layer_cfg, "norm_layer"):
+                embedding_layer_cfg.norm_layer = cfg.norm_layer
+            self._add_child("embedding_layer", embedding_layer_cfg)
             # The embedding layer after global average pooling and the final point-wise convolution.
             self._endpoints_dims["embedding"] = cfg.output_dim
             self._block_to_endpoint_name["embedding"] = "embedding"
@@ -387,7 +423,9 @@ class MobileNets(BaseModel):
     def _compute_stem_size(self) -> int:
         cfg = self.config
         if cfg.scale_stem:
-            return round_features(cfg.stem_size, multiplier=cfg.feat_multiplier)
+            return round_features(
+                cfg.stem_size, multiplier=cfg.feat_multiplier, round_limit=cfg.round_limit
+            )
         else:
             return cfg.stem_size
 
@@ -396,7 +434,7 @@ class MobileNets(BaseModel):
         *,
         block_args: Dict[str, Any],
         global_block_args: Dict[str, Any],
-        block_type: str,
+        block_type: MobileBlockType,
         drop_path_multiplier: float,
     ) -> Dict[str, Any]:
         """Updates the block args by verifying/changing values and adding configs.
@@ -404,7 +442,7 @@ class MobileNets(BaseModel):
         Args:
             block_args: Block args which will be updated.
             global_block_args: Global block args that will overwrite block_args.
-            block_type: The block type, e.g., "depthwise_separable" or "inverted_residual"
+            block_type: The block type.
             drop_path_multiplier: Multiplier for the drop_path.
 
         Returns:
@@ -413,33 +451,26 @@ class MobileNets(BaseModel):
         cfg = self.config
         block_args.update(global_block_args)
 
-        # set output dimension
+        # Set output dimension.
         block_args["output_dim"] = round_features(
-            block_args["output_dim"], multiplier=cfg.feat_multiplier
+            block_args["output_dim"], multiplier=cfg.feat_multiplier, round_limit=cfg.round_limit
         )
 
-        # Block activation function overrides the model default
+        # Block activation function overrides the model default.
         if not block_args["activation"]:
             block_args["activation"] = cfg.activation
 
-        if block_type in ["inverted_residual", "depthwise_separable"]:
+        if block_type in {
+            MobileBlockType.DEPTHWISE_SEPARABLE,
+            MobileBlockType.INVERTED_BOTTLENECK,
+            MobileBlockType.FUSED_INVERTED_BOTTLENECK,
+        }:
             se_ratio = block_args.pop("se_ratio", 0.0)
             if se_ratio > 0.0:
                 block_args["se_layer"] = cfg.se_layer.clone(se_ratio=se_ratio)
             if cfg.drop_path_rate > 0.0:
                 block_args["drop_path"] = cfg.drop_path.clone(
                     rate=cfg.drop_path_rate * drop_path_multiplier
-                )
-            if block_type == "inverted_residual":
-                block_args["depthwise_separable"] = cfg.depthwise_separable.clone(
-                    conv_layer=block_args["conv_layer"],
-                    norm_layer=block_args["norm_layer"],
-                    se_layer=block_args.pop("se_layer", None),
-                    drop_path=block_args.pop("drop_path", None),
-                    activation=block_args["activation"],
-                    kernel_size=block_args.pop("kernel_size"),
-                    stride=block_args.pop("stride"),
-                    padding_type=block_args.pop("padding_type"),
                 )
         return block_args
 
@@ -485,55 +516,75 @@ class MobileNets(BaseModel):
         return self._endpoints_dims
 
 
-def _decode_block_str(block_str: str) -> Tuple[str, Dict[str, Any], int]:
+def _decode_block_str(block_str: str) -> Tuple[MobileBlockType, Dict[str, Any], int]:
     """Decode block definition string.
-    E.g. ir_r3_k5_s2_e3_c40_se0.25_nre
+    E.g. ib_r3_k5_s2_e3_c40_se0.25_nre
 
     All args can exist in any order with the exception of the leading string which
     is assumed to indicate the block type.
 
-    leading string - block type (ir = InvertedResidual, ds = DepthwiseSep, cn = ConvBnAct)
-    r - number of repeat blocks,
-    k - kernel size,
-    s - strides (1-9),
-    e - expansion ratio,
-    c - output channels,
-    se - squeeze/excitation ratio
-    n - activation fn ('re')
+    leading string - block type.
+        ib = INVERTED_BOTTLENECK.
+        fib = FUSED_INVERTED_BOTTLENECK.
+        ds = DEPTHWISE_SEPARABLE.
+        cn = CONV_BN_ACT.
+    r - number of repeat blocks.
+    k - kernel size.
+    s - strides (1-9).
+    e - expansion ratio.
+    c - output channels.
+    se - squeeze/excitation ratio.
+    n - activation fn ('re').
+    skip - use a skip connection.
 
     Reference:
     https://github.com/rwightman/efficientnet-jax/blob/master/jeffnet/common/arch_defs.py
 
     Args:
         block_str: a string representation of block arguments.
+
     Returns:
-        A tuple of the block type (str), block arguments (dict), number of repetitions (int).
+        A tuple of the block type (MobileBlockType), block arguments (dict),
+        number of repetitions (int).
+
     Raises:
         NotImplementedError: If block_type is unknown.
     """
     assert isinstance(block_str, str)
     ops = block_str.split("_")
-    block_type = ops[0]  # Take the block type off the front
+    # Take the block type off the front.
+    block_type = {
+        "ib": MobileBlockType.INVERTED_BOTTLENECK,
+        "fib": MobileBlockType.FUSED_INVERTED_BOTTLENECK,
+        "ds": MobileBlockType.DEPTHWISE_SEPARABLE,
+        "cn": MobileBlockType.CONV_BN_ACT,
+    }[ops[0]]
+    use_skip_connection_if_possible = False
     options = {}
     for op in ops[1:]:
-        # String options being checked on individual basis
-        if op == "nre":
-            # activation fn
+        # String options being checked on individual basis.
+        if op == "skip":
+            # Use a skip connection if the block architecture allows for it.
+            use_skip_connection_if_possible = True
+        elif op == "nre":
+            # Activation function.
             options["n"] = "nn.relu"
         else:
-            # All numeric options
+            # All numeric options.
             split = re.split(r"(\d.*)", op)
             key, value = split[:2]
             options[key] = value
 
-    # If activation is None, the model default (passed to model init) will be used
+    # If activation is None, the model default (passed to model init) will be used.
     activation = options.get("n", None)
     se_ratio = float(options.get("se", 0.0))
     num_repeat = int(options["r"])
 
-    # Each type of block has different valid arguments, fill accordingly
-    if block_type == "ir":
-        block_type = "inverted_residual"
+    # Each type of block has different valid arguments, fill accordingly.
+    if block_type in {
+        MobileBlockType.INVERTED_BOTTLENECK,
+        MobileBlockType.FUSED_INVERTED_BOTTLENECK,
+    }:
         block_args = dict(
             activation=activation,
             output_dim=int(options["c"]),
@@ -542,8 +593,7 @@ def _decode_block_str(block_str: str) -> Tuple[str, Dict[str, Any], int]:
             exp_ratio=float(options["e"]),
             se_ratio=se_ratio,
         )
-    elif block_type == "ds":
-        block_type = "depthwise_separable"
+    elif block_type == MobileBlockType.DEPTHWISE_SEPARABLE:
         block_args = dict(
             activation=activation,
             output_dim=int(options["c"]),
@@ -551,13 +601,13 @@ def _decode_block_str(block_str: str) -> Tuple[str, Dict[str, Any], int]:
             stride=int(options["s"]),
             se_ratio=se_ratio,
         )
-    elif block_type == "cn":
-        block_type = "conv_bn_act"
+    elif block_type == MobileBlockType.CONV_BN_ACT:
         block_args = dict(
             activation=activation,
             output_dim=int(options["c"]),
             kernel_size=int(options["k"]),
             stride=int(options["s"]),
+            use_skip_connection_if_possible=use_skip_connection_if_possible,
         )
     else:
         raise NotImplementedError(f"Unknown block type: {block_type}.")
@@ -570,14 +620,15 @@ def _decode_arch_def(
     depth_multiplier: float = 1.0,
     depth_trunc: str = "ceil",
     fix_first_last: bool = False,
-) -> List[List[Tuple[str, Dict[str, Any]]]]:
+) -> List[List[Tuple[MobileBlockType, Dict[str, Any]]]]:
     """Decodes model architecture definition into corresponding block types and block arguments.
 
     Args:
         arch_def: A representation of the model architecture as a nested list of strings.
         depth_multiplier: Multiplier to scale the depth of stages.
-        depth_trunc: Truncation policy for computing the depth of stages
+        depth_trunc: Truncation policy for computing the depth of stages.
         fix_first_last: If true, prefer to have smaller depth in first and last stage.
+
     Returns:
         A nested list (stages and blocks per stage) of the types and arguments of each block.
     """
@@ -621,13 +672,13 @@ def _arch_mobilenet_v3(variant: str) -> Dict[str, Any]:
                 # stage 0, 112x112 in
                 ["ds_r1_k3_s2_e1_c16"],
                 # stage 1, 56x56 in
-                ["ir_r1_k3_s2_e4.5_c24", "ir_r1_k3_s1_e3.67_c24"],
+                ["ib_r1_k3_s2_e4.5_c24", "ib_r1_k3_s1_e3.67_c24"],
                 # stage 2, 28x28 in
-                ["ir_r1_k3_s2_e4_c40", "ir_r2_k3_s1_e6_c40"],
+                ["ib_r1_k3_s2_e4_c40", "ib_r2_k3_s1_e6_c40"],
                 # stage 3, 14x14 in
-                ["ir_r2_k3_s1_e3_c48"],
+                ["ib_r2_k3_s1_e3_c48"],
                 # stage 4, 14x14in
-                ["ir_r3_k3_s2_e6_c96"],
+                ["ib_r3_k3_s2_e6_c96"],
                 # stage 6, 7x7 in
                 ["cn_r1_k1_s1_c576"],
             ]
@@ -637,13 +688,13 @@ def _arch_mobilenet_v3(variant: str) -> Dict[str, Any]:
                 # stage 0, 112x112 in
                 ["ds_r1_k3_s2_e1_c16_se0.25_nre"],  # relu
                 # stage 1, 56x56 in
-                ["ir_r1_k3_s2_e4.5_c24_nre", "ir_r1_k3_s1_e3.67_c24_nre"],  # relu
+                ["ib_r1_k3_s2_e4.5_c24_nre", "ib_r1_k3_s1_e3.67_c24_nre"],  # relu
                 # stage 2, 28x28 in
-                ["ir_r1_k5_s2_e4_c40_se0.25", "ir_r2_k5_s1_e6_c40_se0.25"],  # hard-swish
+                ["ib_r1_k5_s2_e4_c40_se0.25", "ib_r2_k5_s1_e6_c40_se0.25"],  # hard-swish
                 # stage 3, 14x14 in
-                ["ir_r2_k5_s1_e3_c48_se0.25"],  # hard-swish
+                ["ib_r2_k5_s1_e3_c48_se0.25"],  # hard-swish
                 # stage 4, 14x14in
-                ["ir_r3_k5_s2_e6_c96_se0.25"],  # hard-swish
+                ["ib_r3_k5_s2_e6_c96_se0.25"],  # hard-swish
                 # stage 6, 7x7 in
                 ["cn_r1_k1_s1_c576"],  # hard-swish
             ]
@@ -655,15 +706,15 @@ def _arch_mobilenet_v3(variant: str) -> Dict[str, Any]:
                 # stage 0, 112x112 in
                 ["ds_r1_k3_s1_e1_c16"],
                 # stage 1, 112x112 in
-                ["ir_r1_k3_s2_e4_c24", "ir_r1_k3_s1_e3_c24"],
+                ["ib_r1_k3_s2_e4_c24", "ib_r1_k3_s1_e3_c24"],
                 # stage 2, 56x56 in
-                ["ir_r3_k3_s2_e3_c40"],
+                ["ib_r3_k3_s2_e3_c40"],
                 # stage 3, 28x28 in
-                ["ir_r1_k3_s2_e6_c80", "ir_r1_k3_s1_e2.5_c80", "ir_r2_k3_s1_e2.3_c80"],
+                ["ib_r1_k3_s2_e6_c80", "ib_r1_k3_s1_e2.5_c80", "ib_r2_k3_s1_e2.3_c80"],
                 # stage 4, 14x14in
-                ["ir_r2_k3_s1_e6_c112"],
+                ["ib_r2_k3_s1_e6_c112"],
                 # stage 5, 14x14in
-                ["ir_r3_k3_s2_e6_c160"],
+                ["ib_r3_k3_s2_e6_c160"],
                 # stage 6, 7x7 in
                 ["cn_r1_k1_s1_c960"],
             ]
@@ -673,19 +724,19 @@ def _arch_mobilenet_v3(variant: str) -> Dict[str, Any]:
                 # stage 0, 112x112 in
                 ["ds_r1_k3_s1_e1_c16_nre"],  # relu
                 # stage 1, 112x112 in
-                ["ir_r1_k3_s2_e4_c24_nre", "ir_r1_k3_s1_e3_c24_nre"],  # relu
+                ["ib_r1_k3_s2_e4_c24_nre", "ib_r1_k3_s1_e3_c24_nre"],  # relu
                 # stage 2, 56x56 in
-                ["ir_r3_k5_s2_e3_c40_se0.25_nre"],  # relu
+                ["ib_r3_k5_s2_e3_c40_se0.25_nre"],  # relu
                 # stage 3, 28x28 in
                 [
-                    "ir_r1_k3_s2_e6_c80",
-                    "ir_r1_k3_s1_e2.5_c80",
-                    "ir_r2_k3_s1_e2.3_c80",
+                    "ib_r1_k3_s2_e6_c80",
+                    "ib_r1_k3_s1_e2.5_c80",
+                    "ib_r2_k3_s1_e2.3_c80",
                 ],  # hard-swish
                 # stage 4, 14x14in
-                ["ir_r2_k3_s1_e6_c112_se0.25"],  # hard-swish
+                ["ib_r2_k3_s1_e6_c112_se0.25"],  # hard-swish
                 # stage 5, 14x14in
-                ["ir_r3_k5_s2_e6_c160_se0.25"],  # hard-swish
+                ["ib_r3_k5_s2_e6_c160_se0.25"],  # hard-swish
                 # stage 6, 7x7 in
                 ["cn_r1_k1_s1_c960"],  # hard-swish
             ]
@@ -702,11 +753,11 @@ def _arch_mobilenet_v3(variant: str) -> Dict[str, Any]:
 
 
 def _scale_stage_depth(
-    stage_defs: List[Tuple[str, Dict]],
+    stage_defs: List[Tuple[MobileBlockType, Dict]],
     repeats: List[int],
     depth_multiplier: float = 1.0,
     depth_trunc: str = "ceil",
-) -> List[Tuple[str, Dict]]:
+) -> List[Tuple[MobileBlockType, Dict]]:
     """Per-stage depth scaling.
 
     Scales the block repeats in each stage.
@@ -716,6 +767,7 @@ def _scale_stage_depth(
         repeats: Number of repeats for each stages.
         depth_multiplier: Multiplier to scale the depth of stages.
         depth_trunc: Truncation policy for computing the depth of stages.
+
     Returns:
         A nested list (stages and blocks per stage) of the types and arguments of each block.
     """
@@ -726,7 +778,7 @@ def _scale_stage_depth(
     if depth_trunc == "round":
         # Truncating to int by rounding allows stages with few repeats to remain
         # proportionally smaller for longer. This is a good choice when stage definitions
-        # include single repeat stages that we'd prefer to keep that way as long as possible
+        # include single repeat stages that we'd prefer to keep that way as long as possible.
         num_repeat_scaled = max(1, round(num_repeat * depth_multiplier))
     else:
         # The default for EfficientNet truncates repeats to int via 'ceil'.
@@ -744,72 +796,141 @@ def _scale_stage_depth(
         num_repeat_scaled -= repeat_scaled
     repeats_scaled = repeats_scaled[::-1]
 
-    # Apply the calculated scaling to each block def in the stage
+    # Apply the calculated scaling to each block def in the stage.
     defs_scaled = []
     for stage_def, repeat_scaled in zip(stage_defs, repeats_scaled):
         defs_scaled.extend([deepcopy(stage_def) for _ in range(repeat_scaled)])
     return defs_scaled
 
 
-def _arch_efficientnet(variant: str, **kwargs) -> Dict[str, Any]:
-    """Defines EfficientNet model architectures.
+def _arch_efficientnet(variant: str, version: str = "V1", **kwargs) -> Dict[str, Any]:
+    """Defines EfficientNet model architectures (both V1 and V2).
 
-    Reference:
+    References:
     https://github.com/rwightman/efficientnet-jax/blob/master/jeffnet/common/arch_defs.py
+    https://github.com/huggingface/pytorch-image-models/blob/main/timm/models/efficientnet.py
 
-    Paper: https://arxiv.org/abs/1905.11946
+    Papers:
+    https://arxiv.org/abs/1905.11946
+    https://arxiv.org/abs/2104.00298
 
     Args:
-        variant: The desired EfficientNet variant.
+        variant: The desired EfficientNet variant, e.g., "b0", "lite0".
+        version: The desired EfficientNet version, i.e.,
+            "V1" (https://arxiv.org/abs/1905.11946) or "V2" (https://arxiv.org/abs/2104.00298).
+
     Returns:
         A dictionary specifying the model definition.
     """
 
-    feat_multiplier, depth_multiplier, _, _ = EFFICIENTNETVARIANTS[variant.lower()]
+    variant = variant.lower()
+    # For EfficientNetV1, we ONLY support the variants in EFFICIENTNETVARIANTS.
+    # For EfficientNetV2, we ADDITIONALLY support the S, M, L variants from the original paper.
+    if variant in EFFICIENTNETVARIANTS:
+        feat_multiplier, depth_multiplier, _, _ = EFFICIENTNETVARIANTS[variant]
+    elif version == "V2":
+        feat_multiplier, depth_multiplier = 1.0, 1.0
+    else:
+        raise ValueError(f"Invalid EfficientNetV1 variant: {variant}.")
+    round_limit = 0.9 if version == "V1" else 0.0
 
     if variant.startswith("lite"):
-        padding_type = SamePaddingType.DEFAULT
         fix_first_last = True
         output_dim = 1280
         se_cfg = ""
         activation = "nn.relu6"
         scale_stem = False
     else:
-        padding_type = SamePaddingType.SYMMETRIC
         fix_first_last = False
-        output_dim = round_features(1280, multiplier=feat_multiplier)
+        output_dim = round_features(1280, multiplier=feat_multiplier, round_limit=round_limit)
         se_ratio = 0.25
         se_cfg = f"_se{se_ratio}"
         activation = "nn.swish"
         scale_stem = True
 
-    arch_def = [
-        [f"ds_r1_k3_s1_e1_c16{se_cfg}"],
-        [f"ir_r2_k3_s2_e6_c24{se_cfg}"],
-        [f"ir_r2_k5_s2_e6_c40{se_cfg}"],
-        [f"ir_r3_k3_s2_e6_c80{se_cfg}"],
-        [f"ir_r3_k5_s1_e6_c112{se_cfg}"],
-        [f"ir_r4_k5_s2_e6_c192{se_cfg}"],
-        [f"ir_r1_k3_s1_e6_c320{se_cfg}"],
-    ]
+    if version == "V1":
+        stem_size = 32
+        arch_def = [
+            [f"ds_r1_k3_s1_e1_c16{se_cfg}"],
+            [f"ib_r2_k3_s2_e6_c24{se_cfg}"],
+            [f"ib_r2_k5_s2_e6_c40{se_cfg}"],
+            [f"ib_r3_k3_s2_e6_c80{se_cfg}"],
+            [f"ib_r3_k5_s1_e6_c112{se_cfg}"],
+            [f"ib_r4_k5_s2_e6_c192{se_cfg}"],
+            [f"ib_r1_k3_s1_e6_c320{se_cfg}"],
+        ]
+    elif version == "V2":
+        if variant == "s":
+            stem_size = 24
+            arch_def = [
+                ["cn_r2_k3_s1_e1_c24_skip"],
+                ["fib_r4_k3_s2_e4_c48"],
+                ["fib_r4_k3_s2_e4_c64"],
+                ["ib_r6_k3_s2_e4_c128_se0.25"],
+                ["ib_r9_k3_s1_e6_c160_se0.25"],
+                ["ib_r15_k3_s2_e6_c256_se0.25"],
+            ]
+        elif variant == "m":
+            stem_size = 24
+            arch_def = [
+                ["cn_r3_k3_s1_e1_c24_skip"],
+                ["fib_r5_k3_s2_e4_c48"],
+                ["fib_r5_k3_s2_e4_c80"],
+                ["ib_r7_k3_s2_e4_c160_se0.25"],
+                ["ib_r14_k3_s1_e6_c176_se0.25"],
+                ["ib_r18_k3_s2_e6_c304_se0.25"],
+                ["ib_r5_k3_s1_e6_c512_se0.25"],
+            ]
+        elif variant == "l":
+            stem_size = 32
+            arch_def = [
+                ["cn_r4_k3_s1_e1_c32_skip"],
+                ["fib_r7_k3_s2_e4_c64"],
+                ["fib_r7_k3_s2_e4_c96"],
+                ["ib_r10_k3_s2_e4_c192_se0.25"],
+                ["ib_r19_k3_s1_e6_c224_se0.25"],
+                ["ib_r25_k3_s2_e6_c384_se0.25"],
+                ["ib_r7_k3_s1_e6_c640_se0.25"],
+            ]
+        elif variant in EFFICIENTNETVARIANTS:
+            stem_size = 32
+            arch_def = [
+                ["cn_r1_k3_s1_e1_c16_skip"],
+                ["fib_r2_k3_s2_e4_c32"],
+                ["fib_r2_k3_s2_e4_c48"],
+                [f"ib_r3_k3_s2_e4_c96{se_cfg}"],
+                [f"ib_r5_k3_s1_e6_c112{se_cfg}"],
+                [f"ib_r8_k3_s2_e6_c192{se_cfg}"],
+            ]
+        else:
+            raise ValueError(f"Invalid EfficientNetV2 variant: {variant}.")
+    else:
+        raise ValueError('EfficientNet version must be either "V1" or "V2".')
 
     model_kwargs = dict(
         block_defs=_decode_arch_def(arch_def, depth_multiplier, fix_first_last=fix_first_last),
         output_dim=output_dim,
-        stem_size=32,
+        stem_size=stem_size,
         feat_multiplier=feat_multiplier,
+        round_limit=round_limit,
         activation=activation,
         se_layer=SqueezeExcitation.default_config().set(
             gating="nn.sigmoid",
             activation="nn.swish",
         ),
-        inverted_residual=InvertedResidual.default_config().set(
-            se_reduce_ref=SeReduceReference.INPUT_DIM,
-        ),
-        depthwise_separable=DepthwiseSeparable.default_config().set(
+        depthwise_separable=MobileBlock.default_config().set(
+            mobile_block_type=MobileBlockType.DEPTHWISE_SEPARABLE,
             se_reduction_divisor=1,
         ),
-        padding_type=padding_type,
+        inverted_bottleneck=MobileBlock.default_config().set(
+            mobile_block_type=MobileBlockType.INVERTED_BOTTLENECK,
+            se_reduce_ref=SeReduceReference.INPUT_DIM,
+            se_reduction_divisor=1,
+        ),
+        fused_inverted_bottleneck=MobileBlock.default_config().set(
+            mobile_block_type=MobileBlockType.FUSED_INVERTED_BOTTLENECK,
+            se_reduction_divisor=1,
+        ),
         embedding_layer=EfficientNetEmbedding.default_config(),
         drop_path_rate=0.2,
         scale_stem=scale_stem,
@@ -824,10 +945,14 @@ def _arch_efficientnet(variant: str, **kwargs) -> Dict[str, Any]:
 
 
 def named_model_configs(
-    model_name: ModelNames, variant: str, *, extra_settings: Optional[Dict[str, Any]] = None
+    model_name: ModelNames,
+    variant: str,
+    *,
+    efficientnet_version: Optional[str] = None,
+    extra_settings: Optional[Dict[str, Any]] = None,
 ) -> InstantiableConfig:
     if model_name == ModelNames.EFFICIENTNET:
-        model_settings = _arch_efficientnet(variant)
+        model_settings = _arch_efficientnet(variant, efficientnet_version)
     elif model_name == ModelNames.MOBILENETV3:
         model_settings = _arch_mobilenet_v3(variant)
     else:

--- a/axlearn/vision/mobilenets_blocks.py
+++ b/axlearn/vision/mobilenets_blocks.py
@@ -5,11 +5,22 @@
 # rwightman/efficientnet-jax:
 # Copyright 2020 Ross Wightman.
 # Licensed under the Apache License, Version 2.0 (the "License").
+#
+# huggingface/pytorch-image-models:
+# Copyright 2019 Ross Wightman.
+# Licensed under the Apache License, Version 2.0 (the "License").
 
-"""MobileNetV3 blocks.
+"""Blocks for mobile networks (incl. MobileNetV3,
+EfficientNet, EfficientNetV2 and EfficientNet-Lite).
 
-Reference: https://arxiv.org/abs/1905.02244.
-Implementation adapted from: https://github.com/rwightman/efficientnet-jax/.
+References:
+https://arxiv.org/abs/1905.02244
+https://arxiv.org/abs/1905.11946
+https://arxiv.org/abs/2104.00298
+
+Implementation adapted from:
+https://github.com/rwightman/efficientnet-jax/
+https://github.com/huggingface/pytorch-image-models/blob/main/timm/models/efficientnet.py
 """
 import enum
 import math
@@ -21,6 +32,21 @@ from axlearn.common.layers import BatchNorm, Conv2D, get_activation_fn
 from axlearn.common.module import Module
 from axlearn.common.param_init import PerGroupInitializer
 from axlearn.common.utils import Tensor
+
+
+class MobileBlockType(str, enum.Enum):
+    """Mobile block type.
+
+    CONV_BN_ACT: Convolution followed by BatchNorm followed by activation.
+    DEPTHWISE_SEPARABLE: Depthwise separable convolution.
+    INVERTED_BOTTLENECK: Inverted bottleneck block.
+    FUSED_INVERTED_BOTTLENECK: Fused inverted bottleneck block.
+    """
+
+    CONV_BN_ACT = "conv_bn_act"
+    DEPTHWISE_SEPARABLE = "depthwise_separable"
+    INVERTED_BOTTLENECK = "inverted_bottleneck"
+    FUSED_INVERTED_BOTTLENECK = "fused_inverted_bottleneck"
 
 
 class SamePaddingType(str, enum.Enum):
@@ -39,7 +65,7 @@ class SeReduceReference(str, enum.Enum):
     """Reference dimension for Squeeze Excitation layer.
 
     This enum determines which dimensionality is used for computing num_reduced_filters
-    in the Squeeze Excitation layer when used within InvertedResidual layers.
+    in the Squeeze Excitation layer when used within mobile blocks.
 
     INPUT_DIM: Use the input dim as a reference for computing num_reduced_filters.
     NUM_FEATURES: Use the number of features as a reference for computing num_reduced_filters.
@@ -49,7 +75,13 @@ class SeReduceReference(str, enum.Enum):
     NUM_FEATURES = "num_features"
 
 
-def _make_divisible(value: int, *, divisor: int = 8, min_value: Optional[int] = None) -> int:
+def _make_divisible(
+    value: int,
+    *,
+    divisor: int = 8,
+    min_value: Optional[int] = None,
+    round_limit: float = 0.9,
+) -> int:
     """Adapt value to make it divisble by divisor.
 
     Reference:
@@ -57,8 +89,8 @@ def _make_divisible(value: int, *, divisor: int = 8, min_value: Optional[int] = 
     """
     min_value = min_value or divisor
     new_value = max(min_value, int(value + divisor / 2) // divisor * divisor)
-    # Make sure that round down does not go down by more than 10%.
-    if new_value < 0.9 * value:
+    # Make sure that round down does not go down by more than (1-round_limit).
+    if new_value < round_limit * value:
         new_value += divisor
     return new_value
 
@@ -69,6 +101,7 @@ def round_features(
     multiplier: float = 1.0,
     divisor: int = 8,
     min_num_features: Optional[int] = None,
+    round_limit: float = 0.9,
 ) -> int:
     """Round number of filters based on depth multiplier.
 
@@ -78,7 +111,9 @@ def round_features(
     if not multiplier:
         return num_features
     num_features *= multiplier
-    return _make_divisible(int(num_features), divisor=divisor, min_value=min_num_features)
+    return _make_divisible(
+        int(num_features), divisor=divisor, min_value=min_num_features, round_limit=round_limit
+    )
 
 
 def _compute_same_padding(
@@ -101,21 +136,32 @@ def _compute_same_padding(
 
 
 class ConvBnAct(BaseLayer):
-    """Convolution followed by BatchNorm followed by activation function."""
+    """Convolution followed by BatchNorm followed by activation, with optional skip connection."""
 
     @config_class
     class Config(BaseLayer.Config):
         """Configures ConvBnAct."""
 
+        # Input dim.
+        input_dim: Required[int] = REQUIRED
+        # Output dim; number of features.
+        output_dim: Required[int] = REQUIRED
+
+        # Convolution layer.
         conv_layer: InstantiableConfig = Conv2D.default_config()
+        # Normalization layer.
         norm_layer: InstantiableConfig = BatchNorm.default_config()
+        # Activation function.
         activation: str = "nn.relu"
 
-        input_dim: Required[int] = REQUIRED
-        output_dim: Required[int] = REQUIRED
+        # Kernel size of the convolution layer.
         kernel_size: int = 3
+        # Stride of the convolution layer.
         stride: int = 1
-        # Padding type for computing SAME padding
+        # If True use a skip connection if the input and output dimensions match
+        # and we use a stride of 1.
+        use_skip_connection_if_possible: bool = False
+        # Padding type for computing SAME padding.
         padding_type: SamePaddingType = SamePaddingType.DEFAULT
 
     def __init__(self, cfg: Config, *, parent: Module):
@@ -134,181 +180,221 @@ class ConvBnAct(BaseLayer):
         self._add_child("conv", cfg.conv_layer)
         self._add_child("bn", cfg.norm_layer.set(input_dim=cfg.output_dim))
 
+        # Use a skip connection if the input and output dimensions match and we use a stride of 1.
+        self._use_skip_connection = (
+            cfg.use_skip_connection_if_possible
+            and cfg.stride == 1
+            and cfg.input_dim == cfg.output_dim
+        )
+
     def forward(self, x: Tensor) -> Tensor:
         cfg = self.config
+        shortcut = x
         x = self.conv(x)
         x = self.bn(x)
         x = get_activation_fn(cfg.activation)(x)
+        if self._use_skip_connection:
+            x = x + shortcut
         return x
 
 
-class DepthwiseSeparable(BaseLayer):
-    """Depthwise separable convolution, which separates spatial filtering (via a depthwise
-    convolution) from feature generation (via a pointwise convolution), with an optional
-    squeeze-excitation block in-between to adaptively weight each channel.
+class MobileBlock(BaseLayer):
+    """Implements different blocks for mobile architectures.
 
-    References:
-    https://arxiv.org/pdf/1704.04861.pdf
-    https://arxiv.org/pdf/1905.02244.pdf
+    1)  Depthwise separable convolution, which separates spatial filtering (via a depthwise
+        convolution) from feature generation (via a pointwise convolution), with an optional
+        squeeze-excitation block in between to adaptively weight each channel.
+
+        References:
+        https://arxiv.org/abs/1704.04861
+        https://arxiv.org/abs/1905.02244
+
+    2)  Mobile inverted bottleneck conv block (MBConv, sometimes also referred to as
+        inverted residual block), which has the same structure as a depthwise separable
+        block, but with an optional point-wise expansion in the beginning.
+
+        References:
+        https://arxiv.org/abs/1801.04381
+        https://arxiv.org/abs/1905.02244
+
+    3)  Fused mobile inverted bottleneck conv block (Fused-MBConv, sometimes also referred to as
+        edge residual block), with expansion convolution followed by a point-wise linear projection,
+        with an optional squeeze-excitation block in between to adaptively weight each channel.
+
+        References:
+        https://ai.googleblog.com/2019/08/efficientnet-edgetpu-creating.html
+        https://arxiv.org/abs/2104.00298
     """
 
     @config_class
     class Config(BaseLayer.Config):
-        """Configures DepthwiseSeparable."""
+        """Configures MobileBlock."""
 
+        # Type of the mobile block.
+        mobile_block_type: Required[MobileBlockType] = REQUIRED
+        # Input dim.
+        input_dim: Required[int] = REQUIRED
+        # Output dim; number of output features.
+        output_dim: Required[int] = REQUIRED
+
+        # Convolution layer.
         conv_layer: InstantiableConfig = Conv2D.default_config()
+        # Normalization layer.
         norm_layer: InstantiableConfig = BatchNorm.default_config()
-        # Squeeze-excitation block will not be applied if se_layer is None
-        se_layer: InstantiableConfig = None
-        # Drop-path regularization will not be applied if drop_path is None
-        drop_path: InstantiableConfig = None
+        # Squeeze-excitation block will not be applied if se_layer is None.
+        se_layer: Optional[InstantiableConfig] = None
+        # Drop-path regularization will not be applied if drop_path is None.
+        drop_path: Optional[InstantiableConfig] = None
+        # Activation function.
         activation: str = "nn.relu"
 
-        input_dim: Required[int] = REQUIRED
-        output_dim: Required[int] = REQUIRED
+        # Kernel size of the convolution layer.
         kernel_size: int = 3
+        # Stride of the convolution layer.
         stride: int = 1
-        # Padding type for computing SAME padding
+        # Padding type for computing SAME padding.
         padding_type: SamePaddingType = SamePaddingType.DEFAULT
-        # Reference dimension for computing the number of reduced features
-        # in the Squeeze Excitation Layer; if 0 default to input_dim
-        se_reduce_ref_dim: Optional[int] = 0
-        # Divisor for computing num_reduced_filters in Squeeze Excitation Layer
+        # Expansion ratio for expansion convolution.
+        exp_ratio: float = 1.0
+        # Reference dimension for computing num_reduced_filters in the squeeze
+        # excitation layer; if None, default to input_dim for DEPTHWISE_SEPARABLE,
+        # and to num_features for INVERTED_BOTTLENECK and FUSED_INVERTED_BOTTLENECK.
+        se_reduce_ref: Optional[SeReduceReference] = None
+        # Divisor for computing num_reduced_filters in the squeeze excitation layer.
         se_reduction_divisor: int = 8
 
     def __init__(self, cfg: Config, *, parent: Module):
         super().__init__(cfg, parent=parent)
         cfg = self.config
-        self._add_child(
-            "conv_dw",
-            cfg.conv_layer.clone(
-                input_dim=cfg.input_dim,
-                output_dim=cfg.input_dim,
-                window=(cfg.kernel_size, cfg.kernel_size),
-                strides=(cfg.stride, cfg.stride),
-                padding=_compute_same_padding(
-                    kernel_size=cfg.kernel_size, stride=cfg.stride, padding_type=cfg.padding_type
+        if cfg.mobile_block_type in {
+            MobileBlockType.INVERTED_BOTTLENECK,
+            MobileBlockType.FUSED_INVERTED_BOTTLENECK,
+        }:
+            num_features = _make_divisible(cfg.input_dim * cfg.exp_ratio)
+        else:
+            num_features = cfg.input_dim
+
+        if cfg.exp_ratio > 1.0 and (
+            cfg.mobile_block_type
+            in {MobileBlockType.INVERTED_BOTTLENECK, MobileBlockType.FUSED_INVERTED_BOTTLENECK}
+        ):
+            # Use expansion convolution (point-wise for INVERTED_BOTTLENECK).
+            conv_exp_args = {
+                "input_dim": cfg.input_dim,
+                "output_dim": num_features,
+                "bias": False,
+            }
+            if cfg.mobile_block_type == MobileBlockType.FUSED_INVERTED_BOTTLENECK:
+                conv_exp_args.update(
+                    {
+                        "window": (cfg.kernel_size, cfg.kernel_size),
+                        "strides": (cfg.stride, cfg.stride),
+                        "padding": _compute_same_padding(
+                            kernel_size=cfg.kernel_size,
+                            stride=cfg.stride,
+                            padding_type=cfg.padding_type,
+                        ),
+                    }
+                )
+
+            self._add_child("conv_exp", cfg.conv_layer.clone(**conv_exp_args))
+            self._add_child("bn_exp", cfg.norm_layer.clone(input_dim=num_features))
+
+        if cfg.mobile_block_type in {
+            MobileBlockType.DEPTHWISE_SEPARABLE,
+            MobileBlockType.INVERTED_BOTTLENECK,
+        }:
+            # Use depth-wise convolution.
+            self._add_child(
+                "conv_dw",
+                cfg.conv_layer.clone(
+                    input_dim=num_features,
+                    output_dim=num_features,
+                    window=(cfg.kernel_size, cfg.kernel_size),
+                    strides=(cfg.stride, cfg.stride),
+                    padding=_compute_same_padding(
+                        kernel_size=cfg.kernel_size,
+                        stride=cfg.stride,
+                        padding_type=cfg.padding_type,
+                    ),
+                    num_input_dim_groups=num_features,
+                    bias=False,
+                    param_init=PerGroupInitializer.default_config().set(
+                        initializer=cfg.conv_layer.param_init,
+                        num_groups=num_features,
+                    ),
                 ),
-                num_input_dim_groups=cfg.input_dim,
-                bias=False,
-                param_init=PerGroupInitializer.default_config().set(
-                    initializer=cfg.conv_layer.param_init,
-                    num_groups=cfg.input_dim,
-                ),
-            ),
-        )
+            )
+            self._add_child("bn_dw", cfg.norm_layer.clone(input_dim=num_features))
+
         self._add_child(
             "conv_pw",
             cfg.conv_layer.clone(
-                input_dim=cfg.input_dim,
+                input_dim=num_features,
                 output_dim=cfg.output_dim,
                 bias=False,
             ),
         )
-        self._add_child("bn_dw", cfg.norm_layer.clone(input_dim=cfg.input_dim))
         self._add_child("bn_pw", cfg.norm_layer.clone(input_dim=cfg.output_dim))
         if cfg.se_layer is not None:
-            if cfg.se_reduce_ref_dim == 0:
-                # TODO(pdufter) change this default behaviour
-                # and always populate cfg.se_reduce_ref_dim instead
+            if cfg.se_reduce_ref is None:
+                if cfg.mobile_block_type == MobileBlockType.DEPTHWISE_SEPARABLE:
+                    cfg.se_reduce_ref = SeReduceReference.INPUT_DIM
+                else:
+                    cfg.se_reduce_ref = SeReduceReference.NUM_FEATURES
+            if cfg.se_reduce_ref == SeReduceReference.INPUT_DIM:
                 se_reduce_ref_dim = cfg.input_dim
-            else:
-                se_reduce_ref_dim = cfg.se_reduce_ref_dim
+            elif cfg.se_reduce_ref == SeReduceReference.NUM_FEATURES:
+                se_reduce_ref_dim = num_features
             num_reduced_filters = _make_divisible(
                 se_reduce_ref_dim * cfg.se_layer.se_ratio, divisor=cfg.se_reduction_divisor
             )
             self._add_child(
                 "se",
                 cfg.se_layer.set(
-                    input_dim=cfg.input_dim,
+                    input_dim=num_features,
                     num_reduced_filters=num_reduced_filters,
                 ),
             )
         if cfg.drop_path is not None:
             self._add_child("drop_path", cfg.drop_path)
 
-    def forward(self, x: Tensor, *, shortcut: Optional[Tensor] = None) -> Tensor:
-        cfg = self.config
-        if shortcut is None:
-            shortcut = x
-
-        x = self.conv_dw(x)
-        x = self.bn_dw(x)
-        x = get_activation_fn(cfg.activation)(x)
-
-        if cfg.se_layer is not None:
-            x = self.se(x)
-
-        x = self.conv_pw(x)
-        x = self.bn_pw(x)
-
-        if cfg.stride == 1 and x.shape == shortcut.shape:
-            if cfg.drop_path is not None:
-                x = self.drop_path(x)
-            x = x + shortcut
-        return x
-
-
-class InvertedResidual(BaseLayer):
-    """Inverted residual block, which has the same structure as a depthwise separable block, but
-    with an optional point-wise expansion in the beginning.
-
-    References:
-    https://arxiv.org/pdf/1801.04381.pdf
-    https://arxiv.org/pdf/1905.02244.pdf
-    """
-
-    @config_class
-    class Config(BaseLayer.Config):
-        """Configures InvertedResidual."""
-
-        depthwise_separable: InstantiableConfig = DepthwiseSeparable.default_config()
-        conv_layer: InstantiableConfig = Conv2D.default_config()
-        norm_layer: InstantiableConfig = BatchNorm.default_config()
-        activation: str = "nn.relu"
-
-        input_dim: Required[int] = REQUIRED
-        output_dim: Required[int] = REQUIRED
-        exp_ratio: float = 1.0  # Expansion ratio for point-wise conv expansion.
-        # Reference dimension for squeeze excitation layer
-        se_reduce_ref: SeReduceReference = SeReduceReference.NUM_FEATURES
-
-    def __init__(self, cfg: Config, *, parent: Module):
-        super().__init__(cfg, parent=parent)
-        cfg = self.config
-        features = _make_divisible(cfg.input_dim * cfg.exp_ratio)
-
-        if cfg.exp_ratio > 1.0:
-            self._add_child(
-                "conv_exp",
-                cfg.conv_layer.clone(
-                    input_dim=cfg.input_dim,
-                    output_dim=features,
-                    bias=False,
-                ),
-            )
-            self._add_child("bn_exp", cfg.norm_layer.clone(input_dim=features))
-
-        if cfg.se_reduce_ref == SeReduceReference.INPUT_DIM:
-            se_reduce_ref_dim = cfg.input_dim
-        elif cfg.se_reduce_ref == SeReduceReference.NUM_FEATURES:
-            se_reduce_ref_dim = features
-        self._add_child(
-            "depthwise_separable",
-            cfg.depthwise_separable.set(
-                input_dim=features, output_dim=cfg.output_dim, se_reduce_ref_dim=se_reduce_ref_dim
-            ),
-        )
+        # Use a skip connection if the input and output dimensions match and we use a stride of 1.
+        self._use_skip_connection = cfg.input_dim == cfg.output_dim and cfg.stride == 1
 
     def forward(self, x: Tensor) -> Tensor:
         cfg = self.config
         shortcut = x
 
-        # Point-wise expansion
-        if cfg.exp_ratio > 1.0:
+        if cfg.exp_ratio > 1.0 and (
+            cfg.mobile_block_type
+            in {MobileBlockType.INVERTED_BOTTLENECK, MobileBlockType.FUSED_INVERTED_BOTTLENECK}
+        ):
+            # Expansion convolution (point-wise for INVERTED_BOTTLENECK).
             x = self.conv_exp(x)
             x = self.bn_exp(x)
             x = get_activation_fn(cfg.activation)(x)
 
-        x = self.depthwise_separable(x, shortcut=shortcut)
+        if cfg.mobile_block_type in {
+            MobileBlockType.DEPTHWISE_SEPARABLE,
+            MobileBlockType.INVERTED_BOTTLENECK,
+        }:
+            # Depth-wise convolution.
+            x = self.conv_dw(x)
+            x = self.bn_dw(x)
+            x = get_activation_fn(cfg.activation)(x)
+
+        if cfg.se_layer is not None:
+            # Squeeze-excitation.
+            x = self.se(x)
+
+        # Point-wise convolution.
+        x = self.conv_pw(x)
+        x = self.bn_pw(x)
+
+        if self._use_skip_connection:
+            # Skip connection.
+            if cfg.drop_path is not None:
+                x = self.drop_path(x)
+            x = x + shortcut
         return x

--- a/axlearn/vision/mobilenets_blocks_test.py
+++ b/axlearn/vision/mobilenets_blocks_test.py
@@ -1,6 +1,6 @@
 # Copyright © 2023 Apple Inc.
 
-"""Tests MobileNetV3 blocks."""
+"""Tests blocks for mobile networks."""
 # pylint: disable=no-self-use,too-many-lines,too-many-public-methods
 import jax.random
 import tensorflow as tf
@@ -10,89 +10,149 @@ from axlearn.common import utils
 from axlearn.common.layers import SqueezeExcitation, StochasticDepth
 from axlearn.common.module import functional as F
 from axlearn.common.test_utils import TestCase
-from axlearn.vision.mobilenets_blocks import ConvBnAct, DepthwiseSeparable, InvertedResidual
+from axlearn.vision.mobilenets_blocks import ConvBnAct, MobileBlock, MobileBlockType
 
 
 # pylint: disable=too-many-public-methods
-class MobileNetV3BlockTest(TestCase, tf.test.TestCase):
-    """Tests MobileNetV3 blocks."""
+class MobileNetsBlocksTest(TestCase, tf.test.TestCase):
+    """Tests blocks for mobile networks."""
 
     @parameterized.named_parameters(
         {
-            "testcase_name": "ConvBnAct",
+            "testcase_name": "CONV_BN_ACT",
             "block_class": ConvBnAct,
+            "block_type": None,
             "se_ratio": 0.0,
             "exp_ratio": 1.0,
             "drop_path_rate": 0.0,
             "num_params": 4736,
         },
         {
-            "testcase_name": "DepthwiseSeparable",
-            "block_class": DepthwiseSeparable,
+            "testcase_name": "DEPTHWISE_SEPARABLE",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.DEPTHWISE_SEPARABLE,
             "se_ratio": 0.0,
             "exp_ratio": 1.0,
             "drop_path_rate": 0.0,
             "num_params": 848,
         },
         {
-            "testcase_name": "DepthwiseSeparable_DROP",
-            "block_class": DepthwiseSeparable,
+            "testcase_name": "DEPTHWISE_SEPARABLE_DROP",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.DEPTHWISE_SEPARABLE,
             "se_ratio": 0.5,
             "exp_ratio": 1.0,
             "drop_path_rate": 0.5,
             "num_params": 1128,
         },
         {
-            "testcase_name": "DepthwiseSeparable_SE",
-            "block_class": DepthwiseSeparable,
+            "testcase_name": "DEPTHWISE_SEPARABLE_SE",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.DEPTHWISE_SEPARABLE,
             "se_ratio": 0.5,
             "exp_ratio": 1.0,
             "drop_path_rate": 0.0,
             "num_params": 1128,
         },
         {
-            "testcase_name": "InvertedResidual",
-            "block_class": InvertedResidual,
+            "testcase_name": "INVERTED_BOTTLENECK",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.INVERTED_BOTTLENECK,
             "se_ratio": 0.0,
             "exp_ratio": 1.0,
             "drop_path_rate": 0.0,
             "num_params": 848,
         },
         {
-            "testcase_name": "InvertedResidual_DROP",
-            "block_class": InvertedResidual,
+            "testcase_name": "INVERTED_BOTTLENECK_DROP",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.INVERTED_BOTTLENECK,
             "se_ratio": 0.0,
             "exp_ratio": 1.0,
             "drop_path_rate": 0.5,
             "num_params": 848,
         },
         {
-            "testcase_name": "InvertedResidual_SE",
-            "block_class": InvertedResidual,
+            "testcase_name": "INVERTED_BOTTLENECK_SE",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.INVERTED_BOTTLENECK,
             "se_ratio": 0.5,
             "exp_ratio": 1.0,
             "drop_path_rate": 0.0,
             "num_params": 1128,
         },
         {
-            "testcase_name": "InvertedResidual_EXP",
-            "block_class": InvertedResidual,
+            "testcase_name": "INVERTED_BOTTLENECK_EXP",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.INVERTED_BOTTLENECK,
             "se_ratio": 0.0,
             "exp_ratio": 2.0,
             "drop_path_rate": 0.0,
             "num_params": 2208,
         },
         {
-            "testcase_name": "InvertedResidual_EXP_SE",
-            "block_class": InvertedResidual,
+            "testcase_name": "INVERTED_BOTTLENECK_EXP_SE",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.INVERTED_BOTTLENECK,
             "se_ratio": 0.5,
             "exp_ratio": 2.0,
             "drop_path_rate": 0.0,
             "num_params": 3280,
         },
+        {
+            "testcase_name": "FUSED_INVERTED_BOTTLENECK",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.FUSED_INVERTED_BOTTLENECK,
+            "se_ratio": 0.0,
+            "exp_ratio": 1.0,
+            "drop_path_rate": 0.0,
+            "num_params": 640,
+        },
+        {
+            "testcase_name": "FUSED_INVERTED_BOTTLENECK_DROP",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.FUSED_INVERTED_BOTTLENECK,
+            "se_ratio": 0.0,
+            "exp_ratio": 1.0,
+            "drop_path_rate": 0.5,
+            "num_params": 640,
+        },
+        {
+            "testcase_name": "FUSED_INVERTED_BOTTLENECK_SE",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.FUSED_INVERTED_BOTTLENECK,
+            "se_ratio": 0.5,
+            "exp_ratio": 1.0,
+            "drop_path_rate": 0.0,
+            "num_params": 920,
+        },
+        {
+            "testcase_name": "FUSED_INVERTED_BOTTLENECK_EXP",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.FUSED_INVERTED_BOTTLENECK,
+            "se_ratio": 0.0,
+            "exp_ratio": 2.0,
+            "drop_path_rate": 0.0,
+            "num_params": 5888,
+        },
+        {
+            "testcase_name": "FUSED_INVERTED_BOTTLENECK_EXP_SE",
+            "block_class": MobileBlock,
+            "block_type": MobileBlockType.FUSED_INVERTED_BOTTLENECK,
+            "se_ratio": 0.5,
+            "exp_ratio": 2.0,
+            "drop_path_rate": 0.0,
+            "num_params": 6960,
+        },
     )
-    def test_mobilenetv3_blocks(
-        self, block_class, se_ratio: float, exp_ratio: float, drop_path_rate: float, num_params: int
+    def test_mobilenets_blocks(
+        self,
+        block_class,
+        block_type: MobileBlockType,
+        se_ratio: float,
+        exp_ratio: float,
+        drop_path_rate: float,
+        num_params: int,
     ):
         # Initialize layer.
         input_dim = 16
@@ -100,18 +160,12 @@ class MobileNetV3BlockTest(TestCase, tf.test.TestCase):
         cfg = block_class.default_config().set(
             name="test", input_dim=input_dim, output_dim=output_dim
         )
+        if block_type is not None:
+            cfg.mobile_block_type = block_type
         if se_ratio > 0.0:
-            se_layer = SqueezeExcitation.default_config().set(se_ratio=se_ratio)
-            if block_class == DepthwiseSeparable:
-                cfg.se_layer = se_layer
-            elif block_class == InvertedResidual:
-                cfg.depthwise_separable.se_layer = se_layer
+            cfg.se_layer = SqueezeExcitation.default_config().set(se_ratio=se_ratio)
         if drop_path_rate > 0.0:
-            drop_path = StochasticDepth.default_config().set(rate=drop_path_rate)
-            if block_class == DepthwiseSeparable:
-                cfg.drop_path = drop_path
-            elif block_class == InvertedResidual:
-                cfg.depthwise_separable.drop_path = drop_path
+            cfg.drop_path = StochasticDepth.default_config().set(rate=drop_path_rate)
         if exp_ratio > 1.0:
             cfg.exp_ratio = exp_ratio
         layer: block_class = cfg.instantiate(parent=None)

--- a/axlearn/vision/mobilenets_test.py
+++ b/axlearn/vision/mobilenets_test.py
@@ -28,37 +28,41 @@ from axlearn.vision.mobilenets import (
 )
 
 
-# TODO(e_daxberger): Compare model outputs against reference implementation,
-# e.g. https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet/mobilenet_v3.py
 class MobileNetsTest(parameterized.TestCase):
     """Tests MobileNets."""
 
+    # TODO(edaxberger): Unify this test with test_mobilenets in image_classification_test.py.
     @parameterized.parameters(
-        (ModelNames.MOBILENETV3, "small-minimal-100"),
-        (ModelNames.MOBILENETV3, "small-100"),
-        (ModelNames.MOBILENETV3, "large-minimal-100"),
-        (ModelNames.MOBILENETV3, "large-100"),
-        # (ModelNames.MOBILENETV3, "small-minimal-075"), # not available in timm
-        (ModelNames.MOBILENETV3, "small-075"),
-        # (ModelNames.MOBILENETV3, "large-minimal-075"), # not available in timm
-        (ModelNames.MOBILENETV3, "large-075"),
-        (ModelNames.EFFICIENTNET, "B0"),
-        (ModelNames.EFFICIENTNET, "B1"),
-        (ModelNames.EFFICIENTNET, "B2"),
-        (ModelNames.EFFICIENTNET, "B3"),
-        (ModelNames.EFFICIENTNET, "B4"),
-        (ModelNames.EFFICIENTNET, "B5"),
-        (ModelNames.EFFICIENTNET, "B6"),
-        (ModelNames.EFFICIENTNET, "B7"),
-        (ModelNames.EFFICIENTNET, "B8"),
-        (ModelNames.EFFICIENTNET, "lite0"),
-        (ModelNames.EFFICIENTNET, "lite1"),
-        (ModelNames.EFFICIENTNET, "lite2"),
-        (ModelNames.EFFICIENTNET, "lite3"),
-        (ModelNames.EFFICIENTNET, "lite4"),
+        (ModelNames.MOBILENETV3, "small-minimal-100", None),
+        (ModelNames.MOBILENETV3, "small-075", None),
+        (ModelNames.MOBILENETV3, "small-100", None),
+        (ModelNames.MOBILENETV3, "large-minimal-100", None),
+        (ModelNames.MOBILENETV3, "large-075", None),
+        (ModelNames.MOBILENETV3, "large-100", None),
+        (ModelNames.EFFICIENTNET, "B0", "V1"),
+        (ModelNames.EFFICIENTNET, "B1", "V1"),
+        (ModelNames.EFFICIENTNET, "B2", "V1"),
+        (ModelNames.EFFICIENTNET, "B3", "V1"),
+        (ModelNames.EFFICIENTNET, "B4", "V1"),
+        (ModelNames.EFFICIENTNET, "B5", "V1"),
+        (ModelNames.EFFICIENTNET, "B6", "V1"),
+        (ModelNames.EFFICIENTNET, "B7", "V1"),
+        (ModelNames.EFFICIENTNET, "B8", "V1"),
+        (ModelNames.EFFICIENTNET, "lite0", "V1"),
+        (ModelNames.EFFICIENTNET, "lite1", "V1"),
+        (ModelNames.EFFICIENTNET, "lite2", "V1"),
+        (ModelNames.EFFICIENTNET, "lite3", "V1"),
+        (ModelNames.EFFICIENTNET, "lite4", "V1"),
+        (ModelNames.EFFICIENTNET, "B0", "V2"),
+        (ModelNames.EFFICIENTNET, "B1", "V2"),
+        (ModelNames.EFFICIENTNET, "B2", "V2"),
+        (ModelNames.EFFICIENTNET, "B3", "V2"),
+        (ModelNames.EFFICIENTNET, "S", "V2"),
+        (ModelNames.EFFICIENTNET, "M", "V2"),
+        (ModelNames.EFFICIENTNET, "L", "V2"),
     )
-    def test_param_count(self, model_name, variant):
-        cfg = named_model_configs(model_name, variant)
+    def test_param_count(self, model_name, variant, version):
+        cfg = named_model_configs(model_name, variant, efficientnet_version=version)
         classification_model = (
             ImageClassificationModel.default_config()
             .set(
@@ -72,10 +76,11 @@ class MobileNetsTest(parameterized.TestCase):
             jax.random.PRNGKey(1)
         )
 
-        if model_name == ModelNames.EFFICIENTNET:
-            timm_model_name = "efficientnet"
-        elif model_name == ModelNames.MOBILENETV3:
-            timm_model_name = "mobilenetv3"
+        timm_model_name = {
+            (ModelNames.EFFICIENTNET, "V1"): "efficientnet",
+            (ModelNames.EFFICIENTNET, "V2"): "efficientnetv2",
+            (ModelNames.MOBILENETV3, None): "mobilenetv3",
+        }[(model_name, version)]
         timm_variant = variant.replace("-", "_").lower()
 
         ref_model = timm.create_model(f"tf_{timm_model_name}_{timm_variant}", pretrained=False)
@@ -93,17 +98,18 @@ class MobileNetsTest(parameterized.TestCase):
         self.assertEqual(count_model_params(init_params_classifier), expected_param_count)
 
     @parameterized.product(
-        model=(
-            (ModelNames.MOBILENETV3, "small-minimal-100"),
-            (ModelNames.EFFICIENTNET, "B0"),
-            (ModelNames.EFFICIENTNET, "lite0"),
+        model_variant=(
+            (ModelNames.MOBILENETV3, "small-minimal-100", None),
+            (ModelNames.EFFICIENTNET, "B0", "V1"),
+            (ModelNames.EFFICIENTNET, "lite0", "V1"),
+            (ModelNames.EFFICIENTNET, "B0", "V2"),
         ),
         is_training=(False, True),
         endpoints_mode=tuple(EndpointsMode),
     )
-    def test_shapes(self, model, is_training, endpoints_mode):
-        model_name, variant = model
-        cfg = named_model_configs(model_name, variant)
+    def test_shapes(self, model_variant, is_training, endpoints_mode):
+        model_name, variant, version = model_variant
+        cfg = named_model_configs(model_name, variant, efficientnet_version=version)
         model: MobileNets = cfg.set(name="backbone", endpoints_mode=endpoints_mode).instantiate(
             parent=None
         )
@@ -128,13 +134,15 @@ class MobileNetsTest(parameterized.TestCase):
     @parameterized.product(
         endpoints_mode=tuple(EndpointsMode),
         model_variant=(
-            (ModelNames.MOBILENETV3, "small-minimal-100"),
-            (ModelNames.EFFICIENTNET, "B0"),
-            (ModelNames.EFFICIENTNET, "lite0"),
+            (ModelNames.MOBILENETV3, "small-minimal-100", None),
+            (ModelNames.EFFICIENTNET, "B0", "V1"),
+            (ModelNames.EFFICIENTNET, "lite0", "V1"),
+            (ModelNames.EFFICIENTNET, "B0", "V2"),
         ),
     )
     def test_feature_maps(self, endpoints_mode, model_variant):
-        cfg = named_model_configs(*model_variant)
+        model_name, variant, version = model_variant
+        cfg = named_model_configs(model_name, variant, efficientnet_version=version)
         cfg.embedding_layer = None
         model: MobileNets = cfg.set(name="backbone", endpoints_mode=endpoints_mode).instantiate(
             parent=None
@@ -150,7 +158,7 @@ class MobileNetsTest(parameterized.TestCase):
             inputs=dict(input_batch=jax.tree_util.tree_map(jnp.asarray, inputs)),
         )
         expected_feature_dims = {
-            (ModelNames.MOBILENETV3, "small-minimal-100"): {
+            (ModelNames.MOBILENETV3, "small-minimal-100", None): {
                 EndpointsMode.DEFAULT: {
                     "2": 16,
                     "3": 24,
@@ -167,7 +175,7 @@ class MobileNetsTest(parameterized.TestCase):
                 },
                 EndpointsMode.LASTBLOCKS: {"stem": 16, "1": 16, "2": 24, "3": 48, "4": 576},
             },
-            (ModelNames.EFFICIENTNET, "B0"): {
+            (ModelNames.EFFICIENTNET, "B0", "V1"): {
                 EndpointsMode.DEFAULT: {
                     "2": 16,
                     "3": 24,
@@ -191,7 +199,8 @@ class MobileNetsTest(parameterized.TestCase):
             (
                 ModelNames.EFFICIENTNET,
                 "lite0",
-            ): {  # identical to (ModelNames.EFFICIENTNET, "B0")
+                "V1",
+            ): {  # Identical to (ModelNames.EFFICIENTNET, "B0", "V1").
                 EndpointsMode.DEFAULT: {
                     "2": 16,
                     "3": 24,
@@ -212,18 +221,44 @@ class MobileNetsTest(parameterized.TestCase):
                 },
                 EndpointsMode.LASTBLOCKS: {"1": 16, "2": 24, "3": 40, "4": 112, "5": 320},
             },
+            (ModelNames.EFFICIENTNET, "B0", "V2"): {
+                EndpointsMode.DEFAULT: {
+                    "2": 16,
+                    "3": 32,
+                    "4": 32,
+                    "5": 48,
+                    "6": 48,
+                    "7": 96,
+                    "8": 96,
+                    "9": 96,
+                    "10": 112,
+                    "11": 112,
+                    "12": 112,
+                    "13": 112,
+                    "14": 112,
+                    "15": 192,
+                    "16": 192,
+                    "17": 192,
+                    "18": 192,
+                    "19": 192,
+                    "20": 192,
+                    "21": 192,
+                    "22": 192,
+                },
+                EndpointsMode.LASTBLOCKS: {"1": 16, "2": 32, "3": 48, "4": 112, "5": 192},
+            },
         }
-        # ensure equality between actual output and registered endpoint
+        # Ensure equality between actual output and registered endpoint.
         self.assertListEqual(
             sorted(outputs.keys()),
             sorted(model.endpoints_dims.keys()),
         )
-        # compare with expected outputs
+        # Compare with expected outputs.
         self.assertSetEqual(
             set(expected_feature_dims[model_variant][endpoints_mode].keys()),
             set(model.endpoints_dims.keys()),
         )
-        # compare expected output dims
+        # Compare expected output dims.
         for k in outputs:
             self.assertEqual(
                 expected_feature_dims[model_variant][endpoints_mode][k], model.endpoints_dims[k]

--- a/axlearn/vision/param_converter.py
+++ b/axlearn/vision/param_converter.py
@@ -30,6 +30,8 @@ from axlearn.common.text_encoder import TextEmbeddingEncoder
 from axlearn.common.utils import NestedTensor
 from axlearn.common.vision_transformer import Encoder1D, VisionTransformer
 from axlearn.vision.clip import CLIPImageStreamEncoder, CLIPTextStreamEncoder
+from axlearn.vision.image_classification import ImageClassificationModel
+from axlearn.vision.mobilenets_blocks import MobileBlockType
 
 
 @register_axlearn_to_torch(src=[MultiStreamModel], dst=[hf_clip.CLIPModel])
@@ -377,3 +379,192 @@ def parameters_from_clip_model(
             log_logit_scale=src.logit_scale.reshape(1),
         ),
     )
+
+
+class ClassificationModelParamConverter:
+    """Base class for converting parameters of classification models from PyTorch to JAX."""
+
+    @staticmethod
+    def _params_from_conv(ref: torch.nn.Module) -> NestedTensor:
+        param = {
+            # torch conv uses layout (output, input, H, W)
+            # while axlearn uses (H, W, input, output).
+            "weight": ref.weight.permute(2, 3, 1, 0),
+        }
+        if hasattr(ref, "bias"):
+            param["bias"] = ref.bias
+        return param
+
+    @staticmethod
+    def _params_from_linear(ref: torch.nn.Module) -> NestedTensor:
+        return {
+            # torch linear uses layout (output, input)
+            # while axlearn uses (input, output).
+            "weight": ref.weight.transpose(1, 0),
+            "bias": ref.bias,
+        }
+
+    @staticmethod
+    def _params_from_bn(ref: torch.nn.Module) -> NestedTensor:
+        return {
+            "scale": ref.weight,
+            "bias": ref.bias,
+            "moving_mean": ref.running_mean,
+            "moving_variance": ref.running_var,
+        }
+
+
+class MobileNetsParamConverter(ClassificationModelParamConverter):
+    """Converter for parameters of MobileNets from PyTorch to JAX."""
+
+    @staticmethod
+    def _params_from_squeeze_excitation(ref: torch.nn.Module) -> NestedTensor:
+        params = {}
+        if hasattr(ref, "conv_expand"):
+            params["expand"] = MobileNetsParamConverter._params_from_conv(ref.conv_expand)
+        if hasattr(ref, "conv_reduce"):
+            params["reduce"] = MobileNetsParamConverter._params_from_conv(ref.conv_reduce)
+        return params
+
+    @staticmethod
+    def _params_from_block(block_type: MobileBlockType, ref: torch.nn.Module) -> NestedTensor:
+        if block_type == MobileBlockType.CONV_BN_ACT:
+            params = {
+                "conv": MobileNetsParamConverter._params_from_conv(ref.conv),
+                "bn": MobileNetsParamConverter._params_from_bn(ref.bn1),
+            }
+        elif block_type == MobileBlockType.DEPTHWISE_SEPARABLE:
+            params = {
+                "conv_dw": MobileNetsParamConverter._params_from_conv(ref.conv_dw),
+                "bn_dw": MobileNetsParamConverter._params_from_bn(ref.bn1),
+                "conv_pw": MobileNetsParamConverter._params_from_conv(ref.conv_pw),
+                "bn_pw": MobileNetsParamConverter._params_from_bn(ref.bn2),
+            }
+        elif block_type == MobileBlockType.INVERTED_BOTTLENECK:
+            params = {
+                "conv_exp": MobileNetsParamConverter._params_from_conv(ref.conv_pw),
+                "bn_exp": MobileNetsParamConverter._params_from_bn(ref.bn1),
+                "conv_dw": MobileNetsParamConverter._params_from_conv(ref.conv_dw),
+                "bn_dw": MobileNetsParamConverter._params_from_bn(ref.bn2),
+                "conv_pw": MobileNetsParamConverter._params_from_conv(ref.conv_pwl),
+                "bn_pw": MobileNetsParamConverter._params_from_bn(ref.bn3),
+            }
+        elif block_type == MobileBlockType.FUSED_INVERTED_BOTTLENECK:
+            params = {
+                "conv_exp": MobileNetsParamConverter._params_from_conv(ref.conv_exp),
+                "bn_exp": MobileNetsParamConverter._params_from_bn(ref.bn1),
+                "conv_pw": MobileNetsParamConverter._params_from_conv(ref.conv_pwl),
+                "bn_pw": MobileNetsParamConverter._params_from_bn(ref.bn2),
+            }
+        if hasattr(ref, "se"):
+            params["se"] = MobileNetsParamConverter._params_from_squeeze_excitation(ref.se)
+        return params
+
+    @staticmethod
+    def _params_from_stem(ref: torch.nn.ModuleList) -> NestedTensor:
+        return {
+            "conv": MobileNetsParamConverter._params_from_conv(ref.conv_stem),
+            "bn": MobileNetsParamConverter._params_from_bn(ref.bn1),
+        }
+
+    @staticmethod
+    def _params_from_embedding_layer(ref: torch.nn.ModuleList) -> NestedTensor:
+        params = {
+            "conv_pw": MobileNetsParamConverter._params_from_conv(ref.conv_head),
+        }
+        if hasattr(ref, "bn2"):
+            params["bn"] = MobileNetsParamConverter._params_from_bn(ref.bn2)
+        return params
+
+    @staticmethod
+    def _params_from_backbone(
+        cfg: ImageClassificationModel.Config, ref: torch.nn.ModuleList
+    ) -> NestedTensor:
+        params = {
+            "stem": MobileNetsParamConverter._params_from_stem(ref),
+            "embedding_layer": MobileNetsParamConverter._params_from_embedding_layer(ref),
+        }
+        block_defs = cfg.backbone.block_defs
+        for stage_idx, (stage_defs, ref_stage) in enumerate(zip(block_defs, ref.blocks)):
+            for block_idx, (stage_def, ref_block) in enumerate(zip(stage_defs, ref_stage)):
+                block_type: MobileBlockType = stage_def[0]
+                block_str = f"blocks_{stage_idx}_{block_idx}"
+                params[block_str] = MobileNetsParamConverter._params_from_block(
+                    block_type, ref_block
+                )
+        return params
+
+    @staticmethod
+    def _params_from_classifier(ref: torch.nn.ModuleList) -> NestedTensor:
+        return MobileNetsParamConverter._params_from_linear(ref.classifier)
+
+    @staticmethod
+    def params_from_model(
+        cfg: ImageClassificationModel.Config, ref: torch.nn.Module
+    ) -> NestedTensor:
+        return {
+            "backbone": MobileNetsParamConverter._params_from_backbone(cfg, ref),
+            "classifier": MobileNetsParamConverter._params_from_classifier(ref),
+        }
+
+
+class ResNetParamConverter(ClassificationModelParamConverter):
+    """Converter for ResNet parameters from PyTorch to JAX."""
+
+    @staticmethod
+    def _params_from_downsample(ref: torch.nn.ModuleList) -> NestedTensor:
+        return {
+            "conv": ResNetParamConverter._params_from_conv(ref[0]),
+            "norm": ResNetParamConverter._params_from_bn(ref[1]),
+        }
+
+    @staticmethod
+    def _params_from_block(ref: torch.nn.Module) -> NestedTensor:
+        params = {
+            "conv1": ResNetParamConverter._params_from_conv(ref.conv1),
+            "norm1": ResNetParamConverter._params_from_bn(ref.bn1),
+            "conv2": ResNetParamConverter._params_from_conv(ref.conv2),
+            "norm2": ResNetParamConverter._params_from_bn(ref.bn2),
+        }
+        if hasattr(ref, "conv3"):
+            params["conv3"] = ResNetParamConverter._params_from_conv(ref.conv3)
+        if hasattr(ref, "bn3"):
+            params["norm3"] = ResNetParamConverter._params_from_bn(ref.bn3)
+        if getattr(ref, "downsample"):
+            params["downsample"] = ResNetParamConverter._params_from_downsample(ref.downsample)
+        return params
+
+    @staticmethod
+    def _params_from_stage(ref: torch.nn.ModuleList) -> NestedTensor:
+        return {
+            f"block{i}": ResNetParamConverter._params_from_block(block)
+            for i, block in enumerate(ref)
+        }
+
+    @staticmethod
+    def _params_from_stem(ref: torch.nn.ModuleList) -> NestedTensor:
+        return {
+            "conv1": ResNetParamConverter._params_from_conv(ref.conv1),
+            "norm1": ResNetParamConverter._params_from_bn(ref.bn1),
+        }
+
+    @staticmethod
+    def _params_from_backbone(ref: torch.nn.ModuleList) -> NestedTensor:
+        return {
+            "stem": ResNetParamConverter._params_from_stem(ref),
+            **{
+                f"stage{i}": ResNetParamConverter._params_from_stage(getattr(ref, f"layer{i + 1}"))
+                for i in range(4)
+            },
+        }
+
+    @staticmethod
+    def _params_from_classifier(ref: torch.nn.ModuleList) -> NestedTensor:
+        return ResNetParamConverter._params_from_linear(ref.fc)
+
+    @staticmethod
+    def params_from_model(ref: torch.nn.Module) -> NestedTensor:
+        return {
+            "backbone": ResNetParamConverter._params_from_backbone(ref),
+            "classifier": ResNetParamConverter._params_from_classifier(ref),
+        }


### PR DESCRIPTION
This PR implements EfficientNetV2, based on the existing MobileNetV3 and EfficientNet implementation.

In particular, the main changes made are as follows:
- add a (optional) skip connection to the ConvBnAct block,
- add a new fused inverted bottleneck block which is used in the first few blocks of EfficientNetV2 (instead of the inverted bottleneck blocks used throughout EfficientNet),
- unify the depthwise separable, inverted bottleneck and fused inverted bottleneck blocks into a single class to avoid code duplication.