### PR TITLE
Save tf savables under multi-node setting.

### DIFF
--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -189,7 +189,7 @@ class SpmdTrainer(Module):
                 self._model_param_specs
             )
             for name, spec in utils.flatten_items(self._learner_state_partition_specs):
-                self._step_log("Learner state mesh_axes: %s=%s", name, spec)
+                self._step_log("Learner state spec: %s=%s", name, spec)
             self._trainer_state_specs = _TrainerState(
                 prng_key=ParameterSpec(dtype=jnp.uint32, shape=[4], mesh_axes=PartitionSpec(None)),
                 model=self._model_param_specs,
@@ -530,7 +530,9 @@ class SpmdTrainer(Module):
             for path, spec in utils.flatten_items(self._trainer_state_specs):
                 self.vlog(1, "restore spec: %s=%s", path, spec)
             ckpt_state_spec = self._trainer_state_specs._asdict()
-            ckpt_state_spec_with_input_iter = dict(**ckpt_state_spec, input_iter=iter(self.input))
+            ckpt_state_spec_with_input_iter = dict(
+                **ckpt_state_spec, input_iter=iter(self.input.dataset())
+            )
             restore_input_iter = cfg.save_input_iterator
             try:
                 # Try to restore with `input_iter`.

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -123,7 +123,11 @@ class DummyInput(Module):
         return ds
 
     def __iter__(self):
-        return iter(self.dataset())
+        # Use a different __iter__ than iter(self.dataset()), to test that input iter can be
+        # checkpointed properly even with a custom __iter__ (note that a custom __iter__ is not
+        # guaranteed to be savable).
+        for input_batch in self.dataset():
+            yield input_batch
 
 
 class DummyModel(BaseModel):


### PR DESCRIPTION
- Save tf savables under per-worker paths
- Fixes restoring input_iter in the case where iter is just a plain generator (in which case, we should ckpt/restore input.dataset() directly) -- and updates tests to cover this case