### PR TITLE
pin flax to lower version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "attrs>=21.3.0",
     "absl-py",
     "chex>=0.1.6",
-    "flax>=0.7.1",  # only for checkpoints
+    "flax==0.7.1",  # only for checkpoints. Will require python 3.9 on 0.7.3.
     "importlab==0.7",  # breaks pytype on 0.8
     "jax==0.4.13",
     "jaxlib==0.4.13",
@@ -42,7 +42,7 @@ apple-silicon = [
     "attrs>=21.3.0",
     "absl-py",
     "chex>=0.1.6",
-    "flax>=0.7.1",  # only for checkpoints
+    "flax==0.7.1",  # only for checkpoints. Will require python 3.9 on 0.7.3.
     "jax==0.4.13",
     "jaxlib==0.4.13",
     "nltk==3.7",  # for text preprocessing


### PR DESCRIPTION
flax 0.7.3 will require python 3.9. So we either pin flax to 0.7.1 (or 0.7.2) , or we drop python 3.8 support and move to 3.9.

The change on flax side:
https://github.com/google/flax/commit/836e0e439bc3dc6f9fe91446a1e50bc3efe89e70
I believe that `type[M] `will require https://peps.python.org/pep-0585/ , which was added in python 3.9
