### PR TITLE
Makes `ConfigBase.debug_string()` omit trivial default values.

### DIFF
--- a/axlearn/common/config.py
+++ b/axlearn/common/config.py
@@ -373,10 +373,12 @@ class ConfigBase:
             field = attr.fields_dict(type(self)).get(key)
             if isinstance(field, attr.Attribute):
                 default_val = field.default
-                if omit_trivial_default_values and not default_val and default_val is val:
+                if omit_trivial_default_values and default_val is val and val in (REQUIRED, None):
                     return
             result[key] = val
 
+        # Note that we cannot use `utils.flatten_items` to handle this because the treatment of
+        # lists is different.
         self.visit(visit_fn=process_kv, enter_fn=enter)
         return result
 

--- a/axlearn/common/config.py
+++ b/axlearn/common/config.py
@@ -373,7 +373,7 @@ class ConfigBase:
             field = attr.fields_dict(type(self)).get(key)
             if isinstance(field, attr.Attribute):
                 default_val = field.default
-                if omit_trivial_default_values and not default_val and default_val == val:
+                if omit_trivial_default_values and not default_val and default_val is val:
                     return
             result[key] = val
 

--- a/axlearn/common/config.py
+++ b/axlearn/common/config.py
@@ -67,6 +67,7 @@ import inspect
 import re
 import types
 from collections import defaultdict
+from collections.abc import Container
 from typing import (
     Any,
     Callable,
@@ -75,7 +76,6 @@ from typing import (
     Iterable,
     List,
     Optional,
-    Set,
     Tuple,
     Type,
     TypeVar,
@@ -328,7 +328,7 @@ class ConfigBase:
         *,
         kv_separator: str = ": ",
         field_separator: str = "\n",
-        omit_default_values: Set[Any] = {None, REQUIRED},
+        omit_default_values: Container[Any] = (None, REQUIRED),
     ) -> str:
         """Returns a debug string for the config.
 
@@ -351,7 +351,7 @@ class ConfigBase:
 
         return field_separator.join([fmt(k, v) for k, v in flat_dict.items()])
 
-    def to_flat_dict(self, *, omit_default_values: Set[Any]) -> Dict[str, Any]:
+    def to_flat_dict(self, *, omit_default_values: Container[Any]) -> Dict[str, Any]:
         """Returns a flattened dict with path -> value mappings.
 
         Args:

--- a/axlearn/common/config.py
+++ b/axlearn/common/config.py
@@ -67,10 +67,10 @@ import inspect
 import re
 import types
 from collections import defaultdict
-from collections.abc import Container
 from typing import (
     Any,
     Callable,
+    Collection,
     Dict,
     Generic,
     Iterable,
@@ -328,7 +328,7 @@ class ConfigBase:
         *,
         kv_separator: str = ": ",
         field_separator: str = "\n",
-        omit_default_values: Container[Any] = (None, REQUIRED),
+        omit_default_values: Collection[Any] = (None, REQUIRED),
     ) -> str:
         """Returns a debug string for the config.
 
@@ -351,7 +351,7 @@ class ConfigBase:
 
         return field_separator.join([fmt(k, v) for k, v in flat_dict.items()])
 
-    def to_flat_dict(self, *, omit_default_values: Container[Any]) -> Dict[str, Any]:
+    def to_flat_dict(self, *, omit_default_values: Collection[Any]) -> Dict[str, Any]:
         """Returns a flattened dict with path -> value mappings.
 
         Args:

--- a/axlearn/common/config_test.py
+++ b/axlearn/common/config_test.py
@@ -647,7 +647,7 @@ class ConfigTest(parameterized.TestCase):
         cfg = BaseLayer.default_config()
 
         # Set the value if the key exists.
-        self.assertEqual(cfg.vlog, 0)
+        self.assertIsNone(cfg.vlog)
         maybe_set_config(cfg, "vlog", 1)
         self.assertEqual(cfg.vlog, 1)
 

--- a/axlearn/common/config_test.py
+++ b/axlearn/common/config_test.py
@@ -457,7 +457,7 @@ class ConfigTest(parameterized.TestCase):
         with self.assertRaisesRegex(ValueError, "already specified"):
             self.assertEqual(cfg.var_kwargs, cfg.instantiate(a=3))
 
-    def test_to_dict(self):
+    def test_to_dict_and_debug_string(self):
         def fn_with_args(*args):
             return list(args)
 
@@ -567,6 +567,30 @@ class ConfigTest(parameterized.TestCase):
                 # "my_config.notes": None,
             },
         )
+        self.assertEqual(
+            (
+                "bar[0]: 'a'\n"
+                "bar[1]: 'b'\n"
+                "bar[2]: 'c'\n"
+                "config_dict['config_b'].count: 5\n"
+                "config_func: 'axlearn.common.config.similar_names'\n"
+                "config_list[0].count: 5\n"
+                "config_list[1].count: 1\n"
+                "config_type: 'axlearn.common.config_test.ConfigTest'\n"
+                "foo: 'hello world'\n"
+                "my_config.extra['alpha']: 1\n"
+                "my_config.extra['beta']: 2\n"
+                "my_config.fn.args[0]: 1\n"
+                "my_config.fn.args[1]: 2\n"
+                "my_config.fn.args[2]: 3\n"
+                "my_config.fn.fn: 'axlearn.common.config_test.fn_with_args'\n"
+                "my_config.num_layers: 10\n"
+                "my_config.person['name']: 'Johnny Appleseed'\n"
+                "my_config.person['age']: 30\n"
+                "my_config.person_cls: 'axlearn.common.config_test.Person'"
+            ),
+            cfg.debug_string(),
+        )
 
     @parameterized.product(
         default_value=(REQUIRED, None, False, 0, 0.0, ""),
@@ -581,9 +605,16 @@ class ConfigTest(parameterized.TestCase):
 
         cfg = TestConfig()
         self.assertCountEqual(cfg.to_flat_dict(omit_trivial_default_values=True), {})
+        cfg.set(value=set_value)
         self.assertCountEqual(
-            cfg.clone(value=set_value).to_flat_dict(omit_trivial_default_values=True),
+            cfg.to_flat_dict(omit_trivial_default_values=True),
             {} if default_value is set_value else {"value": set_value},
+            msg=f"{default_value} vs. {set_value}",
+        )
+        # debug_string() omits trivial default values.
+        self.assertEqual(
+            cfg.debug_string(),
+            "" if default_value is set_value else f"value: {repr(set_value)}",
             msg=f"{default_value} vs. {set_value}",
         )
 

--- a/axlearn/common/config_test.py
+++ b/axlearn/common/config_test.py
@@ -474,7 +474,6 @@ class ConfigTest(parameterized.TestCase):
             fn: InstantiableConfig = config.config_for_function(fn_with_args).set(args=[1, 2, 3])
             person: Person = Person("Johnny Appleseed", 30)  # pytype: disable=invalid-annotation
             person_cls: type = Person
-            enable_x: bool = False
             notes: Optional[str] = None
 
         @config_class
@@ -535,7 +534,6 @@ class ConfigTest(parameterized.TestCase):
                 "my_config.person['age']": 30,
                 "my_config.person_cls": Person,
                 "my_config.required_int": REQUIRED,
-                "my_config.enable_x": False,
                 "my_config.notes": None,
             },
         )
@@ -561,9 +559,8 @@ class ConfigTest(parameterized.TestCase):
                 "my_config.person['name']": "Johnny Appleseed",
                 "my_config.person['age']": 30,
                 "my_config.person_cls": Person,
-                # REQUIRED/False/None are trivial default values and so are omitted.
+                # REQUIRED/None are trivial default values and so are omitted.
                 # "my_config.required_int": REQUIRED,
-                # "my_config.enable_x": False,
                 # "my_config.notes": None,
             },
         )
@@ -603,18 +600,17 @@ class ConfigTest(parameterized.TestCase):
         class TestConfig(ConfigBase):
             value: Any = default_value
 
-        cfg = TestConfig()
-        self.assertCountEqual(cfg.to_flat_dict(omit_trivial_default_values=True), {})
-        cfg.set(value=set_value)
+        cfg = TestConfig().set(value=set_value)
+        omit = default_value is set_value and default_value in (REQUIRED, None)
         self.assertCountEqual(
             cfg.to_flat_dict(omit_trivial_default_values=True),
-            {} if default_value is set_value else {"value": set_value},
+            {} if omit else {"value": set_value},
             msg=f"{default_value} vs. {set_value}",
         )
         # debug_string() omits trivial default values.
         self.assertEqual(
             cfg.debug_string(),
-            "" if default_value is set_value else f"value: {repr(set_value)}",
+            "" if omit else f"value: {repr(set_value)}",
             msg=f"{default_value} vs. {set_value}",
         )
 

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -474,10 +474,10 @@ class Module(Configurable):
     def __repr__(self):
         return f"{type(self)}@{self.path()}"
 
-    def vlog_is_on(self, level) -> bool:
+    def vlog_is_on(self, level: int) -> bool:
         return self._vlog_level is not None and level <= self._vlog_level
 
-    def vlog(self, level, msg, *args, **kwargs):
+    def vlog(self, level: int, msg: str, *args, **kwargs):
         if self.vlog_is_on(level):
             logging.info(f"@{self.path()} {msg}", *args, **kwargs)
 

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -389,11 +389,11 @@ class Module(Configurable):
         """Module config.
 
         name: name of this module.
-        vlog: the maximum vlog level.
+        vlog: the maximum vlog level. If None, vlog is disabled.
         """
 
         name: Required[str] = REQUIRED
-        vlog: int = 0
+        vlog: Optional[int] = None
 
     def __init__(self, cfg: Config, *, parent: Optional["Module"]):
         super().__init__(cfg)
@@ -403,7 +403,7 @@ class Module(Configurable):
         self._children: Dict[str, "Module"] = {}
         # Mapping from descendant module name to relative path from current module.
         self._paths_to_shared_modules: Dict[str, List[str]] = {}
-        self._vlog_level = cfg.vlog
+        self._vlog_level = 0 if cfg.vlog is None else cfg.vlog
         # TODO(markblee): Consider using a metaclass.
         for method_name, method_fn in self._methods_to_wrap_for_auto_child_context().items():
             # method_fn is not bound to any instance.


### PR DESCRIPTION
Makes ConfigBase.debug_string() call ConfigBase.to_flat_dict(), which calls itself recursively.

Adds omit_default_values to `to_flat_dict()` and `debug_string()`. A field will be omitted from the output if its value remains the default value of the field *and* the default value is a member of `omit_default_values`.