### PR TITLE
Lists supported bundler types when reporting the unknown bundler type error

### DIFF
--- a/axlearn/cloud/common/bundler.py
+++ b/axlearn/cloud/common/bundler.py
@@ -492,7 +492,8 @@ def get_bundler_config(*, bundler_type: str, spec: List[str]) -> Bundler.Config:
     """
     if bundler_class := _bundlers.get(bundler_type, None):
         return bundler_class.from_spec(spec)
-    raise NotImplementedError(f"Unknown bundler type: {bundler_type}")
+    raise NotImplementedError(f"Unknown bundler type: {bundler_type}. "
+                              f"Supported types are {sorted(list(_bundlers.keys()))}")
 
 
 def bundler_flags():

--- a/axlearn/cloud/common/bundler.py
+++ b/axlearn/cloud/common/bundler.py
@@ -492,8 +492,10 @@ def get_bundler_config(*, bundler_type: str, spec: List[str]) -> Bundler.Config:
     """
     if bundler_class := _bundlers.get(bundler_type, None):
         return bundler_class.from_spec(spec)
-    raise NotImplementedError(f"Unknown bundler type: {bundler_type}. "
-                              f"Supported types are {sorted(list(_bundlers.keys()))}")
+    raise NotImplementedError(
+        f"Unknown bundler type: {bundler_type}. "
+        f"Supported types are {sorted(list(_bundlers.keys()))}"
+    )
 
 
 def bundler_flags():


### PR DESCRIPTION
Without this change:
```
NotImplementedError: Unknown bundler type: tar
```

With this change:
```
NotImplementedError: Unknown bundler type: tar. Supported types are ['artifactregistry', 'cloudbuild', 'docker', 'gcs']
```
