### PR TITLE
Supports retaining intermediate output collections across scan.

### DIFF
--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -51,7 +51,7 @@ from absl import logging
 from typing_extensions import Protocol
 
 from axlearn.common.config import REQUIRED, Configurable, Required, RequiredFieldValue, config_class
-from axlearn.common.utils import NestedTensor, Tensor, partial_with_fn_metadata
+from axlearn.common.utils import NestedTensor, Tensor, partial_with_fn_metadata, prune_tree
 
 
 def _generate_seed_from_name(name: str) -> np.int64:
@@ -753,3 +753,69 @@ def functional(
         getattr(context.output_collection, output_collection_type).clear()
 
     return method_outputs, context.output_collection
+
+
+def scan_in_context(
+    fn,
+    *,
+    carry: NestedTensor,
+    xs: NestedTensor,
+    drop_output: Optional[Callable[[str], bool]] = None,
+) -> Tuple[NestedTensor, NestedTensor]:
+    """A thin wrapper around `jax.lax.scan` which is compatible with `OutputCollection`.
+
+    In particular, summaries and outputs added by `add_summary` and `add_module_output` respectively
+    are accumulated in `current_context().output_collection`, subject to any output filtering.
+
+    Args:
+        fn: A function with args (carry, x) returning a dict(carry=..., y=...).
+        carry: The initial value of the loop carry, to be accumulated across scan.
+        xs: A dict with at least "x" as a key, where each leaf is a tensor of shape
+            [num_scan_iters, ...]. At scan iteration i:
+            - xs["x"][i, ...] represents the inputs to `fn`.
+            - xs[key][i, ...] is provided as a kwarg to the ith invocation context.
+        drop_output: A callable that takes a path and outputs a decision of whether to drop the
+            output at the given path, where True means we drop. By default, the callable is None,
+            meaning nothing is dropped.
+
+    Returns:
+        The scan outputs (carry, ys):
+            - carry: A NestedTensor with the same structure as the input `carry`, representing its
+                value at the final iteration.
+            - ys: A NestedTensor with tensor leaves T of shape [num_scan_iters, ...], with T[i, ...]
+                representing the `fn` outputs and output collection of the ith scan iteration,
+                respesctively.
+    """
+
+    ctx = current_context()
+    if ctx is None:
+        raise ValueError("Expected current_context() to not be None.")
+
+    def scan_fn(carry_i: NestedTensor, scan_i: NestedTensor):
+        output_collection_i = new_output_collection()
+        x_i = scan_i.pop("xs")
+        with child_context(
+            "iter",
+            module=ctx.module,
+            output_collection=output_collection_i,
+            **scan_i,
+        ):
+            carry_i, y_i = fn(carry_i, x_i)
+
+        # Filter output collection.
+        if drop_output is not None:
+            pruned_collection_i = new_output_collection()._asdict()
+            pruned_collection_i.update(
+                prune_tree(
+                    output_collection_i._asdict(),
+                    lambda path, _: drop_output(path),
+                )
+            )
+            output_collection_i = OutputCollection(**pruned_collection_i)
+
+        return carry_i, dict(y_i=y_i, output_collection=output_collection_i)
+
+    carry, scan_ys = jax.lax.scan(scan_fn, init=carry, xs=xs)
+    ctx.output_collection.update(scan_ys.pop("output_collection"))
+
+    return carry, scan_ys["y_i"]

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -50,6 +50,7 @@ from axlearn.common.utils import (
     get_recursively,
     input_partition_spec,
     match_regex_rules,
+    prune_tree,
     runtime_checks,
     set_data_dir,
     set_recursively,
@@ -913,6 +914,36 @@ class MatchRegexRulesTest(TestCase):
         self.assertEqual("w", match_regex_rules("not_special/weight", rules=rules))
         # Custom default value.
         self.assertEqual("d", match_regex_rules("layer/scale", rules=rules, default_value="d"))
+
+
+class PruneTreeTest(TestCase):
+    """Tests prune_tree."""
+
+    def test(self):
+        in_tree = {
+            "a": {
+                "b": {"d": "test"},
+                "c": {
+                    "b": None,
+                    "e": 123,
+                },
+            },
+            "f": 345,
+        }
+        # Prune by path.
+        self.assertEqual(
+            {"a": {"c": {"e": 123}}, "f": 345}, prune_tree(in_tree, lambda k, _: "b" in k)
+        )
+        # Prune by path with prefix/separator.
+        self.assertEqual(
+            {"a": {"c": {"b": None, "e": 123}}, "f": 345},
+            prune_tree(in_tree, lambda k, _: k == "prefix:a:b", prefix="prefix", separator=":"),
+        )
+        # Prune by value.
+        self.assertEqual(
+            {"a": {"b": {"d": "test"}, "c": {"b": None}}},
+            prune_tree(in_tree, lambda _, v: isinstance(v, int)),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Also introduces a more general `scan_in_context` helper which is compatible with output collections, and generalizes `prune_tree` to take tree paths rather than keys.