### PR TITLE
Add support for tensor including UTF-8 string in inference_output

### DIFF
--- a/axlearn/common/inference_output.py
+++ b/axlearn/common/inference_output.py
@@ -80,7 +80,7 @@ def _json_feature(
         return value.decode("utf-8")
 
     if value.dtype == object:
-        value = value.astype(dtype=str)
+        value = np.char.decode(value.astype(np.bytes_), "utf-8")
 
     return value.tolist()
 

--- a/axlearn/common/inference_test.py
+++ b/axlearn/common/inference_test.py
@@ -190,6 +190,7 @@ class InferenceTest(test_utils.TestCase):
         (tf.constant([1]), [1]),
         (jnp.array(1), 1),
         (jnp.array([1, 2, 3]), [1, 2, 3]),
+        (tf.constant(["豆豆"]), ["豆豆"]),
     )
     def test_jsonl_feature(
         self,


### PR DESCRIPTION
Previously inference_output cannot handle outputting tensor with UTF-8, like `tf.constant(["豆豆"])`,
Added support for these kind of tensors.