### PR TITLE
Fix L2 Norm

### DIFF
--- a/axlearn/common/layers_test.py
+++ b/axlearn/common/layers_test.py
@@ -414,6 +414,31 @@ class LayerTest(TestCase, tf.test.TestCase):
         output_norm = jnp.sqrt((outputs**2).sum(axis=-1))
         assert_allclose(output_norm, np.ones_like(output_norm))
 
+    def test_l2_norm_small_vals(self):
+        cfg = L2Norm.default_config().set(name="norm")
+        layer: L2Norm = cfg.instantiate(parent=None)
+
+        # Initialize layer parameters.
+        prng_key = jax.random.PRNGKey(123)
+
+        # Random inputs.
+        prng_key, input_key = jax.random.split(prng_key)
+        orig_inputs = jax.random.uniform(input_key, [2, 3, 10], minval=-1e-5, maxval=1e-5)
+        inputs = orig_inputs.copy()
+
+        outputs, _ = F(
+            layer,
+            inputs=(inputs,),
+            is_training=True,
+            state=None,
+            prng_key=prng_key,
+        )
+        # forward() should not mutate 'inputs' in-place.
+        assert_allclose(inputs, orig_inputs)
+        # The output_norm should be close to sqrt(dim).
+        output_norm = jnp.sqrt((outputs**2).sum(axis=-1))
+        assert_allclose(output_norm, np.ones_like(output_norm))
+
     @parameterized.parameters(
         [
             dict(inputs_shape=[2, 3, 6], paddings=None),

--- a/axlearn/common/normalize.py
+++ b/axlearn/common/normalize.py
@@ -1,7 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 """Normalization utils."""
-import jax
+import jax.numpy as jnp
 
 from axlearn.common.utils import Tensor
 
@@ -17,5 +17,5 @@ def l2_normalize(x: Tensor, eps: float = 1e-8, axis: int = -1) -> Tensor:
     Returns:
         A Tensor with the same shape as x.
     """
-    sum2 = (x * x).sum(axis=axis, keepdims=True)
-    return x * jax.lax.rsqrt(sum2 + eps)
+    l2_norm = jnp.linalg.norm(x, ord=2, axis=axis, keepdims=True)
+    return jnp.divide(x, jnp.maximum(l2_norm, eps))


### PR DESCRIPTION
### What?
This PR changes the way L2Norm is computed to make it correct for inputs with small values. 

### Why?
The correct formula for L2 Norm:  `L2Norm(x) = x / (sqrt(sum_i(x_i ** 2)) + eps)`
The layer currently implements  `L2Norm(x) = x / sqrt(sum_i(x_i ** 2) + eps)`, the eps is inside the sqrt

This breaks when the input has small values. For example, if `x=[[3e-5]]`  and we use the default `eps=1e-8`, we end up with:
`L2Norm([[3e-5]]) = [[3e-5]] / (sqrt(9e-10 + 1e-8)) = 0.28`

### How?
1. Use `jnp.linalg.norm` to compute the L2-Norm
2. Instead of adding `eps` to the norm, we clip with `min_val = eps`. This is the same as the `torch.nn.functional.normalize` implementation ([source](https://pytorch.org/docs/stable/_modules/torch/nn/functional.html#normalize))