### PR TITLE
Adds Module.vprint, which uses jax.debug.print to print tensor contents

### DIFF
--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -45,7 +45,7 @@ def _checkpointer_config():
     return Checkpointer.default_config().set(name="test", dir=tempfile.mkdtemp())
 
 
-class CheckpointerTest(test_utils.TestCase):
+class CheckpointerTest(test_utils.TestWithTemporaryCWD):
     def test_save_and_restore(self):
         mesh_shape = (1, 1)
         if not test_utils.is_supported_mesh_shape(mesh_shape):

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -45,7 +45,7 @@ def _checkpointer_config():
     return Checkpointer.default_config().set(name="test", dir=tempfile.mkdtemp())
 
 
-class CheckpointerTest(test_utils.TestWithTemporaryCWD):
+class CheckpointerTest(test_utils.TestCase):
     def test_save_and_restore(self):
         mesh_shape = (1, 1)
         if not test_utils.is_supported_mesh_shape(mesh_shape):

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -39,8 +39,10 @@ import copy
 import dataclasses
 import hashlib
 import inspect
+import os.path
 import re
 import threading
+import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple, TypeVar, Union
 
@@ -476,6 +478,15 @@ class Module(Configurable):
     def vlog(self, level, msg, *args, **kwargs):
         if level <= self._vlog_level:
             logging.info(f"@{self.path()} {msg}", *args, **kwargs)
+
+    def vprint(self, level, msg, *args, **kwargs):
+        if level <= self._vlog_level:
+            ts = time.strftime("%m%d %T", time.gmtime(time.time()))
+            caller_frame = inspect.stack()[1]  # Get the frame of the caller (index 1)
+            filename = caller_frame.filename
+            line_number = caller_frame.lineno
+            fmt = f"{ts} {os.path.basename(filename)}:{line_number}] @{self.path()} " + msg
+            jax.debug.print(fmt, *args, **kwargs)
 
     def _add_child(
         self,

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -480,13 +480,24 @@ class Module(Configurable):
             logging.info(f"@{self.path()} {msg}", *args, **kwargs)
 
     def vprint(self, level, msg, *args, **kwargs):
+        """Prints debug info with if level <= config.vlog.
+
+        Prints with jax.debug.print(prefix + msg, *args, **kwargs) so that it can handle tensors in
+        args and kwargs, where prefix includes information about the time and caller.
+
+        Args:
+            level: The verbosity level of the print message.
+            msg: The msg for jax.debug.print().
+            *args: The args for jax.debug.print, may contain Tensors.
+            **kwargs: The kwargs for jax.debug.print, may contain Tensors.
+        """
         if level <= self._vlog_level:
             ts = time.strftime("%m%d %T", time.gmtime(time.time()))
             caller_frame = inspect.stack()[1]  # Get the frame of the caller (index 1)
             filename = caller_frame.filename
             line_number = caller_frame.lineno
-            fmt = f"{ts} {os.path.basename(filename)}:{line_number}] @{self.path()} " + msg
-            jax.debug.print(fmt, *args, **kwargs)
+            prefix = f"{ts} {os.path.basename(filename)}:{line_number}] @{self.path()} "
+            jax.debug.print(prefix + msg, *args, **kwargs)
 
     def _add_child(
         self,

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -479,7 +479,7 @@ class Module(Configurable):
         if level <= self._vlog_level:
             logging.info(f"@{self.path()} {msg}", *args, **kwargs)
 
-    def vprint(self, level, msg, *args, **kwargs):
+    def vprint(self, level: int, msg: str, *args, **kwargs):
         """Prints debug info with if level <= config.vlog.
 
         Prints with jax.debug.print(prefix + msg, *args, **kwargs) so that it can handle tensors in
@@ -493,10 +493,10 @@ class Module(Configurable):
         """
         if level <= self._vlog_level:
             ts = time.strftime("%m%d %T", time.gmtime(time.time()))
-            caller_frame = inspect.stack()[1]  # Get the frame of the caller (index 1)
-            filename = caller_frame.filename
+            caller_frame = inspect.stack()[1]  # Get the frame of the caller (index 1).
+            filename = os.path.basename(caller_frame.filename)
             line_number = caller_frame.lineno
-            prefix = f"{ts} {os.path.basename(filename)}:{line_number}] @{self.path()} "
+            prefix = f"{ts} {filename}:{line_number}] @{self.path()} "
             jax.debug.print(prefix + msg, *args, **kwargs)
 
     def _add_child(

--- a/axlearn/common/module_test.py
+++ b/axlearn/common/module_test.py
@@ -23,6 +23,7 @@ from axlearn.common.module import (
 )
 from axlearn.common.module import functional as F
 from axlearn.common.module import install_context_stack, new_output_collection, set_current_context
+from axlearn.common.test_utils import TestWithTemporaryCWD
 
 
 class OutputCollectionTest(absltest.TestCase):
@@ -289,7 +290,7 @@ class ModuleProvidingSharedChild(Module):
             )
 
 
-class ModuleTest(absltest.TestCase):
+class ModuleTest(TestWithTemporaryCWD):
     def test_parent_children(self):
         cfg = NestedModule.default_config().set(
             name="root", child=NestedModule.default_config(), vlog=2

--- a/axlearn/common/module_test.py
+++ b/axlearn/common/module_test.py
@@ -190,7 +190,7 @@ class NestedModule(Module):
         cfg = self.config
         # It is ok to call another method of 'self' directly, if it is invoked only once in the
         # current context.
-        self.vprint(1, "input={x} cfg.child=\n{child}", x=x, child=str(self.config.child))
+        self.vprint(1, "input={x} cfg.child=\n{child}", x=x, child=str(cfg.child))
         x = self.inc(x)
         if cfg.child is not None:
             # Can also call children directly, if each child is invoked only once.

--- a/axlearn/common/module_test.py
+++ b/axlearn/common/module_test.py
@@ -190,11 +190,13 @@ class NestedModule(Module):
         cfg = self.config
         # It is ok to call another method of 'self' directly, if it is invoked only once in the
         # current context.
+        self.vprint(1, "input={x} cfg.child=\n{child}", x=x, child=str(self.config.child))
         x = self.inc(x)
         if cfg.child is not None:
             # Can also call children directly, if each child is invoked only once.
             x = self.child1(x)
             x = self.child2(x)
+        self.vprint(1, "output={x}", x=x)
         return x
 
     def invoke_grandchildren(self, x):
@@ -289,7 +291,9 @@ class ModuleProvidingSharedChild(Module):
 
 class ModuleTest(absltest.TestCase):
     def test_parent_children(self):
-        cfg = NestedModule.default_config().set(name="root", child=NestedModule.default_config())
+        cfg = NestedModule.default_config().set(
+            name="root", child=NestedModule.default_config(), vlog=2
+        )
         root: NestedModule = cfg.instantiate(parent=None)
         self.assertIsInstance(root, NestedModule)
         self.assertEqual(root.path(), "root")


### PR DESCRIPTION
… when verbosity is <= `Module.config.vlog`.

E.g.,
```
self.vprint(1, "output={x}", x=x)
```

prints something like

```
0826 21:52:23 module_test.py:199] @root output=31.0
```

Alternative considered: adding a flag to disable tracing, but `jax.debug.print` seems easier to use.
