### PR TITLE
Fix flax loader

### DIFF
--- a/axlearn/common/adapter_flax_test.py
+++ b/axlearn/common/adapter_flax_test.py
@@ -4,7 +4,6 @@
 import jax.random
 from absl.testing import absltest
 from flax import linen as nn
-from flax.core import FrozenDict
 from jax import numpy as jnp
 
 from axlearn.common import utils
@@ -123,34 +122,28 @@ class FlaxLayerTest(TestCase):
 
         self.assertEqual(
             {
-                "linear1": FrozenDict(
-                    {
-                        "params": {
-                            "bias": (hidden_dim,),
-                            "kernel": (input_dim, hidden_dim),
-                        },
-                    }
-                ),
-                "linear2": FrozenDict(
-                    {
-                        "params": {
-                            "bias": (output_dim,),
-                            "kernel": (hidden_dim, output_dim),
-                        },
-                    }
-                ),
-                "norm": FrozenDict(
-                    {
-                        "batch_stats": {
-                            "mean": (hidden_dim,),
-                            "var": (hidden_dim,),
-                        },
-                        "params": {
-                            "bias": (hidden_dim,),
-                            "scale": (hidden_dim,),
-                        },
-                    }
-                ),
+                "linear1": {
+                    "params": {
+                        "bias": (hidden_dim,),
+                        "kernel": (input_dim, hidden_dim),
+                    },
+                },
+                "linear2": {
+                    "params": {
+                        "bias": (output_dim,),
+                        "kernel": (hidden_dim, output_dim),
+                    },
+                },
+                "norm": {
+                    "batch_stats": {
+                        "mean": (hidden_dim,),
+                        "var": (hidden_dim,),
+                    },
+                    "params": {
+                        "bias": (hidden_dim,),
+                        "scale": (hidden_dim,),
+                    },
+                },
             },
             utils.shapes(layer_params),
         )
@@ -196,13 +189,11 @@ class FlaxLayerTest(TestCase):
 
         self.assertEqual(
             {
-                "embed": FrozenDict(
-                    {
-                        "params": {
-                            "embedding": (num_embeddings, feature_dims),
-                        },
-                    }
-                ),
+                "embed": {
+                    "params": {
+                        "embedding": (num_embeddings, feature_dims),
+                    },
+                }
             },
             utils.shapes(layer_params),
         )

--- a/axlearn/common/state_builder.py
+++ b/axlearn/common/state_builder.py
@@ -570,9 +570,6 @@ class FlaxPretrainedBuilder(Builder):
         return Builder.StateType.TENSORS
 
     def __call__(self, state: Builder.State) -> Builder.State:
-        # pylint: disable-next=import-outside-toplevel
-        from flax.core.frozen_dict import FrozenDict, unfreeze
-
         cfg = self.config
         source_params = cfg.flax_state_supplier_config.instantiate()
 
@@ -588,9 +585,6 @@ class FlaxPretrainedBuilder(Builder):
                 parent_state = parent_state[scope]
             target_flax_state = parent_state[cfg.target_scope[-1]]["params"]
 
-        if isinstance(target_flax_state, FrozenDict):
-            target_flax_state = unfreeze(target_flax_state)
-
         restored_target_state = traverse_and_set_target_state_parameters(
             target_state=target_flax_state,
             target_scope=[],
@@ -605,10 +599,10 @@ class FlaxPretrainedBuilder(Builder):
 
         if len(cfg.target_scope) == 0:
             new_trainer_state = state.trainer_state._replace(
-                model=FrozenDict({"params": restored_target_state})
+                model={"params": restored_target_state}
             )
         else:
-            parent_state[cfg.target_scope[-1]] = FrozenDict({"params": restored_target_state})
+            parent_state[cfg.target_scope[-1]] = {"params": restored_target_state}
             new_trainer_state = state.trainer_state
 
         built_keys = state.built_keys.union(set(key for key, _ in flatten_items(new_trainer_state)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "attrs>=21.3.0",
     "absl-py",
     "chex>=0.1.6",
-    "flax>=0.6.5",  # only for checkpoints, FrozenDict
+    "flax>=0.7.1",  # only for checkpoints
     "importlab==0.7",  # breaks pytype on 0.8
     "jax==0.4.13",
     "jaxlib==0.4.13",
@@ -41,7 +41,7 @@ apple-silicon = [
     "attrs>=21.3.0",
     "absl-py",
     "chex>=0.1.6",
-    "flax>=0.6.5",  # only for checkpoints, FrozenDict
+    "flax>=0.7.1",  # only for checkpoints
     "jax==0.4.13",
     "jaxlib==0.4.13",
     "nltk==3.7",  # for text preprocessing


### PR DESCRIPTION
The latest flax version does not output weights in FrozenDict format, which breaks the pre-trained flax loader. This fixes that.

I ran CI on our internal repo against this version to confirm this does not break any tests . I personally tested my broken use case as well and this fix allowed it to run.
