### PR TITLE
run pytest files in parallel on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,32 @@ executors:
 jobs:
   build-and-test-job:
     executor: build-and-test-executor
+    parallelism: 5
     resource_class: large
     steps:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          command: docker build -t axlearn --target=ci .
           no_output_timeout: 1h
+          command: |
+            circleci tests glob "axlearn/**/*_test.py" > pytest_files.txt
+
+            # TODO(ya5ut,markblee): assess --split-by=timing
+            cat pytest_files.txt | circleci tests split --split-by=name > pytest_files_split.txt
+
+            set -o xtrace
+
+            ls -la
+            cat -n pytest_files.txt       | tail -n 5
+            cat -n pytest_files_split.txt | tail -n 5
+
+            # Docker's build arg will ignore strings after a newline.
+            SPLIT_TESTFILES_ONELINE=$(cat pytest_files_split.txt | tr '\n' ' ')
+
+            # Use single quotes to treat the whitespace-delimited file paths as a single string.
+            docker build --build-arg="PYTEST_FILES='${SPLIT_TESTFILES_ONELINE}'" -t mydockertarget --target=ci .
+
 workflows:
   build-and-test-workflow:
     jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,11 @@ FROM base as ci
 
 RUN pip install .[dev]
 COPY . .
+
+# Defaults to an empty string, i.e. run pytest against all files.
+ARG PYTEST_FILES=''
 # `exit 1` fails the build.
-RUN ./run_tests.sh
+RUN ./run_tests.sh "${PYTEST_FILES}"
 
 ################################################################################
 # Final target spec.                                                           #

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -22,10 +22,13 @@ download_assets() {
   curl https://huggingface.co/t5-base/resolve/main/spiece.model -o axlearn/experiments/testdata/tokenizers/sentencepiece/t5-base.spm
 }
 
+set -o xtrace
+UNQUOTED_PYTEST_FILES=$(echo $1 |  tr -d "'")
+
 pre-commit install
 pre-commit run --all-files || exit_if_error $? "pre-commit failed."
 # Run pytype separately to utilize all cpus and for better output.
 pytype -j auto . || exit_if_error $? "pytype failed."
 download_assets
-pytest --durations=10 -n auto -v -m "not (gs_login or tpu or high_cpu or fp64)" || exit_if_error $? "pytest failed."
+pytest --durations=10 -n auto -v -m "not (gs_login or tpu or high_cpu or fp64)" ${UNQUOTED_PYTEST_FILES} || exit_if_error $? "pytest failed."
 JAX_ENABLE_X64=1 pytest -n auto -v -m "fp64" || exit_if_error $? "pytest failed."


### PR DESCRIPTION
The Circle CI builds on this Github repository takes 40 - 50 mins on average, reducing iteration speed.

This PR lets Circle CI to run `pytest` test cases in parallel by `circleci tests split` command.

On my test Circle CI environment, this PR reduces CI duration by 15 - 20 mins (depending on caches / retries).