### PR TITLE
Supports prefix padding with sample_decode prefill.

### DIFF
--- a/axlearn/common/decoder.py
+++ b/axlearn/common/decoder.py
@@ -284,10 +284,10 @@ class DecodingMixin(Module):
             prefix, max_sequence_length=max_sequence_length, pad_id=cfg.pad_token_id
         )
         init_states, init_outputs = self.prefill_states(
-            # Compute initial time step based on prefix lengths. The prefix for each example in the
-            # batch should begin with a dummy prompt token (e.g. [BOS]). A pad token represents the
-            # end of the prefix and must be followed only by zero or more pad tokens.
-            time_step=(prefix != cfg.pad_token_id).sum(axis=-1) - 1,
+            # Compute initial time step based on prefix. We infer these from the last non-pad token
+            # in the prefix (i.e., the prefix itself can have pad tokens). If the prefix consists of
+            # all pad tokens, we start at index 0.
+            time_step=((prefix != cfg.pad_token_id) * jnp.arange(prefix.shape[1])).max(axis=-1),
             input_ids=input_ids,
             cross_attention_data=cross_attention_data,
             cross_attention_logit_biases=cross_attention_logit_biases,

--- a/axlearn/common/decoding.py
+++ b/axlearn/common/decoding.py
@@ -753,8 +753,8 @@ def _decode_init(
         )
 
     return DecodingState(
-        # Subtract the dummy BOS token. For example, in the no-prefill case, we should start at 0.
-        cur_index=(inputs != pad_id).sum(axis=-1) - 1,
+        # Take the position of the last non-pad token as the initial timestep.
+        cur_index=((inputs != pad_id) * jnp.arange(inputs.shape[1])).max(axis=-1),
         token_scores=init_scores,
         sequences=sequences,
         stop_decoding=jnp.zeros((batch_size, num_decodes), bool),

--- a/axlearn/common/decoding_test.py
+++ b/axlearn/common/decoding_test.py
@@ -1128,7 +1128,9 @@ class DecodeTest(parameterized.TestCase):
             [1, num_decodes, 1],
         )
         prompt_mask = (jnp.arange(decode_length) < prompt_length)[:, None, :]
-        # Ensure pad_id and eos_id are not already in ref_tokens.
+        # Ensure pad_id and eos_id are not already in prompt_tokens.
+        # This is mainly because when decoding from scratch, padding is used to infer whether we're
+        # out of prompt, whereas in the prefill case we treat intermediate padding as within prompt.
         self.assertFalse(jnp.any(prompt_tokens == pad_id))
         self.assertFalse(jnp.any(prompt_tokens == eos_id))
 


### PR DESCRIPTION
- Updates extend_step test to check parity between `forward` vs. `prefill + extend_step`, allowing the prefix to contain padding.
- Updates decode test to check that prefix is properly retained + decoded outputs are what we expect even when prefix contains padding.
- Note that the parity test between `prefill + extend_step` and `init_states + extend_step` still assumes no prefix padding, because in the latter case padding can affect out_of_prompt decisions.