### PR TITLE
[gcp]: migrate google oauth2 credentials to google auth credentials

### DIFF
--- a/axlearn/cloud/gcp/tpu.py
+++ b/axlearn/cloud/gcp/tpu.py
@@ -13,9 +13,9 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import cloud_tpu_client
 from absl import logging
+from google.auth.credentials import Credentials
 from googleapiclient import discovery, errors
 from googleapiclient.http import HttpRequest
-from oauth2client.client import GoogleCredentials
 
 from axlearn.cloud.common.docker import registry_from_repo
 from axlearn.cloud.common.utils import format_table
@@ -46,7 +46,7 @@ def create_tpu(
     name: str,
     *,
     tpu_type: str,
-    credentials: GoogleCredentials,
+    credentials: Credentials,
     bundler_type: str,
     num_slices: int = 1,
     metadata: Optional[Dict[str, str]] = None,
@@ -117,7 +117,7 @@ def _create_legacy_tpu(
     name: str,
     *,
     tpu_type: str,
-    credentials: GoogleCredentials,
+    credentials: Credentials,
     bundler_type: str,
     metadata: Optional[Dict[str, str]] = None,
 ):
@@ -206,7 +206,7 @@ def _create_legacy_tpu(
                 raise TPUCreationError("Failed to create TPU-VM") from e
 
 
-def delete_tpu(name: str, *, credentials: GoogleCredentials, wait: bool = True):
+def delete_tpu(name: str, *, credentials: Credentials, wait: bool = True):
     """Delete TPU.
 
     Args:
@@ -223,7 +223,7 @@ def delete_tpu(name: str, *, credentials: GoogleCredentials, wait: bool = True):
     _delete_legacy_tpu(name, credentials=credentials, wait=wait)
 
 
-def _delete_legacy_tpu(name: str, *, credentials: GoogleCredentials, wait: bool = True):
+def _delete_legacy_tpu(name: str, *, credentials: Credentials, wait: bool = True):
     """Delete TPU (using legacy quota).
 
     See `delete_tpu` docstring for details.
@@ -248,7 +248,7 @@ def _delete_legacy_tpu(name: str, *, credentials: GoogleCredentials, wait: bool 
         time.sleep(10)
 
 
-def list_tpu(credentials: GoogleCredentials) -> List[str]:
+def list_tpu(credentials: Credentials) -> List[str]:
     """List running TPUs.
 
     Args:
@@ -261,7 +261,7 @@ def list_tpu(credentials: GoogleCredentials) -> List[str]:
     return [el.name for el in info]
 
 
-def _delete_multislice_tpu(name: str, *, credentials: GoogleCredentials, wait: bool = True):
+def _delete_multislice_tpu(name: str, *, credentials: Credentials, wait: bool = True):
     """Delete multislice TPU.
 
     See `delete_tpu` docstring for details.
@@ -309,7 +309,7 @@ def _create_multislice_tpu(
     name: str,
     *,
     tpu_type: str,
-    credentials: GoogleCredentials,
+    credentials: Credentials,
     bundler_type: str,
     num_slices: int = 1,
     metadata: Optional[Dict[str, str]] = None,
@@ -406,7 +406,7 @@ class TpuInfo:
     metadata: Dict[str, Any]
 
 
-def list_tpu_info(credentials: GoogleCredentials) -> List[TpuInfo]:
+def list_tpu_info(credentials: Credentials) -> List[TpuInfo]:
     """Collect info for running TPUs.
 
     Args:
@@ -439,7 +439,7 @@ class QueuedResourceInfo(TpuInfo):
     reserved: bool
 
 
-def list_queued_resource_info(credentials: GoogleCredentials) -> List[QueuedResourceInfo]:
+def list_queued_resource_info(credentials: Credentials) -> List[QueuedResourceInfo]:
     """Collect info for live queued resources.
 
     Args:
@@ -468,7 +468,7 @@ def list_queued_resource_info(credentials: GoogleCredentials) -> List[QueuedReso
     return info
 
 
-def _qrm_resource(credentials: GoogleCredentials) -> discovery.Resource:
+def _qrm_resource(credentials: Credentials) -> discovery.Resource:
     """Build gcloud TPU v2alpha1 QueuedResource API resource.
 
     Args:
@@ -486,7 +486,7 @@ def _qrm_resource(credentials: GoogleCredentials) -> discovery.Resource:
     return resource
 
 
-def _tpu_resource(credentials: GoogleCredentials) -> discovery.Resource:
+def _tpu_resource(credentials: Credentials) -> discovery.Resource:
     """Build gcloud TPU v2alpha1 API resource.
 
     Args:

--- a/axlearn/cloud/gcp/tpu_cleaner.py
+++ b/axlearn/cloud/gcp/tpu_cleaner.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, Sequence
 
 from absl import logging
-from oauth2client.client import GoogleCredentials
+from google.auth.credentials import Credentials
 
 from axlearn.cloud.common.cleaner import Cleaner
 from axlearn.cloud.common.types import ResourceMap
@@ -70,7 +70,7 @@ class TPUCleaner(Cleaner):
         return already_terminated
 
     # pylint: disable-next=no-self-use
-    def _delete_batch(self, tpu_names: Sequence[str], *, credentials: GoogleCredentials):
+    def _delete_batch(self, tpu_names: Sequence[str], *, credentials: Credentials):
         """Deletes the TPU jobs with the given names.
 
         We handle deletes in a separate method for easier testing.
@@ -83,7 +83,7 @@ class TPUCleaner(Cleaner):
         still present and retry the delete if necessary.
         """
 
-        def _delete_tpu_async(tpu_name: str, *, credentials: GoogleCredentials):
+        def _delete_tpu_async(tpu_name: str, *, credentials: Credentials):
             try:
                 logging.info("Attempting to delete %s", tpu_name)
                 delete_tpu(tpu_name, credentials=credentials, wait=False)

--- a/axlearn/cloud/gcp/vm.py
+++ b/axlearn/cloud/gcp/vm.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence
 
 from absl import logging
+from google.auth.credentials import Credentials
 from googleapiclient import discovery, errors
-from oauth2client.client import GoogleCredentials
 
 from axlearn.cloud.common.docker import registry_from_repo
 from axlearn.cloud.common.utils import format_table
@@ -36,7 +36,7 @@ def create_vm(
     *,
     vm_type: str,
     disk_size: int,
-    credentials: GoogleCredentials,
+    credentials: Credentials,
     bundler_type: str,
     metadata: Optional[Dict[str, str]] = None,
 ):
@@ -113,7 +113,7 @@ def create_vm(
                 time.sleep(10)
 
 
-def delete_vm(name: str, *, credentials: GoogleCredentials):
+def delete_vm(name: str, *, credentials: Credentials):
     """Delete VM.
 
     Args:
@@ -163,7 +163,7 @@ class VmInfo:
     metadata: Dict[str, Any]
 
 
-def list_vm_info(credentials: GoogleCredentials) -> List[VmInfo]:
+def list_vm_info(credentials: Credentials) -> List[VmInfo]:
     """List running VMs for the given project and zone.
 
     Args:
@@ -189,7 +189,7 @@ def list_vm_info(credentials: GoogleCredentials) -> List[VmInfo]:
     return results
 
 
-def _compute_resource(credentials: GoogleCredentials) -> discovery.Resource:
+def _compute_resource(credentials: Credentials) -> discovery.Resource:
     """Build gcloud compute v1 API resource.
 
     Args:
@@ -325,7 +325,7 @@ def _get_vm_node(name: str, resource: discovery.Resource) -> Optional[Dict[str, 
     return None if not nodes else nodes.pop()
 
 
-def list_disk_images(creds: GoogleCredentials) -> List[str]:
+def list_disk_images(creds: Credentials) -> List[str]:
     """Lists available disk images in the configured `image_project`.
 
     Args:


### PR DESCRIPTION
oauth2client.client.GoogleCredentials was supposed to be replaced by google.auth.credentials.Credentials

1. Current http api wrapper should be able to take both
https://github.com/googleapis/google-api-python-client/blob/main/googleapiclient/discovery.py#L213
2. Some python sdk only accepts google.auth.credentials.Credentials

