### PR TITLE
Adds a flash attention layer.

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -19,6 +19,7 @@ Summary:
 * [Facebook Research DiT](#facebook-research-dit)
 * [Facebook Research fvcore](#facebook-research-fvcore)
 * [Facebook Research mvit](#facebook-research-mvit)
+* [Flash Attention](#flash-attention)
 * [Google AutoML](#google-automl)
 * [Google Flax](#google-flax)
 * [Google JAX](#google-jax)
@@ -33,6 +34,7 @@ Summary:
 * [GT-Vision-Lab VQA](#gt-vision-lab-vqa)
 * [Huggingface Transformers](#huggingface-transformers)
 * [Huggingface Pytorch image models](#huggingface-pytorch-image-models)
+* [Jax Triton](#jax-triton)
 * [Keras](#keras)
 * [kdexd virtex](#kdexd-virtex)
 * [Microsoft DeBERTa](#microsoft-deberta)
@@ -2176,6 +2178,38 @@ Summary:
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+### [Flash Attention](https://github.com/Dao-AILab/flash-attention)
+
+      BSD 3-Clause License
+
+      Copyright (c) 2022, the respective contributors, as shown by the AUTHORS file.
+      All rights reserved.
+
+      Redistribution and use in source and binary forms, with or without
+      modification, are permitted provided that the following conditions are met:
+
+      * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+      * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+      * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+      AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+      IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+      DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+      FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+      DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+      SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+      CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+      OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### [Google AutoML](https://github.com/google/automl)
     Copyright 2020 Google Research.  All rights reserved.
@@ -4687,6 +4721,210 @@ Summary:
        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
        See the License for the specific language governing permissions and
        limitations under the License.
+
+### [Jax Triton](https://github.com/jax-ml/jax-triton)
+
+                                    Apache License
+                              Version 2.0, January 2004
+                           http://www.apache.org/licenses/
+
+      TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+      1. Definitions.
+
+         "License" shall mean the terms and conditions for use, reproduction,
+         and distribution as defined by Sections 1 through 9 of this document.
+
+         "Licensor" shall mean the copyright owner or entity authorized by
+         the copyright owner that is granting the License.
+
+         "Legal Entity" shall mean the union of the acting entity and all
+         other entities that control, are controlled by, or are under common
+         control with that entity. For the purposes of this definition,
+         "control" means (i) the power, direct or indirect, to cause the
+         direction or management of such entity, whether by contract or
+         otherwise, or (ii) ownership of fifty percent (50%) or more of the
+         outstanding shares, or (iii) beneficial ownership of such entity.
+
+         "You" (or "Your") shall mean an individual or Legal Entity
+         exercising permissions granted by this License.
+
+         "Source" form shall mean the preferred form for making modifications,
+         including but not limited to software source code, documentation
+         source, and configuration files.
+
+         "Object" form shall mean any form resulting from mechanical
+         transformation or translation of a Source form, including but
+         not limited to compiled object code, generated documentation,
+         and conversions to other media types.
+
+         "Work" shall mean the work of authorship, whether in Source or
+         Object form, made available under the License, as indicated by a
+         copyright notice that is included in or attached to the work
+         (an example is provided in the Appendix below).
+
+         "Derivative Works" shall mean any work, whether in Source or Object
+         form, that is based on (or derived from) the Work and for which the
+         editorial revisions, annotations, elaborations, or other modifications
+         represent, as a whole, an original work of authorship. For the purposes
+         of this License, Derivative Works shall not include works that remain
+         separable from, or merely link (or bind by name) to the interfaces of,
+         the Work and Derivative Works thereof.
+
+         "Contribution" shall mean any work of authorship, including
+         the original version of the Work and any modifications or additions
+         to that Work or Derivative Works thereof, that is intentionally
+         submitted to Licensor for inclusion in the Work by the copyright owner
+         or by an individual or Legal Entity authorized to submit on behalf of
+         the copyright owner. For the purposes of this definition, "submitted"
+         means any form of electronic, verbal, or written communication sent
+         to the Licensor or its representatives, including but not limited to
+         communication on electronic mailing lists, source code control systems,
+         and issue tracking systems that are managed by, or on behalf of, the
+         Licensor for the purpose of discussing and improving the Work, but
+         excluding communication that is conspicuously marked or otherwise
+         designated in writing by the copyright owner as "Not a Contribution."
+
+         "Contributor" shall mean Licensor and any individual or Legal Entity
+         on behalf of whom a Contribution has been received by Licensor and
+         subsequently incorporated within the Work.
+
+      2. Grant of Copyright License. Subject to the terms and conditions of
+         this License, each Contributor hereby grants to You a perpetual,
+         worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+         copyright license to reproduce, prepare Derivative Works of,
+         publicly display, publicly perform, sublicense, and distribute the
+         Work and such Derivative Works in Source or Object form.
+
+      3. Grant of Patent License. Subject to the terms and conditions of
+         this License, each Contributor hereby grants to You a perpetual,
+         worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+         (except as stated in this section) patent license to make, have made,
+         use, offer to sell, sell, import, and otherwise transfer the Work,
+         where such license applies only to those patent claims licensable
+         by such Contributor that are necessarily infringed by their
+         Contribution(s) alone or by combination of their Contribution(s)
+         with the Work to which such Contribution(s) was submitted. If You
+         institute patent litigation against any entity (including a
+         cross-claim or counterclaim in a lawsuit) alleging that the Work
+         or a Contribution incorporated within the Work constitutes direct
+         or contributory patent infringement, then any patent licenses
+         granted to You under this License for that Work shall terminate
+         as of the date such litigation is filed.
+
+      4. Redistribution. You may reproduce and distribute copies of the
+         Work or Derivative Works thereof in any medium, with or without
+         modifications, and in Source or Object form, provided that You
+         meet the following conditions:
+
+         (a) You must give any other recipients of the Work or
+            Derivative Works a copy of this License; and
+
+         (b) You must cause any modified files to carry prominent notices
+            stating that You changed the files; and
+
+         (c) You must retain, in the Source form of any Derivative Works
+            that You distribute, all copyright, patent, trademark, and
+            attribution notices from the Source form of the Work,
+            excluding those notices that do not pertain to any part of
+            the Derivative Works; and
+
+         (d) If the Work includes a "NOTICE" text file as part of its
+            distribution, then any Derivative Works that You distribute must
+            include a readable copy of the attribution notices contained
+            within such NOTICE file, excluding those notices that do not
+            pertain to any part of the Derivative Works, in at least one
+            of the following places: within a NOTICE text file distributed
+            as part of the Derivative Works; within the Source form or
+            documentation, if provided along with the Derivative Works; or,
+            within a display generated by the Derivative Works, if and
+            wherever such third-party notices normally appear. The contents
+            of the NOTICE file are for informational purposes only and
+            do not modify the License. You may add Your own attribution
+            notices within Derivative Works that You distribute, alongside
+            or as an addendum to the NOTICE text from the Work, provided
+            that such additional attribution notices cannot be construed
+            as modifying the License.
+
+         You may add Your own copyright statement to Your modifications and
+         may provide additional or different license terms and conditions
+         for use, reproduction, or distribution of Your modifications, or
+         for any such Derivative Works as a whole, provided Your use,
+         reproduction, and distribution of the Work otherwise complies with
+         the conditions stated in this License.
+
+      5. Submission of Contributions. Unless You explicitly state otherwise,
+         any Contribution intentionally submitted for inclusion in the Work
+         by You to the Licensor shall be under the terms and conditions of
+         this License, without any additional terms or conditions.
+         Notwithstanding the above, nothing herein shall supersede or modify
+         the terms of any separate license agreement you may have executed
+         with Licensor regarding such Contributions.
+
+      6. Trademarks. This License does not grant permission to use the trade
+         names, trademarks, service marks, or product names of the Licensor,
+         except as required for reasonable and customary use in describing the
+         origin of the Work and reproducing the content of the NOTICE file.
+
+      7. Disclaimer of Warranty. Unless required by applicable law or
+         agreed to in writing, Licensor provides the Work (and each
+         Contributor provides its Contributions) on an "AS IS" BASIS,
+         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+         implied, including, without limitation, any warranties or conditions
+         of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+         PARTICULAR PURPOSE. You are solely responsible for determining the
+         appropriateness of using or redistributing the Work and assume any
+         risks associated with Your exercise of permissions under this License.
+
+      8. Limitation of Liability. In no event and under no legal theory,
+         whether in tort (including negligence), contract, or otherwise,
+         unless required by applicable law (such as deliberate and grossly
+         negligent acts) or agreed to in writing, shall any Contributor be
+         liable to You for damages, including any direct, indirect, special,
+         incidental, or consequential damages of any character arising as a
+         result of this License or out of the use or inability to use the
+         Work (including but not limited to damages for loss of goodwill,
+         work stoppage, computer failure or malfunction, or any and all
+         other commercial damages or losses), even if such Contributor
+         has been advised of the possibility of such damages.
+
+      9. Accepting Warranty or Additional Liability. While redistributing
+         the Work or Derivative Works thereof, You may choose to offer,
+         and charge a fee for, acceptance of support, warranty, indemnity,
+         or other liability obligations and/or rights consistent with this
+         License. However, in accepting such obligations, You may act only
+         on Your own behalf and on Your sole responsibility, not on behalf
+         of any other Contributor, and only if You agree to indemnify,
+         defend, and hold each Contributor harmless for any liability
+         incurred by, or claims asserted against, such Contributor by reason
+         of your accepting any such warranty or additional liability.
+
+      END OF TERMS AND CONDITIONS
+
+      APPENDIX: How to apply the Apache License to your work.
+
+         To apply the Apache License to your work, attach the following
+         boilerplate notice, with the fields enclosed by brackets "[]"
+         replaced with your own identifying information. (Don't include
+         the brackets!)  The text should be enclosed in the appropriate
+         comment syntax for the file format. We also recommend that a
+         file or class name and description of purpose be included on the
+         same "printed page" as the copyright notice for easier
+         identification within third-party archives.
+
+      Copyright [yyyy] [name of copyright owner]
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
 
 ### [Keras](https://github.com/keras-team/keras)
 

--- a/axlearn/common/flash_attention/attention.py
+++ b/axlearn/common/flash_attention/attention.py
@@ -1,0 +1,638 @@
+# Copyright © 2023 Apple Inc.
+#
+# Some of the code in this file is adapted from:
+#
+# HazyResearch/flash-attention:
+# Copyright (c) 2022, Tri Dao, Dan Fu. All rights reserved.
+# Licensed under the BSD 3-Clause License.
+#
+# jax-ml/jax-triton:
+# Copyright 2023 The jax_triton Authors.
+# Licensed under the Apache License, Version 2.0 (the "License").
+
+"""Implements FlashAttention for jax with logit bias support.
+
+This implementation follows the original closely:
+https://github.com/HazyResearch/flash-attention/blob/9818f85fee29ac6b60c9214bce841f8109a18b1b/flash_attn/flash_attn_triton.py
+https://github.com/jax-ml/jax-triton/blob/46991edf162d1d630f64524e7c999e041a7f5126/jax_triton/pallas/ops/attention.py
+
+As well as the original paper: https://arxiv.org/abs/2205.14135
+
+Due to the caveats mentioned in the above link, we make several simplifying assumptions:
+* Sequence length is a multiple of block size (128).
+* No dropout is applied.
+* Currently only tested on A100.
+"""
+# pylint: disable=wrong-import-position,missing-param-doc,differing-param-doc
+import functools
+import os
+
+os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+
+from typing import Any, Optional, Sequence
+
+import jax
+import jax.numpy as jnp
+
+# pytype: disable=import-error  # pylint: disable=import-error
+import jax_triton as jt
+from jax import lax
+from jax_triton import pallas as pl
+
+# pytype: enable=import-error  # pylint: enable=import-error
+
+Tensor = jax.Array
+
+
+def _mha_forward_kernel(
+    # Inputs.
+    q_ref,
+    k_ref,
+    v_ref,
+    b_ref,
+    # Outputs.
+    o_ref,
+    # Residual outputs.
+    *residual_refs,
+    softmax_scale: float,
+    bias_type: str,
+    causal: bool,
+    block_q: int,
+    block_d: int,
+    block_k: int,
+):
+    """Computes attention outputs for the given block.
+
+    For details and references:
+    https://github.com/jax-ml/jax-triton/blob/46991edf162d1d630f64524e7c999e041a7f5126/jax_triton/pallas/ops/attention.py
+    https://arxiv.org/abs/2205.14135 Appendix B.3 Algorithm 2.
+
+    See also `_mha_backward_kernel` for the backward pass.
+
+    Args:
+        q_ref: Input query ref.
+        k_ref: Input key ref.
+        v_ref: Input value ref.
+        b_ref: Input bias ref.
+        o_ref: Output ref.
+        *residual_refs: Residual output refs, e.g. softmax statistics.
+        softmax_scale: Softmax scale.
+        bias_type: Type of bias matrix.
+        causal: Whether to apply causal mask.
+        block_q: Block size for query seq dim.
+        block_d: Block size for head dim.
+        block_k: Block size for key seq dim.
+    """
+    seq_len = q_ref.shape[0]
+    start_q = pl.program_id(0)
+
+    # acc is the buffer where we accumulate the output on sram.
+    # m_i and l_i (see FlashAttention paper) are updated during the k,v loop.
+    m_i = jnp.zeros(block_q, dtype=jnp.float32) - float("inf")
+    l_i = jnp.zeros(block_q, dtype=jnp.float32)
+    # acc is the buffer where we accumulate the output on sram.
+    acc = jnp.zeros((block_q, block_d), dtype=jnp.float32)
+
+    # Load q: it will stay in L1 throughout. Indices form a matrix because we
+    # read, compute, and write all in 2d chunks. 1 element ~= 1 CUDA thread index.
+    # q tile has shape [block_q, block_d], block_d == head_dim.
+    q = pl.load(q_ref, (pl.dslice(start_q * block_q, block_q), pl.dslice(None)))
+
+    # In FlashAttention algorithm 1 there are 2 loops: slow over tiles of kv (size
+    # Bc == block_k here), and fast over blocks of q (size Br == block_q here).
+    # Here we only loop over blocks of kv to process entire seq_len, the loop over
+    # blocks of q is carried out by the grid.
+    def body(start_k, carry):
+        acc, m_prev, l_prev = carry
+
+        k = pl.load(k_ref, (pl.dslice(start_k * block_k, block_k), pl.dslice(None)))
+        qk = jnp.zeros([block_q, block_k], dtype=jnp.float32)
+        qk += pl.dot(q, k.T)  # [block_q, block_k].
+
+        if softmax_scale != 1.0:
+            qk *= softmax_scale  # [block_q, block_k].
+
+        # TODO(markblee): Support 'vector'.
+        if bias_type == "matrix":
+            b = pl.load(
+                b_ref,
+                (pl.dslice(start_q * block_q, block_q), pl.dslice(start_k * block_k, block_k)),
+            )
+            qk += b
+
+        if causal:
+            span_q = start_q * block_q + jnp.arange(block_q)
+            span_k = start_k * block_k + jnp.arange(block_k)
+            qk = jnp.where(span_q[:, None] >= span_k[None, :], qk, float("-inf"))
+
+        # Bring closer to XLA:GPU numerics.
+        # These casts are needed to avoid precision issues.
+        qk = qk.astype(q_ref.dtype)
+        qk = qk.astype(jnp.float32)
+        m_curr = jnp.maximum(jnp.max(qk, axis=1), m_prev)
+        l_prev *= jnp.exp(m_prev - m_curr)
+        p = jnp.exp(qk - m_curr[:, None])
+        l_curr = jnp.sum(p, axis=1) + l_prev
+
+        l_rcp = 1.0 / l_curr
+        p = p * l_rcp[:, None]
+        acc *= (l_prev * l_rcp)[:, None]
+        p = p.astype(jnp.float16)
+
+        v = pl.load(v_ref, (pl.dslice(start_k * block_k, block_k), pl.dslice(block_d)))
+        acc = acc + pl.dot(p.astype(v.dtype), v)
+        return acc, m_curr, l_curr
+
+    if causal:
+        upper_bound = lax.div(block_q * start_q, block_k) + 1
+    else:
+        upper_bound = jt.cdiv(seq_len, block_k)
+    acc, m_i, l_i = lax.fori_loop(0, upper_bound, body, (acc, m_i, l_i))
+
+    if residual_refs:
+        l_ref, m_ref = residual_refs
+        pl.store(l_ref, (pl.ds(start_q * block_q, block_q),), l_i)
+        pl.store(m_ref, (pl.ds(start_q * block_q, block_q),), m_i)
+
+    # Write output to dram.
+    acc = acc.astype(o_ref.dtype)
+    pl.store(o_ref, (pl.dslice(start_q * block_q, block_q), pl.dslice(None)), acc)
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=[4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "softmax_scale",
+        "causal",
+        "block_q",
+        "block_k",
+        "backward_pass_impl",
+        "num_warps",
+        "num_stages",
+        "grid",
+        "interpret",
+        "debug",
+    ],
+)
+def mha(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    bias: Optional[Tensor] = None,
+    softmax_scale: float = 1.0,
+    causal: bool = True,
+    block_q: int = 128,
+    block_k: int = 128,
+    backward_pass_impl: str = "triton",
+    num_warps: Optional[int] = None,
+    num_stages: Optional[int] = None,
+    grid: Optional[Sequence[int]] = None,
+    interpret: bool = False,
+    debug: bool = False,
+):
+    """Computes attention outputs following FlashAttention.
+
+    Args:
+        query: Query of shape [batch_size, target_length, num_heads, per_head_dim].
+        key: Key of shape [batch_size, source_length, num_heads, per_head_dim].
+        value: Value of shape [batch_size, source_length, num_heads, per_head_dim].
+        bias: Optional logit biases of shape [batch_size, num_heads, target_length, source_length].
+        softmax_scale: Optional scale to apply to softmax. Defaults to 1/sqrt(per_head_dim).
+        causal: Whether to apply causal mask.
+        **kwargs: Pallas/triton kwargs.
+
+    Returns:
+        The attention outputs of shape [batch_size, target_length, num_heads, per_head_dim].
+    """
+    del backward_pass_impl
+    batch_size, seq_len, num_heads, head_dim = query.shape
+    block_q = min(block_q, seq_len)
+    block_k = min(block_k, seq_len)
+    # Heuristics.
+    grid_ = grid
+    if grid_ is None:
+        grid_ = (jt.cdiv(seq_len, block_q), batch_size, num_heads)
+
+    # Bias.
+    bias_type = "none"
+    bias_block_spec = None
+    if bias is not None:
+        bias_type = "matrix"  # Assume bias is always a matrix for now.
+        bias_block_spec = pl.BlockSpec(lambda _, j, k: (j, k, 0, 0), (None, None, seq_len, seq_len))
+
+    num_warps_ = num_warps
+    if num_warps_ is None:
+        num_warps_ = 4 if head_dim <= 64 else 8
+    num_stages_ = num_stages
+    if num_stages_ is None:
+        num_stages_ = 2 if head_dim <= 64 else 1
+    kernel = functools.partial(
+        _mha_forward_kernel,
+        softmax_scale=softmax_scale,
+        bias_type=bias_type,
+        causal=causal,
+        block_q=block_q,
+        block_k=block_k,
+        block_d=head_dim,
+    )
+    out_shape = jax.ShapeDtypeStruct(shape=query.shape, dtype=query.dtype)
+    return pl.pallas_call(
+        kernel,
+        grid=grid_,
+        in_specs=[
+            pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # query
+            pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # key
+            pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # value
+            bias_block_spec,  # bias
+        ],
+        out_specs=pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
+        num_warps=num_warps_,
+        num_stages=num_stages_,
+        out_shape=out_shape,
+        debug=debug,
+        interpret=interpret,
+        name="mha_forward",
+    )(query, key, value, bias)
+
+
+def _mha_forward(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    bias: Optional[Tensor],
+    softmax_scale: float,
+    causal: bool,
+    block_q: int,
+    block_k: int,
+    backward_pass_impl: str,
+    num_warps: Optional[int],
+    num_stages: int,
+    grid: Any,
+    interpret: bool,
+    debug: bool,
+):
+    """Calls `_mha_forward_kernel`."""
+    del backward_pass_impl
+    batch_size, seq_len, num_heads, head_dim = query.shape
+    block_q = min(block_q, seq_len)
+    block_k = min(block_k, seq_len)
+    # Heuristics.
+    grid_ = grid
+    if grid_ is None:
+        grid_ = (jt.cdiv(seq_len, block_q), batch_size, num_heads)
+
+    # Bias.
+    bias_type = "none"
+    bias_block_spec = None
+    if bias is not None:
+        bias_type = "matrix"  # Assume bias is always a matrix for now.
+        bias_block_spec = pl.BlockSpec(lambda _, j, k: (j, k, 0, 0), (None, None, seq_len, seq_len))
+
+    num_warps_ = num_warps
+    if num_warps_ is None:
+        num_warps_ = 4 if head_dim <= 64 else 8
+    num_stages_ = num_stages
+    if num_stages is None:
+        num_stages_ = 2 if head_dim <= 64 else 1
+    kernel = functools.partial(
+        _mha_forward_kernel,
+        softmax_scale=softmax_scale,
+        bias_type=bias_type,
+        causal=causal,
+        block_q=block_q,
+        block_k=block_k,
+        block_d=head_dim,
+    )
+    out_shape = [
+        jax.ShapeDtypeStruct(shape=query.shape, dtype=query.dtype),  # out
+        jax.ShapeDtypeStruct(shape=(batch_size, num_heads, seq_len), dtype=jnp.float32),  # l
+        jax.ShapeDtypeStruct(shape=(batch_size, num_heads, seq_len), dtype=jnp.float32),  # m
+    ]
+    out, l, m = pl.pallas_call(
+        kernel,
+        grid=grid_,
+        in_specs=[
+            pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # query
+            pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # key
+            pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # value
+            bias_block_spec,  # bias
+        ],
+        out_specs=[
+            pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
+            pl.BlockSpec(lambda _, j, k: (j, k, 0), (None, None, seq_len)),
+            pl.BlockSpec(lambda _, j, k: (j, k, 0), (None, None, seq_len)),
+        ],
+        num_warps=num_warps_,
+        num_stages=num_stages_,
+        out_shape=out_shape,
+        debug=debug,
+        interpret=interpret,
+        name="mha_forward",
+    )(query, key, value, bias)
+    return out, (query, key, value, bias, out, l, m)
+
+
+def _preprocess_backward_kernel(
+    out_ref,
+    dout_ref,
+    l_ref,
+    new_dout_ref,
+    delta_ref,
+    *,
+    block_q: int,
+):
+    """Precomputes Di for the attention backwards pass.
+
+    This optimization is described in https://arxiv.org/abs/2205.14135 Appendix B.4 observation 2.
+    """
+    pid_m = pl.program_id(0)
+
+    off_m = pl.ds(pid_m * block_q, block_q)
+    # Load.
+    o = pl.load(out_ref, (off_m, slice(None))).astype(jnp.float32)
+    do = pl.load(dout_ref, (off_m, slice(None))).astype(jnp.float32)
+    denom = pl.load(l_ref, (off_m,)).astype(jnp.float32)
+    # Compute.
+    do = do / denom[:, None]
+    delta = jnp.sum(o * do, axis=1)
+    # Write-back.
+    pl.store(new_dout_ref, (off_m, slice(None)), do.astype(new_dout_ref.dtype))
+    pl.store(delta_ref, (off_m,), delta.astype(delta_ref.dtype))
+
+
+def _preprocess_backward(
+    out,
+    do,
+    l,
+    block_q: int,
+    debug: bool,
+    interpret: bool,
+):
+    """Calls `_preprocess_backward_kernel`."""
+    batch_size, seq_len, num_heads, head_dim = out.shape
+    out_shape = [
+        jax.ShapeDtypeStruct(do.shape, do.dtype),
+        jax.ShapeDtypeStruct(l.shape, l.dtype),
+    ]
+    do_scaled, delta = pl.pallas_call(
+        functools.partial(_preprocess_backward_kernel, block_q=block_q),
+        grid=(jt.cdiv(seq_len, block_q), batch_size, num_heads),
+        in_specs=[
+            pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
+            pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
+            pl.BlockSpec(lambda _, j, k: (j, k, 0), (None, None, seq_len)),
+        ],
+        out_specs=[
+            pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
+            pl.BlockSpec(lambda _, j, k: (j, k, 0), (None, None, seq_len)),
+        ],
+        num_warps=4,
+        num_stages=3,
+        out_shape=out_shape,
+        debug=debug,
+        interpret=interpret,
+        name="mha_preprocess_backward",
+    )(out, do, l)
+    return do_scaled, delta
+
+
+def _mha_backward_kernel(
+    # Inputs.
+    q_ref,
+    k_ref,
+    v_ref,
+    b_ref,
+    out_ref,
+    do_scaled_ref,
+    l_ref,
+    m_ref,
+    delta_ref,
+    _,
+    # Outputs.
+    dq_ref,
+    dk_ref,
+    dv_ref,
+    *,
+    softmax_scale: float,
+    bias_type: str,
+    causal: bool,
+    block_q: int,
+    block_d: int,
+    block_k: int,
+):
+    """Computes the backward pass.
+
+    This algorithm is described in https://arxiv.org/abs/2205.14135 Appendix B.4 Algorithm 4.
+
+    See also `_mha_forward_kernel` for the forward pass.
+
+    Args:
+        q_ref: Input query ref.
+        k_ref: Input key ref.
+        v_ref: Input value ref.
+        b_ref: Input bias ref.
+        out_ref: Input forward output ref.
+        do_scaled_ref: Preprocessed dOut ref. See `_preprocess_backward_kernel`.
+        l_ref: Input l ref.
+        m_ref: Input m ref.
+        delta_ref: Input delta ref. See `_preprocess_backward_kernerl`.
+        dq_ref: Output dQuery ref.
+        dk_ref: Output dKey ref.
+        dv_ref: Output dValue ref.
+        softmax_scale: Softmax scale.
+        bias_type: Type of bias matrix.
+        causal: Whether to apply causal mask.
+        block_q: Block size for query seq dim.
+        block_d: Block size for head dim.
+        block_k: Block size for key seq dim.
+    """
+    del out_ref, l_ref  # Not needed
+    seq_len = q_ref.shape[0]
+
+    def outer_loop(start_k, _):
+        dv = jnp.zeros([block_k, block_d], dtype=jnp.float32)
+        dk = jnp.zeros([block_k, block_d], dtype=jnp.float32)
+        k = pl.load(k_ref, (pl.ds(start_k * block_k, block_k), slice(None)))
+        v = pl.load(v_ref, (pl.ds(start_k * block_k, block_k), slice(None)))
+
+        # TODO(markblee): Not needed for non-causal?
+        span_k = start_k * block_k + jnp.arange(block_k)
+
+        def inner_loop(start_q, carry):
+            dv, dk = carry
+            q = pl.load(q_ref, (pl.ds(start_q * block_q, block_q), slice(None)))
+            qk = pl.dot(q, k.T)
+
+            # These casts are needed to avoid precision issues.
+            qk = qk.astype(q_ref.dtype)
+            qk = qk.astype(jnp.float32)
+
+            if softmax_scale != 1.0:
+                qk *= softmax_scale
+
+            if bias_type == "matrix":
+                # Load bias in transposed order, for hopefully better cache efficiency.
+                b = pl.load(
+                    b_ref,
+                    (pl.ds(start_k * block_k, block_k), pl.ds(start_q * block_q, block_q)),
+                )
+                b = b.astype(jnp.float32)
+                qk += b.T  # Transpose back.
+
+            if causal:
+                span_q = start_q * block_q + jnp.arange(block_q)
+                qk = jnp.where(span_q[:, None] >= span_k[None, :], qk, float("-inf"))
+
+            m = pl.load(m_ref, (pl.ds(start_q * block_q, block_q),))
+            p = jnp.exp(qk - m[:, None])
+            do = pl.load(do_scaled_ref, (pl.ds(start_q * block_q, block_q), slice(None)))
+            dv = dv + pl.dot(p.astype(do.dtype).T, do)
+            di = pl.load(delta_ref, (pl.ds(start_q * block_q, block_q),))
+            dp = jnp.zeros((block_q, block_k), dtype=jnp.float32) - di[:, None]
+            dp = dp + pl.dot(do, v.T)
+            ds = p * dp
+            if softmax_scale != 1.0:
+                ds = ds * softmax_scale
+            dk = dk + pl.dot(ds.astype(q_ref.dtype).T, q)
+            dq = pl.load(
+                dq_ref,
+                (pl.ds(start_q * block_q, block_q), slice(None)),
+                eviction_policy="evict_last",
+            )
+            dq = dq + pl.dot(ds.astype(k.dtype), k).astype(dq.dtype)
+            pl.store(
+                dq_ref,
+                (pl.ds(start_q * block_q, block_q), slice(None)),
+                dq,
+                eviction_policy="evict_last",
+            )
+            return dv, dk
+
+        if causal:
+            lower_bound = lax.div(start_k * block_k, block_q)
+        else:
+            lower_bound = 0
+        dv, dk = lax.fori_loop(lower_bound, jt.cdiv(seq_len, block_q), inner_loop, (dv, dk))
+        pl.store(dv_ref, (pl.ds(start_k * block_k, block_k), slice(None)), dv.astype(dv_ref.dtype))
+        pl.store(dk_ref, (pl.ds(start_k * block_k, block_k), slice(None)), dk.astype(dk_ref.dtype))
+
+    lax.fori_loop(0, jt.cdiv(seq_len, block_k), outer_loop, None)
+
+
+def _mha_backward(
+    softmax_scale: float,
+    causal: bool,
+    block_q: int,
+    block_k: int,
+    backward_pass_impl: str,
+    num_warps: Optional[int],
+    num_stages: int,
+    grid: Any,
+    interpret: bool,
+    debug: bool,
+    res,
+    do,
+):
+    """Calls `_mha_backward_kernel`."""
+    del num_warps, num_stages, grid
+    q, k, v, b, out, l, m = res
+
+    batch_size, seq_len, num_heads, head_dim = q.shape
+    block_q = min(block_q, seq_len)
+    block_k = min(block_k, seq_len)
+    do_scaled, delta = _preprocess_backward(out, do, l, block_q, debug, interpret)
+
+    # NOTE: temporarily removed the "xla" branch, which seems unused.
+    if backward_pass_impl == "triton":
+        # We accumulate into dq so we need to initialize it to zeros.
+        dq = jnp.zeros(q.shape, jnp.float32)
+        out_shapes = [
+            jax.ShapeDtypeStruct(dq.shape, dq.dtype),
+            jax.ShapeDtypeStruct(k.shape, k.dtype),
+            jax.ShapeDtypeStruct(v.shape, v.dtype),
+        ]
+
+        # Bias.
+        bias_type = "none"
+        bias_block_spec = None
+        input_output_aliases = {8: 0}
+        if b is not None:
+            # Transpose seq dims for cache efficiency.
+            b = jnp.moveaxis(b, -1, -2)
+            bias_type = "matrix"
+            bias_block_spec = pl.BlockSpec(
+                lambda j, k: (j, k, 0, 0), (None, None, seq_len, seq_len)
+            )
+            # We have one more non-None input (i.e., in_specs has another tree_leaf).
+            input_output_aliases = {9: 0}
+
+        grid = (batch_size, num_heads)
+        # TODO(markblee): num_warps=8 seems to work from basic testing, confirm the below comment.
+        # TODO(sharadmv): figure out why num_warps=8 doesn't work!
+        num_warps = 8
+        dq, dk, dv = pl.pallas_call(
+            functools.partial(
+                _mha_backward_kernel,
+                softmax_scale=softmax_scale,
+                bias_type=bias_type,
+                causal=causal,
+                block_q=block_q,
+                block_d=head_dim,
+                block_k=block_k,
+            ),
+            grid=grid,
+            out_shape=out_shapes,
+            in_specs=[
+                pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # query
+                pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # key
+                pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # value
+                bias_block_spec,  # bias
+                pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
+                pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
+                pl.BlockSpec(lambda j, k: (j, k, 0), (None, None, seq_len)),
+                pl.BlockSpec(lambda j, k: (j, k, 0), (None, None, seq_len)),
+                pl.BlockSpec(lambda j, k: (j, k, 0), (None, None, seq_len)),
+                pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
+            ],
+            out_specs=[
+                pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
+                pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
+                pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
+            ],
+            name="mha_backward",
+            debug=debug,
+            interpret=interpret,
+            num_warps=num_warps,
+            num_stages=1,
+            input_output_aliases=input_output_aliases,
+        )(q, k, v, b, out, do_scaled, l, m, delta, dq)
+    else:
+        raise ValueError(f"Invalid backward pass implementation: {backward_pass_impl}")
+    return dq.astype(q.dtype), dk, dv, None
+
+
+mha.defvjp(_mha_forward, _mha_backward)
+
+
+@functools.partial(jax.jit, static_argnames=["softmax_scale", "causal"])
+def mha_reference(
+    q, k, v, bias: Optional[Tensor] = None, softmax_scale: float = 1.0, causal: bool = True
+):
+    """A simple jax attention implementation.
+
+    Reference:
+    https://github.com/jax-ml/jax-triton/blob/b11bef5805d663beb25057a07987c951f8b9f629/jax_triton/pallas/ops/attention.py#L356
+    """
+    q_seq_len = q.shape[1]
+    kv_seq_len = k.shape[1]
+    logits = jnp.einsum("bqhc,bkhc->bhqk", q, k).astype(jnp.float32)
+    if causal:
+        mask = jnp.tril(jnp.ones((1, 1, q_seq_len, kv_seq_len), dtype=bool))
+        mask = jnp.broadcast_to(mask, logits.shape)
+        logits = jnp.where(mask, logits, float("-inf"))
+    logits *= softmax_scale
+    if bias is not None:
+        logits += bias.astype(jnp.float32)
+    weights = jax.nn.softmax(logits).astype(v.dtype)
+    return jnp.einsum("bhqk,bkhc->bqhc", weights, v)

--- a/axlearn/common/flash_attention/attention_benchmark.py
+++ b/axlearn/common/flash_attention/attention_benchmark.py
@@ -1,0 +1,211 @@
+# Copyright © 2023 Apple Inc.
+
+"""FlashAttention kernel benchmarks.
+
+Sample outputs on A100:
+
+bench-head32-seq1024-d64:
+   batch_size       Jax  Jax Triton    Pallas    PyTorch  PyTorch Triton
+0         2.0  1.294677    0.308249  0.178258   2.774377        0.198660
+1         4.0  2.337943    0.417789  0.268292   5.449353        0.327930
+2         8.0  4.341445    0.625852  0.587789  10.795019        0.585716
+3        16.0  8.209461    1.210101  0.736935  21.485954        1.101084
+batch2-seq2048-d64:
+   num_heads       Jax  Jax Triton    Pallas    PyTorch  PyTorch Triton
+0       12.0  1.758803    0.377092  0.292216   4.154821        0.282745
+1       16.0  2.274562    0.437537  0.324150   5.495135        0.334550
+2       32.0  4.111703    0.646520  0.599221  10.850373        0.558403
+3       40.0  5.044082    0.765017  0.676835  13.539443        0.675699
+4       56.0  6.987845    1.035317  0.764956  18.896891        0.900977
+5       72.0  8.709219    1.234217  0.836006  24.280788        1.129773
+batch2-head32-d64:
+   seq_len       Jax  Jax Triton    Pallas    PyTorch  PyTorch Triton
+0    128.0  0.141517    0.127410  0.274202   0.102813        0.022059
+1    256.0  0.224241    0.128345  0.268729   0.212434        0.042063
+2    512.0  0.426494    0.148231  0.268689   0.770047        0.081487
+3   1024.0  1.298753    0.316831  0.156720   2.774356        0.198292
+4   2048.0  4.031973    0.626030  0.589759  10.851770        0.558741
+batch2-head32-seq2048:
+   per_head_dim       Jax  Jax Triton    Pallas    PyTorch  PyTorch Triton
+0          16.0  3.858791    0.437569  0.213704  10.560411        0.331421
+1          32.0  3.955815    0.514656  0.261292  10.627665        0.437445
+2          64.0  4.121394    0.636113  0.584212  10.851702        0.558101
+3         128.0  4.439079    0.973939  0.371719  11.237614        0.754280
+
+With backward pass:
+
+grad-head32-seq1024-d64:
+   batch_size        Jax  Jax Triton    Pallas    PyTorch  PyTorch Triton
+0         2.0   2.848025    1.942416  1.694485   6.299916        1.133216
+1         4.0   5.322315    1.991064  2.380001  12.186511        1.898364
+2         8.0  10.041783    2.945663  4.342529  23.935926        2.966447
+3        16.0  19.633947    5.056746  7.604803  47.527328        5.060277
+grad-batch2-seq2048-d64:
+   num_heads        Jax  Jax Triton    Pallas    PyTorch  PyTorch Triton
+0       12.0   3.776024    2.353134  3.311361   9.244321        2.498945
+1       16.0   5.015553    2.435218  3.501143  12.162596        2.632030
+2       32.0   9.679915    2.942006  4.506633  24.000723        3.347016
+3       40.0  11.839152    3.409772  5.224550  29.938248        3.646133
+4       56.0  16.324726    5.345623  8.512093  41.617474        5.386331
+5       72.0  20.826162    5.967896  9.429584  53.344563        6.108087
+grad-batch2-head32-d64:
+   seq_len       Jax  Jax Triton    Pallas    PyTorch  PyTorch Triton
+0    128.0  2.084800    1.946231  1.715087   1.179843        0.623846
+1    256.0  2.205729    2.110186  1.704993   0.648029        0.340229
+2    512.0  2.259852    2.102726  1.554168   1.883081        0.480496
+3   1024.0  2.859227    2.069817  1.645913   6.291944        1.120009
+4   2048.0  9.606998    2.954207  4.540852  23.863083        2.998823
+grad-batch2-head32-seq2048:
+   per_head_dim        Jax  Jax Triton    Pallas    PyTorch  PyTorch Triton
+0          16.0   9.076053    2.093116  2.735943  23.176823        1.625986
+1          32.0   9.133391    2.438204  3.100990  23.311085        2.156206
+2          64.0   9.490566    3.001139  4.537563  23.846561        3.010464
+3         128.0  10.347649    5.208034  6.846362  24.728912        5.447452
+
+In addition to the dependencies in attention.py, also requires:
+torch==2.1.0.dev20230726+cu121
+pytorch-triton==2.1.0+9e3e10c5ed
+"""
+# pylint: skip-file
+
+import jax
+import jax.numpy as jnp
+import triton  # pytype: disable=import-error
+
+from axlearn.common.flash_attention.attention import mha, mha_reference
+
+
+def _perf_report(prefix: str):
+    batch_size, num_heads, seq_len, per_head_dim = 2, 32, 2048, 64
+
+    # Vary batch size for fixed heads and seq length.
+    batch_size_bench = triton.testing.Benchmark(
+        x_names=["batch_size"],
+        x_vals=[2, 4, 8, 16],
+        line_arg="library",
+        line_vals=["jax", "jax-triton"],
+        line_names=["Jax", "Jax Triton"],
+        styles=[("blue", "-"), ("purple", "-")],
+        ylabel="ms",
+        plot_name=f"{prefix}-head{num_heads}-seq1024-d{per_head_dim}",
+        args={"num_heads": num_heads, "seq_len": 1024, "per_head_dim": per_head_dim},
+    )
+    # Vary num heads for fixed batch and seq length.
+    num_heads_bench = triton.testing.Benchmark(
+        x_names=["num_heads"],
+        x_vals=[12, 16, 32, 40, 56, 72],
+        line_arg="library",
+        line_vals=["jax", "jax-triton"],
+        line_names=["Jax", "Jax Triton"],
+        styles=[("blue", "-"), ("purple", "-")],
+        ylabel="ms",
+        plot_name=f"{prefix}-batch{batch_size}-seq{seq_len}-d{per_head_dim}",
+        args={"batch_size": batch_size, "seq_len": seq_len, "per_head_dim": per_head_dim},
+    )
+    # Vary seq length for fixed heads and batch size.
+    seq_len_bench = triton.testing.Benchmark(
+        x_names=["seq_len"],
+        x_vals=[2**i for i in range(7, 12)],  # 128 to 2048.
+        line_arg="library",
+        line_vals=["jax", "jax-triton"],
+        line_names=["Jax", "Jax Triton"],
+        styles=[("blue", "-"), ("purple", "-")],
+        ylabel="ms",
+        plot_name=f"{prefix}-batch{batch_size}-head{num_heads}-d{per_head_dim}",
+        args={"batch_size": batch_size, "num_heads": num_heads, "per_head_dim": per_head_dim},
+    )
+    # Vary per head dim for fixed batch and seq length.
+    per_head_dim_bench = triton.testing.Benchmark(
+        x_names=["per_head_dim"],
+        x_vals=[16, 32, 64, 128],
+        line_arg="library",
+        line_vals=["jax", "jax-triton"],
+        line_names=["Jax", "Jax Triton"],
+        styles=[("blue", "-"), ("purple", "-")],
+        ylabel="ms",
+        plot_name=f"{prefix}-batch{batch_size}-head{num_heads}-seq{seq_len}",
+        args={"batch_size": batch_size, "num_heads": num_heads, "seq_len": seq_len},
+    )
+    return triton.testing.perf_report(
+        [batch_size_bench, num_heads_bench, seq_len_bench, per_head_dim_bench]
+    )
+
+
+@_perf_report("fwd")
+def bench_flash_attention(
+    batch_size: int, num_heads: int, seq_len: int, per_head_dim: int, library: str
+):
+    warmup = 25
+    rep = 500
+
+    if library.startswith("jax"):
+        q = jax.random.normal(
+            jax.random.PRNGKey(0), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+        )
+        k = jax.random.normal(
+            jax.random.PRNGKey(1), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+        )
+        v = jax.random.normal(
+            jax.random.PRNGKey(2), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+        )
+        bias = jax.random.normal(
+            jax.random.PRNGKey(2), (batch_size, num_heads, seq_len, seq_len), dtype=jnp.float16
+        )
+
+        if "triton" in library:
+            fn = lambda: mha(q, k, v, bias)
+        else:
+            fn = lambda: mha_reference(q, k, v, bias)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+
+    else:
+        raise ValueError(f"Unsupported: {library}")
+    return ms
+
+
+@_perf_report("grad")
+def bench_flash_attention_backward(
+    batch_size: int, num_heads: int, seq_len: int, per_head_dim: int, library: str
+):
+    warmup = 25
+    rep = 500
+
+    if library.startswith("jax"):
+        q = jax.random.normal(
+            jax.random.PRNGKey(0), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+        )
+        k = jax.random.normal(
+            jax.random.PRNGKey(1), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+        )
+        v = jax.random.normal(
+            jax.random.PRNGKey(2), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+        )
+        bias = jax.random.normal(
+            jax.random.PRNGKey(3), (batch_size, num_heads, seq_len, seq_len), dtype=jnp.float16
+        )
+
+        if "triton" in library:
+
+            @jax.jit
+            def test_fn(q, k, v, bias):
+                return mha(q, k, v, bias).sum()
+
+            test_bwd = jax.grad(test_fn, argnums=(0, 1, 2))
+            fn = lambda: test_bwd(q, k, v, bias)
+        else:
+
+            @jax.jit
+            def ref_fn(q, k, v, bias):
+                return mha_reference(q, k, v, bias).sum()
+
+            ref_bwd = jax.grad(ref_fn, argnums=(0, 1, 2))
+            fn = lambda: ref_bwd(q, k, v, bias)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+
+    else:
+        raise ValueError(f"Unsupported: {library}")
+    return ms
+
+
+bench_flash_attention.run(save_path=".", print_data=True)
+bench_flash_attention_backward.run(save_path=".", print_data=True)

--- a/axlearn/common/flash_attention/attention_test.py
+++ b/axlearn/common/flash_attention/attention_test.py
@@ -1,0 +1,167 @@
+# Copyright © 2023 Apple Inc.
+#
+# Some of the code in this file is adapted from:
+#
+# jax-ml/jax-triton:
+# Copyright 2023 The jax_triton Authors.
+# Licensed under the Apache License, Version 2.0 (the "License").
+
+"""Tests FlashAttention kernels.
+
+Currently tested on A100.
+"""
+# pylint: disable=wrong-import-position
+import functools
+import os
+
+os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
+
+import chex
+import jax
+import jax.numpy as jnp
+import pytest
+
+try:
+    import jax_triton as jt  # pytype: disable=import-error  # pylint: disable=import-error
+
+    from axlearn.common.flash_attention.attention import mha, mha_reference
+
+    if jt.get_compute_capability(0) < 80:
+        pytest.skip(reason="Incompatible hardware.", allow_module_level=True)
+except ModuleNotFoundError as e:
+    # Some libraries can only be installed on GPU, so we'll skip on CI.
+    pytest.skip(
+        reason=f"Skipping flash_attention tests due to missing deps: {e}",
+        allow_module_level=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "batch_size,seq_len,num_heads,per_head_dim",
+    [
+        (1, 384, 1, 64),
+        (2, 384, 2, 64),
+        (1, 384, 1, 64),
+        (2, 384, 2, 64),
+        (1, 384, 8, 64),
+        (2, 384, 8, 64),
+    ],
+)
+@pytest.mark.parametrize("block_size", [128, 64])
+@pytest.mark.parametrize("use_fwd", [True, False])
+@pytest.mark.parametrize("causal", [True, False])
+@pytest.mark.parametrize("sm_scale", [1.0, 0.123])
+@pytest.mark.parametrize("bias_type", ["none", "matrix"])
+def test_fwd_against_ref(
+    batch_size: int,
+    seq_len: int,
+    num_heads: int,
+    per_head_dim: int,
+    block_size: int,
+    use_fwd: bool,
+    causal: bool,
+    sm_scale: float,
+    bias_type: str,
+):
+    k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(0), 4)
+    q = jax.random.normal(k1, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16)
+    k = jax.random.normal(k2, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16)
+    v = jax.random.normal(k3, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16)
+
+    if bias_type == "matrix":
+        bias = jax.random.normal(k4, (batch_size, num_heads, seq_len, seq_len), dtype=jnp.float16)
+    else:
+        bias = None
+
+    if use_fwd:
+
+        @jax.jit
+        def impl(q, k, v, bias):
+            fn = functools.partial(
+                mha,
+                block_q=block_size,
+                block_k=block_size,
+                causal=causal,
+                softmax_scale=sm_scale,
+            )
+            out, _ = jax.vjp(fn, q, k, v, bias)
+            return out
+
+    else:
+        impl = functools.partial(
+            mha, block_q=block_size, block_k=block_size, causal=causal, softmax_scale=sm_scale
+        )
+
+    o = impl(q, k, v, bias)
+    o_ref = mha_reference(q, k, v, bias, causal=causal, softmax_scale=sm_scale)
+    chex.assert_trees_all_close(o, o_ref, atol=0.05)
+
+
+@pytest.mark.parametrize(
+    "batch_size,num_heads,seq_len,per_head_dim",
+    [
+        (1, 1, 384, 64),
+        (2, 2, 384, 64),
+        (1, 1, 384, 64),
+        (2, 2, 384, 64),
+        (1, 8, 384, 64),
+        (2, 8, 384, 64),
+    ],
+)
+@pytest.mark.parametrize("bias_type", ["none", "matrix"])
+@pytest.mark.parametrize("block_size", [128, 64])
+@pytest.mark.parametrize("causal", [True, False])
+def test_bwd_against_ref(
+    batch_size: int,
+    num_heads: int,
+    seq_len: int,
+    per_head_dim: int,
+    bias_type: str,
+    block_size: int,
+    causal: bool,
+):
+    q = jax.random.normal(
+        jax.random.PRNGKey(0), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+    )
+    k = jax.random.normal(
+        jax.random.PRNGKey(1), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+    )
+    v = jax.random.normal(
+        jax.random.PRNGKey(2), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+    )
+
+    if bias_type == "matrix":
+        bias = jax.random.normal(
+            jax.random.PRNGKey(3), (batch_size, num_heads, seq_len, seq_len), dtype=jnp.float16
+        )
+    else:
+        bias = None
+
+    assert str(q.device()) == "gpu:0"
+    sm_scale = q.shape[-1] ** -0.5
+
+    # Compare outputs.
+    jax_out = mha(q, k, v, bias, causal=causal, softmax_scale=sm_scale)
+    jax_ref_out = mha_reference(q, k, v, bias, causal=causal, softmax_scale=sm_scale)
+    chex.assert_trees_all_close(jax_out, jax_ref_out, atol=0.005)
+
+    def fn(q, k, v, bias):
+        return mha(
+            q,
+            k,
+            v,
+            bias,
+            causal=causal,
+            softmax_scale=sm_scale,
+            block_q=block_size,
+            block_k=block_size,
+        ).sum()
+
+    def ref_fn(q, k, v, bias):
+        return mha_reference(q, k, v, bias, causal=causal, softmax_scale=sm_scale).sum()
+
+    # Compare gradients.
+    jax_grads = jax.grad(fn, argnums=(0, 1, 2))(q, k, v, bias)
+    jax_ref_grads = jax.grad(ref_fn, argnums=(0, 1, 2))(q, k, v, bias)
+    chex.assert_trees_all_close(jax_grads, jax_ref_grads, atol=0.05)

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -1,0 +1,112 @@
+# Copyright © 2023 Apple Inc.
+
+"""FlashAttention layers."""
+from typing import Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+from jax.experimental.maps import thread_resources
+from jax.experimental.shard_map import shard_map
+from jax.sharding import PartitionSpec
+
+from axlearn.common.attention import MultiheadAttention
+from axlearn.common.base_layer import BaseLayer
+from axlearn.common.config import ConfigBase
+from axlearn.common.flash_attention.attention import mha
+from axlearn.common.module import Module
+from axlearn.common.utils import Tensor
+
+
+def _check_bias_recursively(cfg: ConfigBase):
+    """Ensures that `cfg.bias` is set to False for all descendants."""
+
+    def visit_fn(_, value):
+        if isinstance(value, BaseLayer.Config) and getattr(value, "bias", False):
+            raise NotImplementedError("cfg.bias is not yet supported.")
+
+    def enter_fn(_, value, default_kv):
+        return None if isinstance(value, BaseLayer.Config) and "bias" in value else default_kv
+
+    cfg.visit(visit_fn=visit_fn, enter_fn=enter_fn)
+    return cfg
+
+
+class FlashAttention(MultiheadAttention):
+    """FlashAttention layer.
+
+    Is a drop-in replacement of MultiheadAttention, with some limitations:
+    * Does not yet support dropout.
+    * Does not support gradients wrt attention logit biases.
+    * Supports a subset of config fields and outputs.
+    """
+
+    def __init__(self, cfg: MultiheadAttention.Config, *, parent: Module):
+        super().__init__(cfg, parent=parent)
+        cfg = self.config
+        _check_bias_recursively(cfg)  # Bias not supported.
+        for key in ["per_dim_scale", "atten_logit_cap"]:
+            if getattr(cfg, key, None) is not None:
+                raise NotImplementedError(f"cfg.{key} is not supported.")
+        if cfg.dropout.rate:
+            raise NotImplementedError("cfg.dropout.rate is not supported.")
+
+    @classmethod
+    def default_config(cls) -> MultiheadAttention.Config:
+        cfg: MultiheadAttention.Config = super().default_config()
+        cfg.dropout.rate = None
+        cfg.per_dim_scale = None
+        cfg.atten_logit_cap = None
+        return cfg
+
+    def _compute_attention(
+        self,
+        *,
+        q_proj: Tensor,
+        k_proj: Tensor,
+        v_proj: Tensor,
+        attention_logit_biases: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        if attention_logit_biases is not None:
+            if attention_logit_biases.ndim != 4:
+                raise ValueError(
+                    f"Expected attention_logit_biases.ndim == 4, got {attention_logit_biases.ndim}"
+                )
+            attention_logit_biases = attention_logit_biases.astype(q_proj.dtype)
+
+        # shard_map-decorated function needs to be jitted.
+        @jax.jit
+        def jit_mha(query, key, value, bias):
+            return mha(
+                query, key, value, bias=bias, causal=False, softmax_scale=self._scale_query(1)
+            )
+
+        mesh = thread_resources.env.physical_mesh
+        # We need to manually partition jax-triton calls.
+        # Note: shard_map doesn't support kwargs.
+        partitioned_mha = shard_map(
+            jit_mha,
+            mesh=mesh,
+            in_specs=(
+                # QKV [batch_size, seq_len, num_heads, per_head_dim].
+                PartitionSpec("data", None, "model", None),
+                PartitionSpec("data", None, "model", None),
+                PartitionSpec("data", None, "model", None),
+                # Bias [batch_size, num_heads, seq_len, seq_len].
+                PartitionSpec("data", "model", None, None),
+            ),
+            # O [batch_size, seq_len, num_heads, per_head_dim].
+            out_specs=PartitionSpec("data", None, "model", None),
+            # Disables a checking pass which jax can't apply when there's a triton_call in the body.
+            check_rep=False,
+        )
+
+        outputs = partitioned_mha(
+            q_proj,
+            k_proj,
+            v_proj,
+            attention_logit_biases,
+        )
+        batch, target_len, num_heads, _ = q_proj.shape
+        _, source_len, _, _ = k_proj.shape
+        # TODO(markblee): Add output probs and benchmark.
+        return outputs, jnp.empty((batch, num_heads, target_len, source_len))

--- a/axlearn/common/flash_attention/layer_test.py
+++ b/axlearn/common/flash_attention/layer_test.py
@@ -1,0 +1,193 @@
+# Copyright © 2023 Apple Inc.
+
+"""Tests FlashAttention layers."""
+import jax
+import jax.numpy as jnp
+import pytest
+from absl.testing import parameterized
+from jax.experimental import mesh_utils
+from jax.sharding import Mesh
+
+try:
+    import jax_triton as jt  # pytype: disable=import-error  # pylint: disable=import-error
+
+    from axlearn.common.flash_attention.layer import FlashAttention
+
+    if jt.get_compute_capability(0) < 80:
+        pytest.skip(reason="Incompatible hardware.", allow_module_level=True)
+except ModuleNotFoundError as e:
+    # Some libraries can only be installed on GPU, so we'll skip on CI.
+    pytest.skip(
+        reason=f"Skipping flash_attention tests due to missing deps: {e}",
+        allow_module_level=True,
+    )
+
+from axlearn.common.attention import NEG_INF, MultiheadAttention
+from axlearn.common.base_layer import BaseLayer
+from axlearn.common.config import config_class
+from axlearn.common.layers import set_bias_recursively
+from axlearn.common.module import Module
+from axlearn.common.module import functional as F
+from axlearn.common.test_utils import TestCase, is_supported_mesh_shape
+
+
+def _fake_inputs(*, batch: int, num_heads: int, seq_len: int, hidden_dim: int):
+    query = jax.random.normal(
+        jax.random.PRNGKey(0),
+        [batch, seq_len, hidden_dim],
+        dtype=jnp.bfloat16,
+    )
+    key = jax.random.normal(
+        jax.random.PRNGKey(1),
+        [batch, seq_len, hidden_dim],
+        dtype=jnp.bfloat16,
+    )
+    value = jax.random.normal(
+        jax.random.PRNGKey(2),
+        [batch, seq_len, hidden_dim],
+        dtype=jnp.bfloat16,
+    )
+    bias = (
+        jnp.array(
+            jax.random.randint(
+                jax.random.PRNGKey(3), [batch, num_heads, seq_len, seq_len], minval=0, maxval=2
+            )
+        )
+        * NEG_INF
+    )
+    return dict(query=query, key=key, value=value, attention_logit_biases=bias)
+
+
+class TestFlashAttention(TestCase):
+    """Tests FlashAttention layer."""
+
+    @parameterized.parameters(
+        dict(batch=2, seq_len=384, num_heads=4, per_head_dim=32, mesh=(1, 1)),
+        dict(batch=2, seq_len=2048, num_heads=4, per_head_dim=64, mesh=(1, 1)),
+        dict(batch=8, seq_len=2048, num_heads=4, per_head_dim=64, mesh=(8, 1)),
+    )
+    def test_forward(self, batch, seq_len, num_heads, per_head_dim, mesh):
+        if not is_supported_mesh_shape(mesh):
+            pytest.skip(reason=f"Unsupported mesh {mesh}.")
+
+        with Mesh(mesh_utils.create_device_mesh(mesh), ("data", "model")):
+            hidden_dim = num_heads * per_head_dim
+            kwargs = dict(
+                query_dim=hidden_dim,
+                key_dim=hidden_dim,
+                value_dim=hidden_dim,
+                num_heads=num_heads,
+                dtype=jnp.bfloat16,
+            )
+            ref_cfg = MultiheadAttention.default_config().set(**kwargs)
+            test_cfg = FlashAttention.default_config().set(**kwargs)
+            set_bias_recursively(ref_cfg, False)
+            set_bias_recursively(test_cfg, False)
+
+            ref_layer = ref_cfg.set(name="ref").instantiate(parent=None)
+            test_layer = test_cfg.set(name="test").instantiate(parent=None)
+
+            # Use the same params for both. Only attention implementation differs.
+            params = ref_layer.initialize_parameters_recursively(prng_key=jax.random.PRNGKey(123))
+            inputs = _fake_inputs(
+                batch=batch,
+                num_heads=num_heads,
+                seq_len=seq_len,
+                hidden_dim=hidden_dim,
+            )
+
+            ref_out, _ = F(
+                ref_layer,
+                prng_key=jax.random.PRNGKey(5),
+                state=params,
+                inputs=inputs,
+                is_training=True,
+            )
+            test_out, _ = F(
+                test_layer,
+                prng_key=jax.random.PRNGKey(5),
+                state=params,
+                inputs=inputs,
+                is_training=True,
+            )
+            # TODO(markblee): Test probs.
+            self.assertNestedAllClose(ref_out.data, test_out.data, atol=0.05)
+
+    @parameterized.parameters(
+        dict(batch=2, seq_len=384, num_heads=4, per_head_dim=32, mesh=(1, 1)),
+        dict(batch=2, seq_len=2048, num_heads=4, per_head_dim=64, mesh=(1, 1)),
+        dict(batch=8, seq_len=2048, num_heads=4, per_head_dim=64, mesh=(8, 1)),
+    )
+    def test_backward(self, batch, seq_len, num_heads, per_head_dim, mesh):
+        if not is_supported_mesh_shape(mesh):
+            pytest.skip(reason=f"Unsupported mesh {mesh}.")
+
+        with Mesh(mesh_utils.create_device_mesh(mesh), ("data", "model")):
+
+            class DummyModel(BaseLayer):
+                """A dummy model."""
+
+                @config_class
+                class Config(BaseLayer.Config):
+                    layer: MultiheadAttention.Config = MultiheadAttention.default_config()
+
+                def __init__(self, cfg: Config, *, parent: Module):
+                    super().__init__(cfg, parent=parent)
+                    cfg = self.config
+                    self._add_child("layer", cfg.layer)
+
+                def forward(self, *, query, key, value, attention_logit_biases):
+                    # [batch, target_length, target_dim].
+                    x = self.layer(
+                        query,
+                        key=key,
+                        value=value,
+                        attention_logit_biases=attention_logit_biases,
+                    )
+                    # TODO(markblee,zhaoyi-zhang): The atol needs to increase significantly if using
+                    # jnp.sum, as we no longer scale by the size of the data dims.
+                    return jnp.mean(x.data, dtype=query.dtype)
+
+            hidden_dim = num_heads * per_head_dim
+            kwargs = dict(
+                query_dim=hidden_dim,
+                key_dim=hidden_dim,
+                value_dim=hidden_dim,
+                num_heads=num_heads,
+                dtype=jnp.bfloat16,
+            )
+            ref_cfg = DummyModel.default_config().set(
+                layer=MultiheadAttention.default_config().set(**kwargs),
+            )
+            test_cfg = DummyModel.default_config().set(
+                layer=FlashAttention.default_config().set(**kwargs),
+            )
+            set_bias_recursively(ref_cfg, False)
+            set_bias_recursively(test_cfg, False)
+            ref_layer = ref_cfg.set(name="ref").instantiate(parent=None)
+            test_layer = test_cfg.set(name="test").instantiate(parent=None)
+
+            # Use the same params for both. Only attention implementation differs.
+            params = ref_layer.initialize_parameters_recursively(prng_key=jax.random.PRNGKey(123))
+            inputs = _fake_inputs(
+                batch=batch,
+                num_heads=num_heads,
+                seq_len=seq_len,
+                hidden_dim=hidden_dim,
+            )
+
+            def loss(params, inputs, layer):
+                loss, _ = F(
+                    layer,
+                    inputs=inputs,
+                    state=params,
+                    is_training=True,
+                    prng_key=jax.random.PRNGKey(0),
+                )
+                return loss
+
+            ref_value, ref_grads = jax.value_and_grad(loss)(params, inputs, ref_layer)
+            test_value, test_grads = jax.value_and_grad(loss)(params, inputs, test_layer)
+
+            self.assertNestedAllClose(ref_value, test_value, atol=1e-5)
+            self.assertNestedAllClose(ref_grads, test_grads, atol=1e-5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,16 @@ t5x = [
     "t5==0.9.4",
     "t5x@git+https://github.com/google-research/t5x.git@caa500771af314e3cb877b5c158c1db4ae0427c2"
 ]
+# Jax-triton. Can only be installed on a GPU machine.
+jax_triton = [
+    "cmake",
+    # Compatible with jax 0.4.13.
+    "jax-triton@git+https://github.com/jax-ml/jax-triton.git@c3721db034b4311e0a8799d6a28ce8aea7be1da1",
+    "jaxlib==0.4.13+cuda12.cudnn89",
+    "nvidia-cudnn-cu12==8.9.2.26",
+    # To avoid conflicting with jax.
+    "tensorflow-cpu==2.8.0",
+]
 
 [tool.flit.module]
 # This defines the import name. https://flit.pypa.io/en/stable/pyproject_toml.html#module-section


### PR DESCRIPTION
- Adds basic support for attention logit biases in the pallas attention op.
- Adds a benchmarking script for fwd+bwd.
- Adds FlashAttention layer which is (mostly) a drop-in replacement for MultiheadAttention (with caveats, see docstrings).
- Updates licenses/acknowledgements.