### PR TITLE
Adds support for generics in configs.

### DIFF
--- a/axlearn/cloud/common/scheduler.py
+++ b/axlearn/cloud/common/scheduler.py
@@ -234,6 +234,7 @@ class JobVerdict:
 class Scheduler(Configurable):
     """A job scheduler."""
 
+    @config_class
     class Config(Configurable.Config):
         """Configures Scheduler."""
 

--- a/axlearn/cloud/gcp/bundler.py
+++ b/axlearn/cloud/gcp/bundler.py
@@ -70,7 +70,7 @@ class GCSTarBundler(BaseTarBundler):
     TYPE = "gcs"
 
     @classmethod
-    def default_config(cls: BaseTarBundler.Config) -> BaseTarBundler.Config:
+    def default_config(cls):
         cfg = super().default_config()
         # Read from settings by default, if available.
         if ttl_bucket := gcp_settings("ttl_bucket", required=False):
@@ -98,7 +98,7 @@ class ArtifactRegistryBundler(DockerBundler):
     TYPE = "artifactregistry"
 
     @classmethod
-    def default_config(cls: DockerBundler.Config) -> DockerBundler.Config:
+    def default_config(cls):
         cfg = super().default_config()
         cfg.repo = gcp_settings("docker_repo", required=False)
         cfg.dockerfile = gcp_settings("default_dockerfile", required=False)
@@ -120,7 +120,7 @@ class CloudBuildBundler(BaseDockerBundler):
     TYPE = "cloudbuild"
 
     @classmethod
-    def default_config(cls: BaseDockerBundler.Config) -> BaseDockerBundler.Config:
+    def default_config(cls):
         cfg = super().default_config()
         cfg.repo = gcp_settings("docker_repo", required=False)
         cfg.dockerfile = gcp_settings("default_dockerfile", required=False)

--- a/axlearn/common/causal_lm.py
+++ b/axlearn/common/causal_lm.py
@@ -339,7 +339,7 @@ def gpt_decoder_config(
     """
     stack_cfg = stack_cfg.clone()
 
-    assert stack_cfg.cls in [
+    assert stack_cfg.klass in [
         StackedTransformerLayer,
         RepeatedTransformerLayer,
         PipelinedTransformerLayer,

--- a/axlearn/common/config_test.py
+++ b/axlearn/common/config_test.py
@@ -79,7 +79,7 @@ class ConfigTest(absltest.TestCase):
         self.assertEmpty(cfg.items())
         self.assertNotIn("num_layers", cfg)
         self.assertEqual(
-            "<class 'axlearn.common.config.config_class("
+            "<class 'axlearn.common.config_test.config_class("
             f"{ConfigTest.__module__}.ConfigTest.test_definition.<locals>.EmptyConfig"
             ")'>",
             str(type(cfg)),
@@ -226,7 +226,7 @@ class ConfigTest(absltest.TestCase):
     def test_value_types(self):
         @config_class
         class TestConfig(ConfigBase):
-            sub: Optional[List] = None
+            sub: Optional[Any] = None
 
         cfg = TestConfig()
         # Config field values can be a list.
@@ -393,8 +393,8 @@ class ConfigTest(absltest.TestCase):
             f"config_for_class({Layer.__module__}.{Layer.__qualname__})", type(cfg).__name__
         )
         self.assertIsInstance(cfg, config.InstantiableConfig)
-        self.assertContainsSubset({"cls", "in_features", "out_features", "bias"}, cfg.keys())
-        self.assertEqual(cfg.cls, Layer)
+        self.assertContainsSubset({"klass", "in_features", "out_features", "bias"}, cfg.keys())
+        self.assertEqual(cfg.klass, Layer)
         self.assertIsInstance(cfg.in_features, config.RequiredFieldValue)
         self.assertIsInstance(cfg.out_features, config.RequiredFieldValue)
         self.assertTrue(
@@ -475,8 +475,8 @@ class ConfigTest(absltest.TestCase):
             foo: str = "hello world"
             bar: List[str] = ["a", "b", "c"]
             my_config: TestConfigA = TestConfigA()  # pytype: disable=invalid-annotation
-            config_dict: Dict[str, InstantiableConfig] = {"config_b": TestConfigB()}
-            config_list: List[InstantiableConfig] = [TestConfigB(), TestConfigB().set(count=1)]
+            config_dict: Dict[str, ConfigBase] = {"config_b": TestConfigB()}
+            config_list: List[ConfigBase] = [TestConfigB(), TestConfigB().set(count=1)]
             config_type: type = ConfigTest
             config_func: Callable = config.similar_names
 

--- a/axlearn/common/conformer.py
+++ b/axlearn/common/conformer.py
@@ -237,10 +237,10 @@ class ConformerLayer(BaseLayer):
         self._add_child("norm", cfg.norm.set(input_dim=cfg.input_dim))
 
         if cfg.rel_pos_emb:
-            if not cfg.self_attention.attention.cls == MultiheadAttention:
+            if not cfg.self_attention.attention.klass == MultiheadAttention:
                 raise ValueError(
                     "rel_pos_emb should only be set in MultiheadAttention, "
-                    f"but got {cfg.self_attention.attention.cls}."
+                    f"but got {cfg.self_attention.attention.klass}."
                 )
             pos_emb_dim = cfg.self_attention.attention.num_heads
             self._add_child("rel_pos_emb", cfg.rel_pos_emb.set(dim=pos_emb_dim))

--- a/axlearn/common/inference.py
+++ b/axlearn/common/inference.py
@@ -228,7 +228,7 @@ class InferenceRunner(Module):
             self._inference_runner_state_partition_specs = jax.tree_util.tree_map(
                 lambda spec: spec.mesh_axes, self._inference_runner_state_specs
             )
-            logging.info("Building ckpt state from %s", cfg.init_state_builder.cls.__name__)
+            logging.info("Building ckpt state from %s", cfg.init_state_builder.klass.__name__)
             builder = cfg.init_state_builder.set(
                 name="init_state_builder",
             ).instantiate(parent=None)
@@ -238,7 +238,7 @@ class InferenceRunner(Module):
                 logging.warning(
                     "init_state_builder %s expects input_state_type StateType.TENSOR "
                     "but inference runner gives StateType.TENSOR_SPECS.",
-                    cfg.init_state_builder.cls.__name__,
+                    cfg.init_state_builder.klass.__name__,
                 )
 
             # See "On compatible trainer checkpoints for `InferenceRunner`" in the file docstring.

--- a/axlearn/common/learner_test.py
+++ b/axlearn/common/learner_test.py
@@ -747,6 +747,7 @@ class CompositeLearnerTest(TestCase):
             expected_summaries,
             output_collection.summaries,
         )
+        # pytype: enable=attribute-error
 
     def test_learner_config(self):
         opt1_cfg = config_for_function(sgd_optimizer).set(

--- a/axlearn/common/poolings.py
+++ b/axlearn/common/poolings.py
@@ -69,8 +69,10 @@ class AttentionPooling(BasePoolingLayer):
     @classmethod
     def default_config(cls) -> Config:
         cfg: AttentionPooling.Config = super().default_config()
-        cfg.cross_attention.attention.num_heads = 1  # pylint: disable=no-member
-        cfg.feed_forward.hidden_dim = scaled_hidden_dim(scale=4)  # pylint: disable=no-member
+        # pylint: disable=no-member  # pytype: disable=attribute-error
+        cfg.cross_attention.attention.num_heads = 1
+        cfg.feed_forward.hidden_dim = scaled_hidden_dim(scale=4)
+        # pylint: enable=no-member  # pytype: enable=attribute-error
         return cfg
 
     def __init__(self, cfg: Config, *, parent: Optional[Module]):

--- a/axlearn/common/state_builder.py
+++ b/axlearn/common/state_builder.py
@@ -311,7 +311,7 @@ class RestoreAndConvertBuilder(Builder):
     @classmethod
     def spec_to_config(cls, spec: str) -> Config:
         cfg = cls.default_config()
-        cfg.builder = cfg.builder.cls.spec_to_config(spec)
+        cfg.builder = cfg.builder.klass.spec_to_config(spec)
         return cfg
 
     def __init__(self, cfg: Config, *, parent: Optional[Module]):

--- a/axlearn/common/vision_transformer.py
+++ b/axlearn/common/vision_transformer.py
@@ -27,6 +27,7 @@ from jax import numpy as jnp
 
 from axlearn.common import param_init
 from axlearn.common.attention import (
+    BaseStackedTransformerLayer,
     LearnedPositionalEmbedding,
     RepeatedTransformerLayer,
     StackedTransformerLayer,
@@ -170,7 +171,7 @@ class Encoder1D(BaseLayer):
         # Positional embedding config.
         pos_emb: InstantiableConfig = LearnedPositionalEmbedding.default_config()
         # The transformer layer stack config.
-        transformer: InstantiableConfig = StackedTransformerLayer.default_config()
+        transformer: BaseStackedTransformerLayer.Config = StackedTransformerLayer.default_config()
         # The normalization layer config for encoder output.
         output_norm: InstantiableConfig = layer_norm_config()
         # The DropToken layer proposed in the FLIP paper.
@@ -476,7 +477,7 @@ _NAMED_VIT_MODELS = {
 
 
 def _set_model_config(
-    cfg,
+    cfg: VisionTransformer.Config,
     *,
     num_layers: int,
     model_dim: int,
@@ -533,12 +534,15 @@ def _set_model_config(
     encoder_cfg.use_pos_emb = use_pos_emb
     if use_pos_emb:
         encoder_cfg.pos_emb.shape = (seq_len,)
+
+    # pylint: disable=attribute-error
     if feed_forward_dim is not None:
         encoder_cfg.transformer.layer.feed_forward.hidden_dim = feed_forward_dim
     encoder_cfg.transformer.layer.self_attention.attention.num_heads = num_heads
 
     if atten_logit_cap is not None:
         encoder_cfg.transformer.layer.self_attention.attention.atten_logit_cap = atten_logit_cap
+    # pylint: enable=attribute-error
 
     set_dropout_rate_recursively(cfg, dropout_rate)
     if peak_stochastic_depth_rate is not None:

--- a/axlearn/vision/coca.py
+++ b/axlearn/vision/coca.py
@@ -384,10 +384,10 @@ def set_coca_vision_encoder_config(
     image_encoder_cfg.caption_pooler = caption_pooler_config.set(
         num_outputs=caption_pooler_num_outputs
     )
-    if caption_pooler_config.cls == AttentionPooling:
+    if caption_pooler_config.klass == AttentionPooling:
         image_encoder_cfg.caption_pooler.cross_attention.attention.num_heads = num_heads
     image_encoder_cfg.contrastive_pooler = contrastive_pooler_config.set(num_outputs=1)
-    if contrastive_pooler_config.cls == AttentionPooling:
+    if contrastive_pooler_config.klass == AttentionPooling:
         image_encoder_cfg.contrastive_pooler.cross_attention.attention.num_heads = num_heads
     image_encoder_cfg.pooler_mode = pooler_mode
     # Set up the Transformer.

--- a/axlearn/vision/resnet.py
+++ b/axlearn/vision/resnet.py
@@ -538,7 +538,7 @@ class ResNet(BaseLayer):
 
         # The ResNet block layers.
         self._endpoints_dims = {}
-        use_bottleneck = cfg.stage.block.cls == Bottleneck
+        use_bottleneck = cfg.stage.block.klass == Bottleneck
         for stage_i, num_blocks in enumerate(cfg.num_blocks_per_stage):
             if use_bottleneck:
                 output_dim = hidden_dim * 4 if stage_i == 0 else hidden_dim * 2


### PR DESCRIPTION
In particular, this enables the following use-cases:

<details>
<summary>InstantiableConfig</summary>

```
def fn(x: InstantiableConfig[int]):  # Before: type is not subscriptable.
    x.instantiate()  # After: Type hint shows `int`.
```
</details>

<details>
<summary>config_for_function</summary>

```
def fn(*, x, y) -> int:
    return x + y

cfg = config_for_function(fn)  # Before: ConfigBase, After: FunctionConfigBase[int].
cfg.set(x=1, y=2)
cfg.instantiate()  # Before: Any, After: int.
```
</details>

<details>
<summary>config_for_class</summary>

```
class Test:
    def __init__(self, a):
        self.test = a

cfg = config_for_class(Test)  # Before: ConfigBase, After: ClassConfigBase[Test].
cfg1.set(a=1)
x = cfg1.instantiate()  # Before: Any, After: Test.
```
</details>

<details>
<summary>Configurable</summary>

```
class Test(Configurable):

    @config_class
    class Config(Configurable.Config):
        a: int = 1

cfg = Test.default_config()  # Before: ConfigBase, After: Config[Test].
cfg.a = 1
y = cfg.instantiate()  # Before: Any, After: Test.
```
</details>