### PR TITLE
Removes timestamp information in vprint

### DIFF
--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -234,6 +234,7 @@ def write_index_file(*, ckpt_dir: str, index: Any):
 
 
 def _parse_tensor_spec(spec_dict: Dict[str, str]) -> TensorSpec:
+    # The shape string is of format `(dim...)`. [1:-1] removes the parentheses.
     shape = [int(x) for x in spec_dict["shape"][1:-1].split(",") if x]
     dtype_str = spec_dict["dtype"]
     dtype_dict = {
@@ -262,7 +263,7 @@ def read_state_spec(ckpt_dir: str) -> NestedTensorSpec:
 
     Args:
         ckpt_dir: The checkpoint directory corresponding to a specific step, e.g., the directory
-            returned by latest_checkpoint_path(checkpointer.config.dir).
+            returned by `latest_checkpoint_path(checkpointer.config.dir)`.
 
     Returns:
         A NestedTensorSpec representing the tensors stored under `ckpt_dir`. Each TensorSpec

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -492,11 +492,10 @@ class Module(Configurable):
             **kwargs: The kwargs for jax.debug.print, may contain Tensors.
         """
         if level <= self._vlog_level:
-            ts = time.strftime("%m%d %T", time.gmtime(time.time()))
             caller_frame = inspect.stack()[1]  # Get the frame of the caller (index 1).
             filename = os.path.basename(caller_frame.filename)
             line_number = caller_frame.lineno
-            prefix = f"{ts} {filename}:{line_number}] @{self.path()} "
+            prefix = f"{filename}:{line_number}] @{self.path()} "
             jax.debug.print(prefix + msg, *args, **kwargs)
 
     def _add_child(

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -42,7 +42,6 @@ import inspect
 import os.path
 import re
 import threading
-import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple, TypeVar, Union
 


### PR DESCRIPTION
... because the timestamp reflects when the python code is traced, not when the compiled program actually runs, so it can be more misleading than useful.

Also addresses review comments on read_state_spec.
