### PR TITLE
Adds axlearn gcp cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The AXLearn Library for Deep Learning
 
+**This library is under active development and the API is subject to change.**
+
 AXLearn is a library built on top of [JAX](https://jax.readthedocs.io/) and
 [XLA](https://www.tensorflow.org/xla) to support development of large-scale deep learning models.
 

--- a/axlearn/cli/__init__.py
+++ b/axlearn/cli/__init__.py
@@ -36,7 +36,24 @@ The executed `Command` ultimately gets processed at `absl_main`. Depending on wh
 contain a `module`, (shell) `command`, or something else. This is used to determine how to process
 the command, and can be easily extended to support additional command types.
 """
-from axlearn.cli.utils import main
+# pylint: disable=import-outside-toplevel
+from axlearn.cli.utils import main as base_main
+from axlearn.cli.utils import register_root_command_group
+
+
+def main(**kwargs):
+    # Register default command groups, depending on which extras the user has installed.
+    # Do this in __main__ to avoid registering on import.
+    try:
+        from axlearn.cli.gcp import add_cmd_group
+
+        register_root_command_group(add_cmd_group, name="gcp")
+    except (ImportError, ModuleNotFoundError):
+        # GCP extras not installed.
+        pass
+
+    base_main(**kwargs)
+
 
 if __name__ == "__main__":
     # Note: don't use `app.run(main)`, as we invoke `app.run` within `main` itself.

--- a/axlearn/cli/gcp.py
+++ b/axlearn/cli/gcp.py
@@ -1,0 +1,80 @@
+# Copyright © 2023 Apple Inc.
+
+"""AXLearn Google Cloud CLI."""
+
+import logging
+
+from axlearn.cli.utils import CommandGroup, get_path
+from axlearn.cloud.common.config import load_configs
+from axlearn.cloud.common.docker import registry_from_repo
+from axlearn.cloud.common.utils import infer_cli_name
+from axlearn.cloud.gcp.config import CONFIG_NAMESPACE
+
+
+def add_cmd_group(*, parent: CommandGroup):
+    """Adds the root GCP command group."""
+
+    gcp_cmd = CommandGroup("gcp", parent=parent)
+
+    _, gcp_configs = load_configs(CONFIG_NAMESPACE)
+    active_config = gcp_configs.get("_active", None)
+
+    if active_config is None:
+        logging.warning(
+            "No GCP project has been activated; please run `%s gcp config activate`.",
+            infer_cli_name(),
+        )
+
+    # Set common flags.
+    gcp_cmd.add_flag(
+        "--project", undefok=True, default=get_path(gcp_configs, f"{active_config}.project", None)
+    )
+    gcp_cmd.add_flag(
+        "--zone", undefok=True, default=get_path(gcp_configs, f"{active_config}.zone", None)
+    )
+
+    # Configure projects.
+    gcp_cmd.add_cmd_from_module(
+        "config", module="axlearn.cloud.gcp.config", help="Configure GCP settings"
+    )
+
+    # Interact with compute.
+    gcp_cmd.add_cmd_from_bash("sshvm", command="gcloud compute ssh", help="SSH into a VM")
+    gcp_cmd.add_cmd_from_bash(
+        "sshtpu",
+        command="gcloud alpha compute tpus tpu-vm ssh",
+        help="SSH into a TPU-VM",
+    )
+
+    # Interact with jobs.
+    gcp_cmd.add_cmd_from_module(
+        "bundle",
+        module="axlearn.cloud.gcp.bundler",
+        help="Bundle the local directory",
+    )
+    gcp_cmd.add_cmd_from_module(
+        "tpu",
+        module="axlearn.cloud.gcp.jobs.tpu_runner",
+        help="Launch arbitrary commands on TPU-VMs",
+    )
+    gcp_cmd.add_cmd_from_module(
+        "bastion",
+        module="axlearn.cloud.gcp.jobs.bastion_vm",
+        help="Launch jobs through Bastion orchestrator",
+    )
+
+    # Auth command.
+    docker_repo = get_path(gcp_configs, f"{active_config}.docker_repo", None)
+    # For the purposes of the following commands, see:
+    # https://cloud.google.com/docs/authentication/provide-credentials-adc#gcloud-credentials
+    auth_command = "gcloud auth login && gcloud auth application-default login"
+    if docker_repo:
+        # Note: we currently assume that docker_repo is a GCP one.
+        auth_command += f" && gcloud auth configure-docker {registry_from_repo(docker_repo)}"
+    gcp_cmd.add_cmd_from_bash(
+        "auth",
+        command=auth_command,
+        help="Authenticate to GCP",
+        # Match no flags -- `gcloud auth ...` doesn't support `--project`, `--zone`, etc.
+        filter_argv="a^",
+    )

--- a/axlearn/cloud/common/utils.py
+++ b/axlearn/cloud/common/utils.py
@@ -6,8 +6,9 @@ import logging as pylogging
 import os
 import shlex
 import subprocess
+import sys
 import uuid
-from typing import Dict, List, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Union
 
 import pkg_resources
 from absl import logging
@@ -223,3 +224,32 @@ def canonicalize_to_list(v: Union[str, Sequence[str]], *, delimiter: str = ",") 
     if isinstance(v, str):
         v = [elem.strip() for elem in v.split(delimiter)]
     return list(v)
+
+
+def parse_action(
+    argv: Sequence[str], *, options: Sequence[str], default: Optional[str] = None
+) -> str:
+    """Parses action from argv, or exits with usage info.
+
+    The action is always expected to be in argv[1].
+
+    Args:
+        argv: Positional CLI arguments. Does not include --flags.
+        options: Possible actions.
+        default: Optional default action if none specified.
+
+    Returns:
+        The chosen action.
+
+    Raises:
+        SystemExit: if an invalid action (or no action and default is None) is provided.
+    """
+    assert default is None or default in options
+    action = argv[1] if len(argv) >= 2 else default
+    if action is None or action not in options:
+        print(
+            f"Invalid action: {action}. Expected one of [{','.join(options)}]. "
+            "Please rerun with --help."
+        )
+        sys.exit(1)
+    return action

--- a/axlearn/cloud/common/utils_test.py
+++ b/axlearn/cloud/common/utils_test.py
@@ -73,3 +73,19 @@ class UtilsTest(parameterized.TestCase):
             "\n"
         )
         self.assertEqual(expected, utils.format_table(headings=headings, rows=rows))
+
+    @parameterized.parameters(
+        dict(argv=["cli", "activate"], expected="activate"),
+        dict(argv=["cli", "cleanup"], expected="cleanup"),
+        dict(argv=["cli", "list", "something"], expected="list"),
+        # Test failure case.
+        dict(argv=[], expected=SystemExit()),
+        dict(argv=["cli", "invalid"], expected=SystemExit()),
+    )
+    def test_parse_action(self, argv, expected):
+        options = ["activate", "list", "cleanup"]
+        if isinstance(expected, BaseException):
+            with self.assertRaises(type(expected)):
+                utils.parse_action(argv, options=options)
+        else:
+            self.assertEqual(expected, utils.parse_action(argv, options=options))

--- a/axlearn/cloud/gcp/config.py
+++ b/axlearn/cloud/gcp/config.py
@@ -4,19 +4,34 @@
 
 Possible actions: [list|activate|cleanup]
 
-For `list`:
-- Lists all configured projects, as well as their labels.
-- Specify `--label <label>` to filter among projects. Multiple labels can be specified by repeating
-  the flag. The resulting projects will match all labels.
+    List:
+        - Lists all configured projects, as well as their labels.
+        - Specify `--label <label>` to filter among projects. Multiple labels can be specified by
+            repeating the flag. The resulting projects will match all labels.
 
-For `activate`:
-- Sets a project configuration to be "active". This means that all commands invoked from CLI will
-  use the given project, zone, etc. associated with the active config.
-- Specify `--label <label>` to narrow down the list of projects to consider for activation. If
-  there are multiple candidates, starts an interactive prompt for the user to select one.
+    Activate:
+        - Sets a project configuration to be "active". This means that all commands invoked from CLI
+            will use the given project, zone, etc. associated with the active config.
+        - Specify `--label <label>` to narrow down the list of projects to consider for activation.
+            If there are multiple candidates, prompts the user to select one.
 
-For `cleanup`:
-- Removes all configuration files. Will prompt for confirmation.
+    Cleanup:
+        - Removes all configuration files. Will prompt for confirmation.
+
+Examples:
+
+    # List available projects.
+    axlearn gcp config list
+
+    # List available projects by label.
+    axlearn gcp config list --label=my-label
+
+    # Activate a project by prompt.
+    axlearn gcp config activate
+
+    # Activate a project by one or more labels.
+    axlearn gcp config activate --label=my-label --label=my-other-label
+
 """
 
 import sys

--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -14,28 +14,40 @@ There are several design considerations:
     and launching the command. This makes it suitable for launching from bastion VMs, where the
     bastion VM can fail without terminating all associated jobs.
 
-NOTE: While the script is mostly pre-emptible, it is not fully idempotent. You may get unexpected
-behavior if launching the script multiple times concurrently, although under normal circumstances
-this shouldn't happen.
+Notes:
+- While the script is mostly pre-emptible, it is not fully idempotent. You may get unexpected
+    behavior if launching the script multiple times concurrently, although under normal
+    circumstances this shouldn't happen.
+- In most cases you may want to launch the TPU job via bastion (see bastion_vm), which comes with
+    queueing and scheduling. However, running this script directly can be useful for debugging.
+
+Possible actions: [start|stop|list]
+
+    Start: starts (or resumes monitoring) the TPU job.
+    Stop: stops the TPU job and tears down resources.
+    List: lists all TPUs.
 
 Examples:
 
     # Simple launch. Everything after -- is treated as the command.
-    axlearn gcp launch tpu_trainer -- python3 my_script.py
+    axlearn gcp tpu start -- python3 my_script.py
 
     # Launch with env and retries.
-    axlearn gcp launch tpu_trainer \
+    axlearn gcp tpu start \
         --max_tries=3 --env=MY_ENV=1 -- python3 my_script.py
 
     # Launch with docker.
-    PROJECT=...
-    axlearn gcp launch tpu_trainer \
-        --bundler_type=docker \
-        --bundler_spec=build_arg1=my-build-arg \
-        ...
+    axlearn gcp tpu start \
+        --bundler_type=artifactregistry \
+        --bundler_spec=repo=my-repo \
+        --bundler_spec=dockerfile=Dockerfile \
+        --bundler_spec=build_arg1=my-build-arg ...
+
+    # List running TPUs.
+    axlearn gcp tpu list
 
     # Stop and teardown the job.
-    axlearn gcp launch tpu_trainer --action=stop
+    axlearn gcp tpu stop --taskname=my-task
 
 """
 # TODO(markblee):
@@ -46,13 +58,19 @@ Examples:
 import enum
 import pathlib
 import subprocess
+import sys
 import time
 from typing import Dict, Optional
 
 from absl import app, flags, logging
 
 from axlearn.cloud.common.bundler import DockerBundler, bundler_flags, get_bundler_config
-from axlearn.cloud.common.utils import configure_logging, generate_taskname, parse_kv_flags
+from axlearn.cloud.common.utils import (
+    configure_logging,
+    generate_taskname,
+    parse_action,
+    parse_kv_flags,
+)
 from axlearn.cloud.gcp.bundler import GCSTarBundler
 from axlearn.cloud.gcp.config import gcp_settings
 from axlearn.cloud.gcp.job import TPUJob, docker_command
@@ -61,9 +79,11 @@ from axlearn.cloud.gcp.tpu import (
     _tpu_resource,
     create_tpu,
     delete_tpu,
+    format_tpu_info,
     get_queued_tpu_node,
     get_tpu_node,
     infer_tpu_workers,
+    list_tpu_info,
 )
 from axlearn.cloud.gcp.utils import common_flags, get_credentials, running_from_vm
 from axlearn.cloud.gcp.vertexai_tensorboard import (
@@ -82,7 +102,7 @@ def _private_flags():
     bundler_flags()
     flags.FLAGS.set_default("bundler_type", GCSTarBundler.TYPE)
     flags.DEFINE_string("taskname", None, "Task name.")
-    flags.DEFINE_string("tpu_type", None, "Type of TPU to start.", required=True)
+    flags.DEFINE_string("tpu_type", None, "Type of TPU to start.")
     flags.DEFINE_integer("num_slices", 1, "The number of slices of specified TPU type to start.")
     flags.DEFINE_integer("max_tries", 10, "Max attempts to launch the job.")
     flags.DEFINE_integer("retry_interval", 60, "Interval in seconds between tries.")
@@ -92,21 +112,14 @@ def _private_flags():
         None,
         "If specified, the directory to store outputs (such as logs).",
     )
-    flags.DEFINE_enum(
-        "action",
-        "start",
-        ["start", "stop"],
-        "Start: starts (or resumes monitoring) the TPU trainer.\n"
-        "Stop: stop the TPU trainer and teardown resources.\n",
-    )
 
 
-class TPUTrainerJob(TPUJob):
-    """Launches and monitors TPU training."""
+class TPURunnerJob(TPUJob):
+    """Launches and monitors a TPU job."""
 
     @config_class
     class Config(TPUJob.Config):
-        """Configures TPUTrainerJob."""
+        """Configures TPURunnerJob."""
 
         # Remote output directory. Should be a gs:// path.
         # TODO(markblee): Support other cloud storages using tf.io.
@@ -163,7 +176,7 @@ class TPUTrainerJob(TPUJob):
 
     def _wrap(self, cmd: str, *, env: Optional[Dict[str, str]] = None):
         """Wraps the command with env vars, and docker run if using docker bundler."""
-        cfg: TPUTrainerJob.Config = self.config
+        cfg: TPURunnerJob.Config = self.config
         if self._bundler.TYPE == DockerBundler.TYPE:
             cmd = docker_command(
                 cmd,
@@ -177,7 +190,7 @@ class TPUTrainerJob(TPUJob):
         return cmd.strip()
 
     def _prepare_env(self) -> Dict[str, str]:
-        """Returns env vars to use in the trainer command."""
+        """Returns env vars to use in the command."""
         logging.info("Preparing env...")
         cfg = self.config
         # Make a copy of env vars.
@@ -201,7 +214,7 @@ class TPUTrainerJob(TPUJob):
 
     def _install_bundle(self):
         """Installs the bundle on remote TPU-VM."""
-        cfg: TPUTrainerJob.Config = self.config
+        cfg: TPURunnerJob.Config = self.config
         logging.info("Installing bundle...")
         # Install the bundle.
         install_cmd = self._bundler.install_command(self._bundler.id(cfg.name))
@@ -216,7 +229,7 @@ class TPUTrainerJob(TPUJob):
 
     def _start(self):
         """Provisions TPU-VMs and installs the bundle."""
-        cfg: TPUTrainerJob.Config = self.config
+        cfg: TPURunnerJob.Config = self.config
         # If not on bastion, bundle early so the user can cd away from cwd.
         if not running_from_vm():
             self._bundler.bundle(cfg.name)
@@ -258,7 +271,7 @@ class TPUTrainerJob(TPUJob):
 
     def _run_command(self):
         """Launches the command on the TPU-VMs."""
-        cfg: TPUTrainerJob.Config = self.config
+        cfg: TPURunnerJob.Config = self.config
         # Install the bundle.
         self._install_bundle()
         # Prepare command environment variables.
@@ -280,10 +293,10 @@ class TPUTrainerJob(TPUJob):
             {cmd} 2>&1 | stdbuf -oL sed "s/^/$HOSTNAME: /" | tee -a {self._run_log};
             if [ ${{PIPESTATUS[0]}} -eq 0 ]; then
                 echo "Setting status to SUCCESS..." >> {self._run_log};
-                {self._set_status_command(TPUTrainerJob.Status.SUCCESS)};
+                {self._set_status_command(TPURunnerJob.Status.SUCCESS)};
             else
                 echo "Setting status to FAILED..." >> {self._run_log};
-                {self._set_status_command(TPUTrainerJob.Status.FAILED)};
+                {self._set_status_command(TPURunnerJob.Status.FAILED)};
             fi
             """
         logging.info("Starting remote command...")
@@ -309,7 +322,7 @@ class TPUTrainerJob(TPUJob):
             self._monitor.reset()
 
     def _delete(self):
-        cfg: TPUTrainerJob.Config = self.config
+        cfg: TPURunnerJob.Config = self.config
         logging.info("Copying outputs from %s...", self._output_dir)
         self._copy_outputs(src=f"{self._output_dir}/", dst=f"{cfg.output_dir}/output/$HOSTNAME")
         logging.info("Start deleting TPU %s...", cfg.name)
@@ -317,7 +330,7 @@ class TPUTrainerJob(TPUJob):
         logging.info("Finished deleting %s.", cfg.name)
 
     def _num_workers(self) -> int:
-        cfg: TPUTrainerJob.Config = self.config
+        cfg: TPURunnerJob.Config = self.config
         return infer_tpu_workers(cfg.tpu_type) * cfg.num_slices
 
     def _get_status(self) -> Status:
@@ -338,11 +351,11 @@ class TPUTrainerJob(TPUJob):
             node = get_tpu_node(cfg.name, _tpu_resource(credentials))
         # TODO(markblee): Also check for TPU boot status.
         if node is None:
-            return TPUTrainerJob.Status.NOT_STARTED
+            return TPURunnerJob.Status.NOT_STARTED
 
         # Probe liveness monitor.
         if self._monitor is not None and self._monitor.started() and not self._monitor.ping():
-            return TPUTrainerJob.Status.STUCK
+            return TPURunnerJob.Status.STUCK
 
         # If screen session is running, return RUNNING.
         # Otherwise, if the process' status flag is set, return the status.
@@ -350,11 +363,11 @@ class TPUTrainerJob(TPUJob):
         procs = self._execute_remote_cmd(
             f"""sudo screen -wipe;
             if sudo screen -ls {_COMMAND_SESSION_NAME}; then
-                echo {self._status_flag(TPUTrainerJob.Status.RUNNING)};
+                echo {self._status_flag(TPURunnerJob.Status.RUNNING)};
             elif [[ -f {self._status_file} ]]; then
                 cat {self._status_file};
             else
-                echo {self._status_flag(TPUTrainerJob.Status.NOT_RUNNING)};
+                echo {self._status_flag(TPURunnerJob.Status.NOT_RUNNING)};
             fi
             """,
             shell=True,
@@ -364,14 +377,14 @@ class TPUTrainerJob(TPUJob):
         )
         # Filter out statuses from each worker.
         statuses = {}
-        valid_statuses = set(status.name for status in TPUTrainerJob.Status)
+        valid_statuses = set(status.name for status in TPURunnerJob.Status)
         for proc in procs:
             if proc.returncode == 0:
                 for line in proc.stdout.split("\n"):  # pytype: disable=attribute-error
                     if line.strip().startswith("STATUS_"):
                         _, worker_id, status = line.strip().split("_", maxsplit=2)
                         if status in valid_statuses:
-                            statuses[worker_id] = TPUTrainerJob.Status[status]
+                            statuses[worker_id] = TPURunnerJob.Status[status]
             else:
                 logging.warning(
                     "Failed to get job status. stdout=%s, stderr=%s", proc.stdout, proc.stderr
@@ -380,42 +393,42 @@ class TPUTrainerJob(TPUJob):
         logging.info("Worker statuses: %s", statuses)
         status_values = set(statuses.values())
         # If any worker failed, whole job failed.
-        if TPUTrainerJob.Status.FAILED in status_values:
-            return TPUTrainerJob.Status.FAILED
+        if TPURunnerJob.Status.FAILED in status_values:
+            return TPURunnerJob.Status.FAILED
         # Otherwise, if all workers agree on status, return it.
         if len(statuses) == self._num_workers() and len(status_values) == 1:
             return list(status_values)[0]
 
         # Unable to infer status (or workers don't all agree), return UNKNOWN.
-        return TPUTrainerJob.Status.UNKNOWN
+        return TPURunnerJob.Status.UNKNOWN
 
     def _execute(self):
-        cfg: TPUTrainerJob.Config = self.config
+        cfg: TPURunnerJob.Config = self.config
 
         while True:
             status = self._get_status()
-            if status == TPUTrainerJob.Status.SUCCESS:
+            if status == TPURunnerJob.Status.SUCCESS:
                 logging.info("Job completed successfully.")
                 self._delete()
                 return
             # Command is stuck, teardown and raise so we can retry.
-            elif status == TPUTrainerJob.Status.STUCK:
+            elif status == TPURunnerJob.Status.STUCK:
                 self._delete()
                 raise ValueError("Job is stuck.")
             # Command failed, teardown and raise so we can retry.
-            elif status == TPUTrainerJob.Status.FAILED:
+            elif status == TPURunnerJob.Status.FAILED:
                 self._delete()
                 raise ValueError("Job failed.")
             # TPU-VM doesn't exist -- create it and launch the command.
-            elif status == TPUTrainerJob.Status.NOT_STARTED:
+            elif status == TPURunnerJob.Status.NOT_STARTED:
                 self._start()
                 logging.info("TPU-VMs have started.")
             # TPU-VM is ready but not running command -- start the command.
-            elif status == TPUTrainerJob.Status.NOT_RUNNING:
+            elif status == TPURunnerJob.Status.NOT_RUNNING:
                 logging.info("Job is not running. Running the command...")
                 self._run_command()
             # Running, sleep and check back in a bit.
-            elif status == TPUTrainerJob.Status.RUNNING:
+            elif status == TPURunnerJob.Status.RUNNING:
                 # Note: in the multislice scenario, there will be num_slices of each worker ID.
                 logging.info(
                     "Job is still running...\nTo view logs: gsutil ls %s/output/",
@@ -427,12 +440,27 @@ class TPUTrainerJob(TPUJob):
                 time.sleep(cfg.status_interval_seconds)
             # Job can have an unresolved status in a transitory period where workers have not all
             # completed a step. This is usually resolved by waiting.
-            elif status == TPUTrainerJob.Status.UNKNOWN:
+            elif status == TPURunnerJob.Status.UNKNOWN:
                 logging.info("Job has unknown status. Waiting to see if it resolves itself...")
                 time.sleep(cfg.status_interval_seconds)
 
 
 def main(argv):
+    action = parse_action(argv, options=["start", "stop", "list"], default="start")
+
+    if action == "list":
+        print(format_tpu_info(list_tpu_info(get_credentials())))
+        return
+
+    if not FLAGS.tpu_type:
+        print("--tpu_type is required. Please rerun with --help.")
+        sys.exit(1)
+
+    command = " ".join(argv[2:])
+    if not command:
+        print("Command is required. Please rerun with --help.")
+        sys.exit(1)
+
     taskname = FLAGS.taskname or generate_taskname()
     output_dir = FLAGS.output_dir or f"gs://{gcp_settings('ttl_bucket')}/axlearn/tasks/{taskname}"
 
@@ -449,22 +477,22 @@ def main(argv):
     if is_vertexai_tensorboard_configured():
         vertexai_tb_uploader = VertexAITensorboardUploader.default_config()
 
-    cfg = TPUTrainerJob.from_flags(FLAGS).set(
+    cfg = TPURunnerJob.from_flags(FLAGS).set(
         name=taskname,
         env_vars={**default_env, **parse_kv_flags(FLAGS.env)},
-        command=" ".join(argv[1:]),
+        command=command,
         output_dir=output_dir,
         vertexai_tb_uploader=vertexai_tb_uploader,
         bundler=get_bundler_config(bundler_type=FLAGS.bundler_type, spec=FLAGS.bundler_spec),
     )
+    job: TPURunnerJob = cfg.instantiate()
 
-    job: TPUTrainerJob = cfg.instantiate()
-    if FLAGS.action == "start":
+    if action == "start":
         job.execute()
-    elif FLAGS.action == "stop":
+    elif action == "stop":
         job._delete()  # pylint: disable=protected-access
     else:
-        raise ValueError(f"Unknown action {FLAGS.action}")
+        raise ValueError(f"Unknown action {action}")
 
 
 if __name__ == "__main__":

--- a/axlearn/cloud/gcp/vertexai_tensorboard.py
+++ b/axlearn/cloud/gcp/vertexai_tensorboard.py
@@ -28,9 +28,9 @@ def _vertexai_experiment_name_from_output_dir(output_dir: str) -> str:
 def is_vertexai_tensorboard_configured() -> bool:
     """Checks the config to see whether VertexAI Tensorboard should be enabled."""
     return bool(
-        gcp_config.gcp_settings("vertexai_tensorboard")
-        and gcp_config.gcp_settings("vertexai_region")
-        and gcp_config.gcp_settings("project")
+        gcp_config.gcp_settings("vertexai_tensorboard", required=False)
+        and gcp_config.gcp_settings("vertexai_region", required=False)
+        and gcp_config.gcp_settings("project", required=False)
     )
 
 


### PR DESCRIPTION
Adds the following commands (and scaffolding for GCP CLI):
- `axlearn gcp tpu` -- launch commands on TPU from local
- `axlearn gcp bastion` -- submit jobs to be executed by a running bastion host (e.g., queuing and scheduling jobs running `axlearn gcp tpu`)

Also simplifies the scripts to take a positional arg `action` instead of the more verbose `--action=...`.
