### PR TITLE
Remove FrozenDict.

### DIFF
--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -11,7 +11,6 @@ import tempfile
 import threading
 from typing import Iterable, List, Sequence
 
-import flax.core
 import jax
 import pytest
 import tensorflow as tf
@@ -176,7 +175,7 @@ class CheckpointerTest(test_utils.TestCase):
                 )
             ckpt.stop()
 
-    @parameterized.parameters(utils.VDict, flax.core.FrozenDict)
+    @parameterized.parameters((utils.VDict,))
     def test_custom_dict(self, custom_dict_type):
         mesh_shape = (1, 1)
         if not test_utils.is_supported_mesh_shape(mesh_shape):

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -34,7 +34,6 @@ import jax
 import numpy as np
 from absl import logging
 from flax import serialization
-from flax.core import FrozenDict
 from jax import numpy as jnp
 from jax.experimental import maps, multihost_utils, pjit
 from jax.sharding import PartitionSpec
@@ -46,7 +45,7 @@ Tensor = jax.Array
 # Recursive type annotations not supported by pytype yet.
 NestedTree = Union[Any, Dict[str, Any]]  # Union[Any, Dict[str, "NestedTree"]]
 # Union[..., Dict[str, "NestedTensor"]]
-NestedTensor = Union[Tensor, Dict[str, Any], FrozenDict[str, Any]]
+NestedTensor = Union[Tensor, Dict[str, Any]]
 # NestedPartitionSpec = Optional[Union[PartitionSpec, Dict[str, "NestedPartitionSpec"]]]
 NestedPartitionSpec = Optional[Union[PartitionSpec, Dict[str, Any]]]
 
@@ -374,7 +373,7 @@ def complete_partition_spec_tree(
             return type(tree)(*[replace_none_with_proxy(x) for x in tree])
         if isinstance(tree, (tuple, list)):
             return type(tree)([replace_none_with_proxy(x) for x in tree])
-        if isinstance(tree, (dict, FrozenDict)):
+        if isinstance(tree, dict):
             return type(tree)([(k, replace_none_with_proxy(v)) for k, v in tree.items()])
         raise ValueError(f"{type(tree)}: {tree}")
 

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -14,7 +14,6 @@ import tensorflow as tf
 import torch
 from absl.testing import absltest, parameterized
 from flax import serialization
-from flax.core import FrozenDict
 from jax import numpy as jnp
 from jax.experimental import checkify, mesh_utils
 from jax.sharding import PartitionSpec
@@ -136,8 +135,6 @@ class TreeUtilsTest(TestCase):
         d2 = OrderedDict(reversed(kv))
         self.assertEqual([("a", 1), ("b", 2)], sorted(flatten_items(d1)))
         self.assertEqual([("a", 1), ("b", 2)], sorted(flatten_items(d2)))
-        frozen_dict = {"a": FrozenDict({"b": {"c": 1}})}
-        self.assertEqual([("a/b/c", 1)], flatten_items(frozen_dict))
 
     def assertTensorEqual(self, a, b):
         self.assertIsInstance(a, jnp.ndarray)

--- a/axlearn/huggingface/hf_module.py
+++ b/axlearn/huggingface/hf_module.py
@@ -11,7 +11,6 @@ import jax.numpy as jnp
 import jax.random
 import tensorflow as tf
 from absl import logging
-from flax.core.frozen_dict import freeze, unfreeze
 from transformers.configuration_utils import PretrainedConfig
 from transformers.modeling_flax_utils import FlaxPreTrainedModel
 
@@ -179,7 +178,7 @@ class HfModuleWrapper(BaseModel, ABC):
             hf_model = cfg.hf_model_type.from_pretrained(
                 local_pretrained_model_path, from_pt=cfg.from_pt
             )
-            hf_module_params = unfreeze(params[HF_MODULE_KEY])
+            hf_module_params = params[HF_MODULE_KEY]
             hf_module_params["params"] = {
                 key: (
                     value
@@ -188,7 +187,7 @@ class HfModuleWrapper(BaseModel, ABC):
                 )
                 for key, value in hf_model.params.items()
             }
-            params[HF_MODULE_KEY] = freeze(hf_module_params)
+            params[HF_MODULE_KEY] = hf_module_params
         return params
 
     def _dummy_input_kwargs(self) -> Dict[str, Optional[Tensor]]:  # pylint: disable=no-self-use


### PR DESCRIPTION
Flax is no longer returning `FrozenDict` by default: https://github.com/google/flax/blob/4879b4c0fc324bdf1aafa076843548ceec0d07fe/flax/configurations.py#L120. More details at https://github.com/google/flax/issues/1223.

We do not need to work with `FrozenDict` anymore. `FrozenDict` seems to be causing problems in https://github.com/apple/axlearn/blob/0f6ae2b0e8c0ddd0d196b014ce5adb86e62d5718/axlearn/common/utils.py#L343-L345 too - when `treedef` has `FrozenDict` but `partition_spec_tree` does not `complete_partition_spec_tree` would fail.