### PR TITLE
Add checkpoint policy saving at the last iteration

### DIFF
--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -544,6 +544,26 @@ def every_n_steps_policy(n: int = 1, *, min_step: int = 1) -> CheckpointPolicy:
     return fn
 
 
+def every_n_steps_and_last_policy(
+    n: int = 1, *, min_step: int = 1, max_step: int
+) -> CheckpointPolicy:
+    """Checkpoints every n steps, but not before `min_step`,
+    and at the last training iteration `max_step`.
+
+    Args:
+        n: The checkpointing frequency. Checkpointing will be triggered every `n` steps
+        min_step: The minimum step to start checkpointing.
+        max_step: The maximum number of training steps.
+            Checkpointing will be triggered at step `max_step`.
+    """
+    every_n_steps_fn = every_n_steps_policy(n=n, min_step=min_step)
+
+    def fn(*, step: int, evaler_summaries: Dict[str, Any]) -> bool:
+        return every_n_steps_fn(step=step, evaler_summaries=evaler_summaries) or step == max_step
+
+    return fn
+
+
 class Checkpointer(Module):
     """A checkpointer that supports various StateStorage implementations."""
 

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -27,6 +27,7 @@ from axlearn.common.checkpointer import (
     EvalMetric,
     TensorStoreStateStorage,
     check_state_structure,
+    every_n_steps_and_last_policy,
     every_n_steps_policy,
     latest_checkpoint_path,
     read_state_spec,
@@ -496,6 +497,15 @@ class CheckpointerTest(test_utils.TestCase):
         self.assertFalse(policy(step=2, evaler_summaries={}))
         self.assertTrue(policy(step=3, evaler_summaries={}))
         self.assertFalse(policy(step=4, evaler_summaries={}))
+
+    def test_every_n_steps_and_last_policy(self):
+        policy = every_n_steps_and_last_policy(n=5, max_step=13)
+        self.assertTrue(policy(step=5, evaler_summaries={}))
+        self.assertFalse(policy(step=9, evaler_summaries={}))
+        self.assertTrue(policy(step=10, evaler_summaries={}))
+        self.assertFalse(policy(step=11, evaler_summaries={}))
+        self.assertFalse(policy(step=12, evaler_summaries={}))
+        self.assertTrue(policy(step=13, evaler_summaries={}))
 
     def test_latest_checkpoint_path(self):
         with tempfile.TemporaryDirectory() as td:

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -19,7 +19,12 @@ from jax import numpy as jnp
 from axlearn.common import layers, learner, optimizers, param_init, test_utils, utils
 from axlearn.common.base_layer import NestedParameterSpec
 from axlearn.common.base_model import BaseModel
-from axlearn.common.checkpointer import Checkpointer, CheckpointPolicy, every_n_steps_policy
+from axlearn.common.checkpointer import (
+    Checkpointer,
+    CheckpointPolicy,
+    every_n_steps_and_last_policy,
+    every_n_steps_policy,
+)
 from axlearn.common.config import REQUIRED, Required, config_class, config_for_function
 from axlearn.common.evaler import SpmdEvaler
 from axlearn.common.evaler import every_n_steps_policy as eval_every_n_steps_policy
@@ -721,6 +726,41 @@ class TrainerTest(test_utils.TestCase):
             # `save_input_iterator` != `restore_input_iterator`, # so that users can turn on/off
             # `save_input_iterator` for models without breaking backwards compatibility.
             self.assertEqual(6, trainer2.restore_checkpoint())
+
+    def test_last_step_checkpoint_policy(self):
+        """Test checkpoint policy saving at the last step."""
+        model_cfg = DummyModel.default_config().set(dtype=jnp.float32)
+
+        cfg = SpmdTrainer.default_config().set(
+            name="test_trainer",
+            dir=tempfile.mkdtemp(),
+            mesh_axis_names=("data", "model"),
+            mesh_shape=(1, 1),
+            model=model_cfg,
+            input=DummyInput.default_config(),
+            learner=learner.Learner.default_config().set(
+                optimizer=config_for_function(optimizers.sgd_optimizer).set(
+                    learning_rate=0.1, decouple_weight_decay=True
+                ),
+            ),
+            max_step=8,
+            checkpointer=Checkpointer.default_config().set(
+                save_policy=config_for_function(every_n_steps_and_last_policy).set(
+                    n=3,
+                    max_step=8,
+                ),
+            ),
+        )
+
+        # Run trainer.
+        trainer: SpmdTrainer = cfg.instantiate(parent=None)
+        trainer.run(prng_key=jax.random.PRNGKey(123))
+
+        assert os.path.exists(os.path.join(cfg.dir, "trainer_state_tree.txt"))
+        trainer2: SpmdTrainer = cfg.instantiate(parent=None)
+        with trainer2.mesh():
+            # We should have checkpointed at the last step.
+            self.assertEqual(8, trainer2.restore_checkpoint())
 
     def test_composite_learner(self):
         """Tests composite learner with two sub learners for weight/bias respectively."""


### PR DESCRIPTION
Adds `every_n_steps_and_last_policy` that saves the checkpoint every n steps and at the configurable last iteration.
Sample use:

```
cfg.checkpointer.save_policy = config_for_function(every_n_steps_and_last_policy).set(
    max_step=max_step,
    n=steps_per_snapshot,
)
```