### PR TITLE
Adds a generic launch job.

### DIFF
--- a/axlearn/cli/gcp.py
+++ b/axlearn/cli/gcp.py
@@ -53,6 +53,11 @@ def add_cmd_group(*, parent: CommandGroup):
         help="Bundle the local directory",
     )
     gcp_cmd.add_cmd_from_module(
+        "launch",
+        module="axlearn.cloud.gcp.jobs.launch",
+        help="Launch arbitrary commands on remote compute",
+    )
+    gcp_cmd.add_cmd_from_module(
         "tpu",
         module="axlearn.cloud.gcp.jobs.tpu_runner",
         help="Launch arbitrary commands on TPU-VMs",

--- a/axlearn/cloud/common/bundler.py
+++ b/axlearn/cloud/common/bundler.py
@@ -498,24 +498,22 @@ def get_bundler_config(*, bundler_type: str, spec: List[str]) -> Bundler.Config:
     )
 
 
-def bundler_flags():
-    """Common bundler flags."""
-    flags.DEFINE_string(
-        "bundler_type",
-        None,
-        "Bundler type.",
-        required=True,
-    )
+def bundler_flags(**kwargs):
+    """Common bundler flags. Keyword args will be forwarded to flag definitions."""
+
+    flags.DEFINE_string("bundler_type", None, "Bundler type.", required=True, **kwargs)
     flags.DEFINE_multi_string(
         "bundler_spec",
         [],
         "Bundler spec provided as key=value. "
         "Refer to each bundler's `from_spec` method docstring for details.",
+        **kwargs,
     )
     flags.DEFINE_multi_string(
         "bundler_exclude",
         BUNDLE_EXCLUDE,
         "Files/folders in root to exclude from code bundle.",
+        **kwargs,
     )
 
 

--- a/axlearn/cloud/common/config.py
+++ b/axlearn/cloud/common/config.py
@@ -43,8 +43,8 @@ def load_configs(
             file is found.
 
     Returns:
-        A tuple of (config_file, namespace_configs), where config_file can be None if no config file
-        could be found and required is False.
+        A tuple of (config_file, namespace_configs). If no config file could be found and required
+        is False, config_file will be None and namespace_configs will be an empty dict.
     """
     configs = {}
     config_file = None
@@ -259,7 +259,7 @@ def _prompt_project(project_configs: Dict[str, Any]) -> Optional[str]:
     """Prompts the user to select a project among the existing projects.
 
     Args:
-        projects: Mapping from `_project_config_key(project, zone)` to project-specific configs.
+        projects: Mapping from project key to project-specific configs.
 
     Returns:
         The selected key, or None if no project_configs or the user made an invalid choice.

--- a/axlearn/cloud/common/utils.py
+++ b/axlearn/cloud/common/utils.py
@@ -6,12 +6,11 @@ import logging as pylogging
 import os
 import shlex
 import subprocess
-import sys
 import uuid
 from typing import Dict, List, Optional, Sequence, Union
 
 import pkg_resources
-from absl import logging
+from absl import app, logging
 
 from axlearn.cloud import ROOT_MODULE_NAME
 
@@ -55,8 +54,8 @@ def handle_popen(proc: subprocess.Popen):
         )
 
 
-def generate_taskname() -> str:
-    """Generate a unique task name."""
+def generate_job_name() -> str:
+    """Generate a unique job name."""
     return f"{os.environ['USER'].replace('_', '')}-{uuid.uuid4().hex.lower()[:6]}"
 
 
@@ -231,25 +230,29 @@ def parse_action(
 ) -> str:
     """Parses action from argv, or exits with usage info.
 
-    The action is always expected to be in argv[1].
+    The action is inferred from the first positional arg in argv[1:] (where argv[0] is interpreted
+    as the CLI name).
 
     Args:
-        argv: Positional CLI arguments. Does not include --flags.
+        argv: CLI arguments, possibly including --flags.
         options: Possible actions.
-        default: Optional default action if none specified.
+        default: Optional default action if unable to infer action from argv.
 
     Returns:
         The chosen action.
 
     Raises:
-        SystemExit: if an invalid action (or no action and default is None) is provided.
+        absl.app.UsageError: if an invalid action (or no action and default is None) is provided.
     """
     assert default is None or default in options
-    action = argv[1] if len(argv) >= 2 else default
-    if action is None or action not in options:
-        print(
-            f"Invalid action: {action}. Expected one of [{','.join(options)}]. "
-            "Please rerun with --help."
-        )
-        sys.exit(1)
+    action = None
+    for arg in argv[1:]:
+        arg = arg.strip()
+        if not arg.startswith("--"):
+            action = arg
+            break
+    if action not in options:
+        action = default
+    if action is None or action not in options:  # No action nor default provided.
+        raise app.UsageError(f"Invalid action: {action}. Expected one of [{','.join(options)}].")
     return action

--- a/axlearn/cloud/common/utils_test.py
+++ b/axlearn/cloud/common/utils_test.py
@@ -8,6 +8,7 @@ import tempfile
 from typing import Dict, Sequence, Union
 from unittest import mock
 
+from absl import app
 from absl.testing import parameterized
 
 from axlearn.cloud import ROOT_MODULE
@@ -78,14 +79,18 @@ class UtilsTest(parameterized.TestCase):
         dict(argv=["cli", "activate"], expected="activate"),
         dict(argv=["cli", "cleanup"], expected="cleanup"),
         dict(argv=["cli", "list", "something"], expected="list"),
+        dict(argv=["cli", "--flag1", "activate"], expected="activate"),
+        dict(argv=["cli"], default="list", expected="list"),
+        dict(argv=["cli", "invalid"], default="list", expected="list"),
+        dict(argv=["cli", "invalid", "activate"], default="list", expected="list"),
         # Test failure case.
-        dict(argv=[], expected=SystemExit()),
-        dict(argv=["cli", "invalid"], expected=SystemExit()),
+        dict(argv=[], expected=app.UsageError("")),
+        dict(argv=["cli", "invalid"], expected=app.UsageError("")),
     )
-    def test_parse_action(self, argv, expected):
+    def test_parse_action(self, argv, expected, default=None):
         options = ["activate", "list", "cleanup"]
         if isinstance(expected, BaseException):
             with self.assertRaises(type(expected)):
-                utils.parse_action(argv, options=options)
+                utils.parse_action(argv, options=options, default=default)
         else:
-            self.assertEqual(expected, utils.parse_action(argv, options=options))
+            self.assertEqual(expected, utils.parse_action(argv, options=options, default=default))

--- a/axlearn/cloud/gcp/bundler.py
+++ b/axlearn/cloud/gcp/bundler.py
@@ -74,7 +74,7 @@ class GCSTarBundler(BaseTarBundler):
         cfg = super().default_config()
         # Read from settings by default, if available.
         if ttl_bucket := gcp_settings("ttl_bucket", required=False):
-            cfg.set(remote_dir=f"gs://{ttl_bucket}/axlearn/tasks")
+            cfg.set(remote_dir=f"gs://{ttl_bucket}/axlearn/jobs")
         return cfg
 
     @classmethod

--- a/axlearn/cloud/gcp/bundler_test.py
+++ b/axlearn/cloud/gcp/bundler_test.py
@@ -34,7 +34,7 @@ class RegistryTest(TestCase):
                 bundler_type=GCSTarBundler.TYPE,
                 spec=["external=test_external"],
             )
-            self.assertEqual(cfg.remote_dir, "gs://default_bucket/axlearn/tasks")
+            self.assertEqual(cfg.remote_dir, "gs://default_bucket/axlearn/jobs")
             self.assertEqual(cfg.external, "test_external")
 
     @parameterized.parameters(ArtifactRegistryBundler, CloudBuildBundler)

--- a/axlearn/cloud/gcp/config.py
+++ b/axlearn/cloud/gcp/config.py
@@ -68,7 +68,8 @@ def gcp_settings(
         SystemExit: If a required config could not be read, i.e. the value is None even after
         applying default (if applicable).
     """
-    config_file, configs = config.load_configs(CONFIG_NAMESPACE, required=True)
+    required = required and default is None
+    config_file, configs = config.load_configs(CONFIG_NAMESPACE, required=required)
     flag_values = _flag_values()
     project = flag_values.get("project", None)
     zone = flag_values.get("zone", None)
@@ -77,8 +78,8 @@ def gcp_settings(
     else:
         # Try to infer from active config.
         config_name = configs.get("_active", None)
-    project_configs = configs.get(config_name, None)
-    if project_configs is None:
+    project_configs = configs.get(config_name, {})
+    if required and not project_configs:
         # TODO(markblee): Link to docs once available.
         logging.error(
             "Unknown settings for project=%s and zone=%s; "

--- a/axlearn/cloud/gcp/config_test.py
+++ b/axlearn/cloud/gcp/config_test.py
@@ -31,12 +31,23 @@ class ConfigTest(absltest.TestCase):
             with self.assertRaises(SystemExit):
                 gcp_config.gcp_settings("project")
 
+            # Should not fail if not required.
+            self.assertIsNone(gcp_config.gcp_settings("project", required=False))
+
+            # Should not fail if a default exists.
+            self.assertEqual(
+                "default", gcp_config.gcp_settings("project", required=True, default="default")
+            )
+
             # Create a default config, which should get picked up.
             default_config = create_default_config(temp_dir)
 
             # Should fail because no config for --project and --zone.
             with self.assertRaises(SystemExit):
                 gcp_config.gcp_settings("project")
+
+            # Should not fail if not required.
+            self.assertIsNone(gcp_config.gcp_settings("project", required=False))
 
             # Write some values to the config.
             config.write_configs_with_header(
@@ -47,6 +58,9 @@ class ConfigTest(absltest.TestCase):
             # Should fail because key cannot be found.
             with self.assertRaises(SystemExit):
                 gcp_config.gcp_settings("unknown_key")
+
+            # Should not fail if not required.
+            self.assertIsNone(gcp_config.gcp_settings("unknown_key", required=False))
 
             # Should succeed.
             self.assertEqual(gcp_config.gcp_settings("project"), "test")

--- a/axlearn/cloud/gcp/job_test.py
+++ b/axlearn/cloud/gcp/job_test.py
@@ -20,7 +20,7 @@ import pytest
 from absl import flags, logging
 from absl.testing import absltest
 
-from axlearn.cloud.common.utils import configure_logging, generate_taskname
+from axlearn.cloud.common.utils import configure_logging, generate_job_name
 from axlearn.cloud.gcp.bundler import GCSTarBundler
 from axlearn.cloud.gcp.config import gcp_settings
 from axlearn.cloud.gcp.job import CPUJob, TPUJob, _kill_ssh_agent, _start_ssh_agent
@@ -74,7 +74,7 @@ class TPUJobTest(TestCase):
     """Tests TPUJob."""
 
     def test_execute_from_local(self):
-        jobname = generate_taskname()
+        jobname = generate_job_name()
         atexit.register(delete_tpu, jobname, credentials=get_credentials())
         project = gcp_settings("project")
         zone = gcp_settings("zone")
@@ -126,7 +126,7 @@ class CPUJobTest(TestCase):
     """Tests CPUJob."""
 
     def test_execute_from_local(self):
-        jobname = generate_taskname()
+        jobname = generate_job_name()
         atexit.register(delete_vm, jobname, credentials=get_credentials())
         cfg = DummyBastionJob.default_config().set(
             name=jobname,

--- a/axlearn/cloud/gcp/jobs/bastion_vm_test.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm_test.py
@@ -218,18 +218,17 @@ class BastionJobTest(parameterized.TestCase):
             for m in mocks:
                 stack.enter_context(m)
 
-            cfg = BastionJob.default_config().set(
-                job_dir=tmpdir,
-                output_dir=tmpdir,
-                scheduler=JobScheduler.default_config().set(project_quota_file="test"),
-                cleaner=TPUCleaner.default_config(),
-                max_tries=1,
-            )
-            bastion = cfg.set(
-                name="test", project="test", zone="test", retry_interval=30, command=""
-            ).instantiate()
+            with mock.patch(f"{module_name}._bastion_dir", return_value=tmpdir):
+                cfg = BastionJob.default_config().set(
+                    scheduler=JobScheduler.default_config().set(project_quota_file="test"),
+                    cleaner=TPUCleaner.default_config(),
+                    max_tries=1,
+                )
+                bastion = cfg.set(
+                    name="test", project="test", zone="test", retry_interval=30, command=""
+                ).instantiate()
 
-            yield bastion
+                yield bastion
 
     @parameterized.product(
         [

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -1,0 +1,641 @@
+# Copyright © 2023 Apple Inc.
+
+"""Launch commands on Google Cloud.
+
+The launch command provides a few benefits:
+1. Provides a uniform API and entrypoint for interacting with different instance types.
+2. Provides utilities for registering custom launcher implementations.
+
+The launch flow depends on the launcher being used. Each launcher must define a "matcher" function
+that decides, for a given CLI action (e.g. 'start') and instance type (e.g. 'tpu-v4-8'), whether the
+launcher can be used. See `_LAUNCHERS` for a full list, and `LaunchTPUJob` for an example.
+
+Possible actions: [start|stop|list]
+
+    Start: submits a job to the queue.
+    Stop: stops the job or removes a job from the queue.
+    List: lists jobs and their statuses.
+
+Additional flags may be supplied based on --instance_type. Run with --help to see all flags.
+Commands are parsed from the positional arguments (so anything after a trailing `--`).
+
+Examples:
+
+    # View all launch flags for the given instance type.
+    axlearn gcp launch --instance_type=tpu-v4-8 --help
+
+    # Simple TPU launch. Internally submits `axlearn gcp tpu ...` to bastion to run, instead of
+    # running locally.
+    axlearn gcp launch --instance_type=tpu-v4-32 -- python3 my_script.py
+
+    # Launch with extra dependencies.
+    axlearn gcp launch --instance_type=tpu-v4-32 --bundler_spec=extras=dev -- python3 my_script.py
+
+    # Dry-run: prints the job config without launching.
+    axlearn gcp launch --instance_type=tpu-v4-32 --dry_run -- python3 my_script.py
+
+    # Launch with docker.
+    axlearn gcp launch --instance_type=tpu-v4-8 \
+        --bundler_type=artifactregistry
+        --bundler_spec=repo=my-repo \
+        --bundler_spec=dockerfile=Dockerfile \
+        --bundler_spec=build_arg1=my-build-arg ...
+
+"""
+# pylint: disable=redefined-outer-name,protected-access
+
+import functools
+import os
+import sys
+import tempfile
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Callable, Dict, NamedTuple, Optional, TextIO, Tuple, Type, cast
+
+import regex as re
+from absl import app, flags, logging
+
+from axlearn.cloud.common.bundler import bundler_flags, get_bundler_config
+from axlearn.cloud.common.quota import QUOTA_CONFIG_PATH, get_user_projects
+from axlearn.cloud.common.scheduler import JobMetadata
+from axlearn.cloud.common.types import ResourceMap, ResourceType
+from axlearn.cloud.common.utils import (
+    canonicalize_to_list,
+    configure_logging,
+    format_table,
+    generate_job_name,
+    infer_cli_name,
+    parse_action,
+)
+from axlearn.cloud.gcp.config import gcp_settings
+from axlearn.cloud.gcp.job import Job
+from axlearn.cloud.gcp.jobs import tpu_runner
+from axlearn.cloud.gcp.jobs.bastion_vm import Job as BastionJob
+from axlearn.cloud.gcp.jobs.bastion_vm import (
+    JobState,
+    SubmitBastionJob,
+    download_job_batch,
+    new_jobspec,
+    serialize_jobspec,
+    shared_bastion_name,
+)
+from axlearn.cloud.gcp.tpu import (
+    infer_tpu_cores,
+    infer_tpu_version,
+    infer_tpu_workers,
+    list_tpu_info,
+)
+from axlearn.cloud.gcp.utils import catch_auth, common_flags, get_credentials
+from axlearn.common.config import (
+    REQUIRED,
+    ConfigOr,
+    Required,
+    config_class,
+    config_for_function,
+    maybe_instantiate,
+    maybe_set_config,
+)
+
+FLAGS = flags.FLAGS
+
+
+class Launcher(NamedTuple):
+    """A job launcher.
+
+    Consists of:
+    * job_cls:
+        A Job class which defines, at minimum, `_execute()`, `_list()` and `_delete()` methods,
+        invoked for "start", "list", "stop" actions respectively. It can optionally define a
+        `define_flags()` classmethod, which can be used for registering launch flags. These flags
+        will automatically be printed when invoking with --help, and will automatically be provided
+        to `Job.from_flags` when instantiating the Job.
+    * matcher:
+        A callable `(action, instance_type) -> bool` (or a config instantiating thereof), used to
+        decide whether the launcher is applicable for a given action and instance type.
+    * description:
+        Human-readable description of the launcher. Printed e.g. if no launchers are matched.
+    """
+
+    # We take a class here instead of a config, since a materialized config is often not available
+    # at the time of registry. Instead, we often construct the config via `job_cls.from_flags`.
+    job_cls: Type[Job]
+    # A config is usually more print-friendly, but not strictly required.
+    matcher: ConfigOr[Callable[[str, str], bool]]
+    description: str
+
+
+class BaseBastionLaunchJob(Job):
+    """A base job definition that launches commands via bastion.
+
+    It provides functionality to submit, delete, and list bastion jobs, but is agnostic to specific
+    resource types. At minimum, subclasses should override `_resources()` to specify resources used
+    by the job, which will be used for quota management and scheduling.
+
+    See `LaunchTPUJob` as an example.
+    """
+
+    @config_class
+    class Config(Job.Config):
+        """Configures BaseBastionLaunchJob."""
+
+        # Instance type to launch.
+        instance_type: Required[str] = REQUIRED
+        # Bastion submit config.
+        bastion: Required[SubmitBastionJob.Config] = REQUIRED
+        # User ID for bastion quota and scheduling.
+        user_id: Required[str] = REQUIRED
+        # Project ID for bastion quota and scheduling.
+        project_id: Required[str] = REQUIRED
+
+    @classmethod
+    def define_flags(cls, fv: flags.FlagValues):
+        """Defines launch flags on the provided flag_values."""
+        # We specify allow_override=True so that subclasses may redefine common flags without
+        # conflict.
+        common_kwargs = dict(flag_values=fv, allow_override=True)
+        common_flags(**common_kwargs)
+        bundler_flags(**common_kwargs)
+        # TODO(markblee): Support configuring an identity provider for --user_id.
+        flags.DEFINE_string("name", generate_job_name(), "Job name.", **common_kwargs)
+        flags.DEFINE_string(
+            "bastion", shared_bastion_name(), "Name of bastion VM to use.", **common_kwargs
+        )
+        flags.DEFINE_string(
+            "user_id",
+            os.getenv("USER"),
+            "User ID to use for resource attribution.",
+            **common_kwargs,
+        )
+        flags.DEFINE_string(
+            "project_id",
+            None,
+            "Quota project ID to use for scheduling.",
+            **common_kwargs,
+        )
+
+    @classmethod
+    def from_flags(cls, fv: flags.FlagValues, **kwargs) -> Config:
+        """Constructs config from flags defined by `define_flags()`.
+
+        Args:
+            fv: Flag values (e.g., FLAGS).
+            kwargs: Optional key/values to set on the config.
+
+        Returns:
+            The job config.
+        """
+        cfg = super().from_flags(fv, **kwargs)
+        # Construct bundler config.
+        cfg.bundler = get_bundler_config(bundler_type=fv.bundler_type, spec=fv.bundler_spec)
+        # Construct bastion/job config, excluding any output_dir or job_dir flag.
+        cfg.bastion = SubmitBastionJob.from_flags(fv, name=fv.bastion, job_name=cfg.name).set(
+            job_spec_file=""
+        )
+        return cfg
+
+    def _delete(self):
+        """Submits a delete request to bastion."""
+        bastion: SubmitBastionJob = self.config.bastion.instantiate()
+        bastion._delete()
+
+    def _list(self, output_file: Optional[TextIO] = None) -> Dict[str, Any]:
+        """Lists running jobs and optionally prints them in tabular format.
+
+        Args:
+            output_file: Output file. If None, prints to stdout, otherwise writes to the file.
+                Subclasses can send outputs to /dev/null if they intend to reformat the output.
+
+        Returns:
+            A dict containing:
+            * jobs: A list of all bastion-managed jobs sorted by name.
+            * usage_by_user: A dict mapping user_id to (total usage, number of jobs), sorted
+                descending by total usage.
+            * usage_by_project: A dict mapping project_id to (total usage, number of jobs), sorted
+                descending by total usage.
+        """
+        cfg = self.config
+        bastion: SubmitBastionJob = cfg.bastion.instantiate()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = bastion._output_dir()
+            jobs = download_job_batch(
+                spec_dir=f"{base_dir}/jobs/active",
+                state_dir=f"{base_dir}/jobs/states",
+                user_state_dir=f"{base_dir}/jobs/user_states",
+                local_spec_dir=tmpdir,
+            )
+            jobs: Dict[str, BastionJob] = dict(sorted(jobs.items(), key=lambda kv: kv[0]))
+
+            # Maps user_id -> resource_type -> (total_usage, count).
+            usage_by_user = defaultdict(lambda: defaultdict(lambda: [0, 0]))
+            usage_by_project = defaultdict(lambda: defaultdict(lambda: [0, 0]))
+            for job in jobs.values():
+                if job.state == JobState.PENDING:
+                    continue
+                user_id = job.spec.metadata.user_id
+                project_id = job.spec.metadata.project_id
+                resources = job.spec.metadata.resources
+                for resource_type, usage in resources.items():
+                    usage_by_user[user_id][resource_type][0] += usage
+                    usage_by_user[user_id][resource_type][1] += 1
+                    usage_by_project[project_id][resource_type][0] += usage
+                    usage_by_project[project_id][resource_type][1] += 1
+
+            print(format_table(**self._jobs_table(jobs)), file=output_file)
+            print(format_table(**self._usage_table(usage_by_project)), file=output_file)
+            print(format_table(**self._usage_table(usage_by_user)), file=output_file)
+            return dict(
+                jobs=jobs,
+                usage_by_user=usage_by_user,
+                usage_by_project=usage_by_project,
+            )
+
+    def _resources(self) -> ResourceMap:
+        """Infers resources from instance_type. Can be overridden by subclasses.
+
+        Should return a ResourceMap, where keys are resource types and values are resource amounts.
+        """
+        return {}
+
+    def _execute(self):
+        """Submits the command to bastion."""
+        cfg = self.config
+
+        # Check for group membership if --project_id is provided.
+        # TODO(markblee): Make this check at the bastion level.
+        if cfg.project_id:
+            quota_file = (
+                f"gs://{gcp_settings('private_bucket')}/{cfg.bastion.name}/{QUOTA_CONFIG_PATH}"
+            )
+            user_projects = get_user_projects(quota_file, user_id=cfg.user_id)
+            if cfg.project_id.lower() not in user_projects:
+                raise ValueError(
+                    f"User '{cfg.user_id}' is not a member of the project '{cfg.project_id}'. "
+                    f"Instead, user '{cfg.user_id}' is a member of: {user_projects}"
+                )
+        if cfg.bundler:
+            self._bundler.bundle(cfg.name)
+        logging.info("Starting run for job name %s", cfg.name)
+        with tempfile.NamedTemporaryFile("w") as f:
+            logging.info("Command: %s", cfg.command)
+            metadata = JobMetadata(
+                user_id=cfg.user_id,
+                project_id=cfg.project_id or "none",
+                creation_time=datetime.now(),
+                resources=self._resources(),
+            )
+            serialize_jobspec(new_jobspec(name=cfg.name, command=cfg.command, metadata=metadata), f)
+            bastion: SubmitBastionJob = cfg.bastion.set(job_spec_file=f.name).instantiate()
+            bastion._execute()
+        print(
+            f"\nStop/cancel the job with:\n"
+            f"{infer_cli_name()} gcp launch stop --name={cfg.name} --bastion={cfg.bastion.name}"
+        )
+
+    def _jobs_table(self, jobs: Dict[str, BastionJob]) -> Dict:
+        """Construct tabular jobs info.
+
+        Args:
+            jobs: A mapping from job name to job info.
+
+        Returns:
+            A table which can be passed to `format_table`.
+        """
+        return dict(
+            headings=["NAME", "USER_ID", "JOB_STATE", "PROJECT_ID", "RESOURCES", "PRIORITY"],
+            rows=[
+                [
+                    job.spec.name,
+                    job.spec.metadata.user_id,
+                    job.state,
+                    job.spec.metadata.project_id,
+                    str(job.spec.metadata.resources),
+                    str(job.spec.metadata.priority),
+                ]
+                for job in jobs.values()
+            ],
+        )
+
+    def _usage_table(self, usage_info: Dict[str, Dict[ResourceType, Tuple[float, int]]]):
+        """Construct tabular usage info.
+
+        Args:
+            usage_info: A mapping from principal to resource type to
+                (total usage, total number of jobs).
+
+        Returns:
+            A table which can be passed to `format_table`.
+        """
+        table = dict(
+            headings=["PRINCIPAL", "RESOURCE", "USAGE", "COUNT"],
+            rows=[
+                [
+                    principal or "unknown",
+                    resource_type,
+                    usage[0],
+                    usage[1],
+                ]
+                for principal, resource_usage in usage_info.items()
+                for resource_type, usage in resource_usage.items()
+            ],
+        )
+        # Sort by usage descending.
+        table["rows"] = sorted(table["rows"], key=lambda v: (v[1], v[2]), reverse=True)
+        return table
+
+
+# TODO(markblee): Add a LaunchCPUJob.
+class LaunchTPUJob(BaseBastionLaunchJob):
+    """Launches a TPU job via bastion."""
+
+    @config_class
+    class Config(BaseBastionLaunchJob.Config):
+        """Configures LaunchTPUJob."""
+
+        # Number of TPU slices.
+        num_slices: int = 1
+        # Output directory for job logs.
+        output_dir: Optional[str] = None
+
+    @classmethod
+    def define_flags(cls, fv: flags.FlagValues):
+        """Defines launch flags using tpu_runner."""
+        super().define_flags(fv)
+        tpu_runner.launch_flags(flag_values=fv)
+        fv.set_default("name", generate_job_name())
+        fv.set_default("tpu_type", cls._tpu_type(fv.instance_type))
+        fv["tpu_type"].help += " (Note: inherited from --instance_type)."
+
+    @classmethod
+    def from_flags(cls, fv: flags.FlagValues, *, command: str, **kwargs) -> Config:
+        """Constructs config from flags defined by `define_flags()`.
+
+        In addition to logic defined in `BaseBastionLaunchJob.from_flags()`:
+        * Ensures "tpu" extras are bundled.
+        * Automatically includes flags used by tpu_runner as part of the command.
+
+        Args:
+            fv: Flag values (e.g., FLAGS).
+            command: The user-supplied command, i.e. everything after `--` as a string.
+            kwargs: Optional key/values to set on the config.
+
+        Returns:
+            The job config.
+        """
+        cfg = super().from_flags(fv, **kwargs)
+
+        # Construct bundler config.
+        # Ensure that TPU deps are always installed. Note: find_links is only applicable for tar
+        # bundlers. For docker bundlers, point to the TPU build target.
+        maybe_set_config(
+            cfg.bundler,
+            "find_links",
+            ["https://storage.googleapis.com/jax-releases/libtpu_releases.html"],
+        )
+        extras = canonicalize_to_list(cfg.bundler.extras)
+        extras.append("tpu")
+        cfg.bundler.set(extras=extras)
+
+        # Save flags values corresponding to our launch flags.
+        launch_fv = flags.FlagValues()
+        tpu_runner.launch_flags(flag_values=launch_fv)
+
+        # Convert the user-supplied flags into a space-separated string, which is forwarded to the
+        # command executed by bastion. Only flags which are used by the tpu_runner are forwarded.
+        filtered = []
+        for _, module_flags in fv.flags_by_module_dict().items():
+            for flag in module_flags:
+                if flag.name in launch_fv and flag.value is not None:
+                    # Multi-flags get serialized with newlines.
+                    filtered.extend(flag.serialize().split("\n"))
+        launch_flags = " ".join(filtered)
+        # Note: command is only used for start.
+        cfg.command = f"python3 -m {tpu_runner.__name__} start {launch_flags} -- {command}"
+
+        return cfg
+
+    @classmethod
+    def _tpu_type(cls, instance_type: str) -> str:
+        # Infers tpu type from instance type.
+        return instance_type.replace("tpu-", "")
+
+    def _list(self, output_file: Optional[TextIO] = None) -> Dict[str, Any]:
+        """Lists running jobs and their associated TPU resources.
+
+        In addition to outputs provided by `BaseBastionLaunchJob._list()`, also returns a dict with:
+        * running_tpu_infos: The currently-running TPUs.
+        * running_tpu_to_job_name: A mapping from TPU name to job name.
+        """
+        with open(os.devnull, "w", encoding="utf-8") as f:
+            list_info = super()._list(output_file=f)
+        running_tpu_infos = {
+            tpu_info.name: tpu_info for tpu_info in list_tpu_info(get_credentials())
+        }
+        running_tpu_to_job_name = {}
+
+        # Append TPU state information to the jobs table.
+        jobs_table = self._jobs_table(list_info["jobs"])
+        jobs_table["headings"].append("TPU_STATE")
+        for i, job in enumerate(list_info["jobs"].values()):
+            job = cast(BastionJob, job)
+
+            # In the multislice case, job_tpu_names come from job_name-<slice>.
+            # TODO(markblee): Don't rely on parsing flags.
+            if matches := re.search(r"--num_slices[= ](\d+)", job.spec.command):
+                num_slices = int(matches[1])
+            else:
+                num_slices = 1
+
+            if num_slices > 1:
+                job_tpu_names = [f"{job.spec.name}-{slice_idx}" for slice_idx in range(num_slices)]
+            else:
+                job_tpu_names = [job.spec.name]
+
+            # Gather unique TPU states for the given job.
+            tpu_states = set()
+            for tpu_name in job_tpu_names:
+                if tpu_name in running_tpu_infos:
+                    tpu_states.add(running_tpu_infos[tpu_name].state or "UNKNOWN")
+                    running_tpu_to_job_name[tpu_name] = job.spec.name
+                else:
+                    tpu_states.add("PENDING")
+
+            jobs_table["rows"][i].append(",".join(tpu_states))
+
+        print(format_table(**jobs_table), file=output_file)
+        print("Usage by project:", file=output_file)
+        print(format_table(**self._usage_table(list_info["usage_by_project"])), file=output_file)
+        print("Usage by user:", file=output_file)
+        print(format_table(**self._usage_table(list_info["usage_by_user"])), file=output_file)
+
+        return dict(
+            running_tpu_infos=running_tpu_infos,
+            running_tpu_to_job_name=running_tpu_to_job_name,
+            **list_info,
+        )
+
+    def _resources(self) -> ResourceMap:
+        """Defines TPU resources used by the job."""
+        cfg = self.config
+        tpu_type = self._tpu_type(cfg.instance_type)
+        return {infer_tpu_version(tpu_type): infer_tpu_cores(tpu_type) * cfg.num_slices}
+
+    def _execute(self):
+        """Submits the command to bastion.
+
+        In addition to logic defined in `BaseBastionLaunchJob._execute()`, also emits the output
+        logs for each TPU worker.
+        """
+        cfg = self.config
+        super()._execute()
+        output_dir = cfg.output_dir or f"gs://{gcp_settings('ttl_bucket')}/axlearn/jobs/{cfg.name}"
+        all_logs = "\n".join(
+            [
+                f'gsutil cat "{output_dir}/output/*-{i}/run.log"'
+                for i in range(infer_tpu_workers(self._tpu_type(cfg.instance_type)))
+            ]
+        )
+        print(
+            "\nNote that the job may take a few minutes to start. "
+            f"Once started, view TPU log outputs with:\n{all_logs}\n"
+        )
+
+
+def _match_by_regex(match_regex: Dict[str, str]):
+    """Matches action and instance type by regex.
+
+    For example:
+
+        match_regex={'start': 'pat1', 'list': 'pat2'}
+
+    ... means that the launcher will be used if action is 'start' and --instance_type regex matches
+    'pat1', or if action is 'list' and --instance_type regex matches 'pat2'. The launcher will not
+    be invoked for any other action.
+    """
+
+    def fn(action: str, instance_type: str) -> bool:
+        """Returns True iff the launcher supports the given action and instance_type."""
+        return action in match_regex and bool(re.match(match_regex[action], instance_type))
+
+    return fn
+
+
+# Launchers specified here will be tried (in the given order) when launching a given instance type.
+_LAUNCHERS = [
+    Launcher(
+        job_cls=LaunchTPUJob,
+        matcher=config_for_function(_match_by_regex).set(
+            match_regex=dict(start=r"tpu-v.+-(\d)+", list=r"tpu.*", stop=r"tpu.*"),
+        ),
+        description=(
+            "Supports launching TPU jobs. "
+            "For 'start', provide the full TPU version, e.g. --instance_type=tpu-v4-8. "
+            "For 'list' or 'stop', provide the full version or simply --instance_type=tpu."
+        ),
+    )
+]
+
+
+def _get_launcher_or_exit(*, action: str, instance_type: str) -> Launcher:
+    """Retrieves launcher by matching instance_type.
+
+    If there are multiple matches, the first one in the registry is returned.
+    """
+    # Idenfity launcher from instance type.
+    for launcher in _LAUNCHERS:
+        m = maybe_instantiate(launcher.matcher)
+        if m(action, instance_type):
+            return launcher
+
+    launchers = "\n".join(
+        [
+            f"Job: {launcher.job_cls.__name__}\n"
+            f"Description: {launcher.description}\n"
+            f"Matcher: {launcher.matcher}\n"
+            for launcher in _LAUNCHERS
+        ]
+    )
+    raise app.UsageError(
+        f"Don't know how to launch instance type '{instance_type}' for action '{action}'.\n"
+        f"The registered launchers are:\n\n{launchers}"
+    )
+
+
+@catch_auth
+def main(_):
+    if FLAGS.instance_type is None:
+        raise app.UsageError("--instance_type is required.")
+
+    action = parse_action(sys.argv, options=["start", "stop", "list"], default="start")
+    launcher = _get_launcher_or_exit(action=action, instance_type=FLAGS.instance_type)
+
+    # Parse the command from argv. Note that argv may or may not contain action, so we explicitly
+    # look for '--' and extract all args after it. Use sys.argv instead of argv from params, since
+    # the param argv has '--' stripped.
+    command = ""
+    for i, arg in enumerate(sys.argv):
+        if arg.strip() == "--":
+            command = " ".join(sys.argv[i + 1 :])
+            break
+    cfg = launcher.job_cls.from_flags(FLAGS, command=command)
+    job: BaseBastionLaunchJob = cfg.instantiate()
+    if FLAGS.dry_run:
+        print(f"Action: {action}\nJob config:\n{job.config}")
+        return
+
+    if action == "start":
+        job._execute()
+    elif action == "list":
+        job._list()
+    elif action == "stop":
+        job._delete()
+    else:
+        raise app.UsageError(f"Unsupported action {action}")
+
+
+def _private_flags():
+    """Defines all launch flags, and amends `app.usage` with additional launch help info."""
+
+    flags.DEFINE_string("instance_type", None, "Instance type to launch.")
+    flags.DEFINE_bool("dry_run", False, "Output job config and exit without running.")
+    FLAGS(sys.argv, known_only=True)
+
+    launch_help = None
+    # Allow instance_type to be None when running --help without any flags. On the other hand, if
+    # instance_type is provided when running --help, we show additional help info.
+    if FLAGS.instance_type:
+        action = parse_action(sys.argv, options=["start", "stop", "list"], default="start")
+        launcher = _get_launcher_or_exit(action=action, instance_type=FLAGS.instance_type)
+        orig_flags = FLAGS.flag_values_dict()
+        if hasattr(launcher.job_cls, "define_flags"):
+            launcher.job_cls.define_flags(FLAGS)
+        output_lines = []
+        FLAGS._render_flag_list(
+            [FLAGS[name] for name in FLAGS if name not in orig_flags], output_lines
+        )
+        launch_help = "\n".join(output_lines)
+
+    app.usage = functools.partial(_wrapped_usage, usage=app.usage, launch_help=launch_help)
+
+
+def _wrapped_usage(
+    *,
+    usage: Callable,
+    launch_help: Optional[str],
+    writeto_stdout: bool = False,
+    **kwargs,
+):
+    """Wraps original usage by printing additional launch-specific help."""
+    usage(writeto_stdout=writeto_stdout, **kwargs)
+    of = sys.stdout if writeto_stdout else sys.stderr
+    if launch_help:
+        of.write(
+            f"\nFlags for the provided --instance_type={FLAGS.instance_type}:\n{launch_help}\n"
+        )
+    else:
+        of.write("\nPass --instance_type to see additional flags.\n")
+
+
+if __name__ == "__main__":
+    configure_logging(logging.INFO)
+    _private_flags()
+    app.run(main)

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -1,0 +1,286 @@
+# Copyright © 2023 Apple Inc.
+
+"""Tests launchers."""
+# pylint: disable=protected-access
+
+from datetime import datetime
+from unittest import mock
+
+from absl import app, flags
+from absl.testing import parameterized
+
+from axlearn.cloud.common.job import Job
+from axlearn.cloud.common.scheduler import JobMetadata
+from axlearn.cloud.gcp.jobs import launch
+from axlearn.cloud.gcp.jobs.bastion_vm import Job as BastionJob
+from axlearn.cloud.gcp.jobs.bastion_vm import JobState as BastionJobState
+from axlearn.cloud.gcp.jobs.bastion_vm import deserialize_jobspec, new_jobspec
+from axlearn.cloud.gcp.jobs.launch import (
+    BaseBastionLaunchJob,
+    Launcher,
+    LaunchTPUJob,
+    _get_launcher_or_exit,
+    _match_by_regex,
+)
+from axlearn.common.config import config_for_function
+from axlearn.common.test_utils import TestWithTemporaryCWD
+
+
+class TestUtils(parameterized.TestCase):
+    """Tests util functions."""
+
+    @parameterized.parameters(
+        # Matches any "start" command.
+        dict(
+            matcher=_match_by_regex(match_regex=dict(start=".*")),
+            cases=[
+                dict(action="start", instance_type="", expected=True),
+                dict(action="start", instance_type="test type", expected=True),
+                # Missing matcher for list.
+                dict(action="list", instance_type="", expected=False),
+            ],
+        ),
+        # Matches TPU types.
+        dict(
+            matcher=_match_by_regex(match_regex=dict(start=r"v(\d)+.*-(\d)+", list="tpu")),
+            cases=[
+                dict(action="start", instance_type="v4-8", expected=True),
+                dict(action="start", instance_type="v5litepod-16", expected=True),
+                dict(action="start", instance_type="tpu", expected=False),
+                dict(action="list", instance_type="tpu", expected=True),
+            ],
+        ),
+    )
+    def test_match_by_regex(self, matcher, cases):
+        for case in cases:
+            self.assertEqual(case["expected"], matcher(case["action"], case["instance_type"]))
+
+    def test_get_launcher_or_exit(self):
+        def match_tpu(action, instance_type):
+            del action
+            return instance_type == "tpu"
+
+        class DummyTPULauncher(Job):
+            pass
+
+        mock_launchers = [
+            Launcher(job_cls=DummyTPULauncher, matcher=match_tpu, description="test"),
+        ]
+        with mock.patch(f"{launch.__name__}._LAUNCHERS", mock_launchers):
+            launcher = _get_launcher_or_exit(action="start", instance_type="tpu")
+            self.assertEqual(launcher.job_cls, DummyTPULauncher)
+            self.assertEqual(launcher.matcher, match_tpu)
+
+            with self.assertRaises(app.UsageError):
+                _get_launcher_or_exit(action="start", instance_type="other")
+
+
+class TestBaseBastionLaunchJob(parameterized.TestCase):
+    """Tests BaseBastionLaunchJob."""
+
+    def _mock_config(self, **kwargs):
+        cfg = BaseBastionLaunchJob.default_config().set(
+            instance_type="test",
+            user_id="test_user",
+            project_id=None,
+            name="test_job",
+            command="test_command",
+            max_tries=1,
+            retry_interval=60,
+        )
+        cfg.set(**kwargs)
+
+        def dummy_submit_job(name: str, job_spec_file: str = ""):
+            del name
+            if job_spec_file:
+                with open(job_spec_file, "r", encoding="utf-8") as f:
+                    spec = deserialize_jobspec(f)
+                    self.assertEqual(spec.name, cfg.name)
+                    self.assertEqual(spec.command, cfg.command)
+                    self.assertEqual(spec.metadata.user_id, cfg.user_id)
+                    self.assertEqual(spec.metadata.project_id, cfg.project_id or "none")
+            return mock.MagicMock()
+
+        return cfg.set(bastion=config_for_function(dummy_submit_job).set(name="test_bastion"))
+
+    def test_start(self):
+        # Test with defaults.
+        job = self._mock_config().instantiate()
+        job._execute()
+
+        # Test with bundler.
+        bundler = mock.MagicMock()
+        job = self._mock_config(bundler=config_for_function(lambda: bundler)).instantiate()
+        job._execute()
+        self.assertTrue(bundler.bundle.called)
+
+        # Test with invalid project id.
+        project_id = "test_project"
+        patch_fns = mock.patch.multiple(
+            launch.__name__,
+            gcp_settings=mock.Mock(return_value=""),
+            get_user_projects=mock.Mock(return_value=["other_project"]),
+        )
+        with patch_fns, self.assertRaisesRegex(ValueError, "other_project"):
+            job = self._mock_config(project_id=project_id).instantiate()
+            job._execute()
+
+        # Test with valid project id.
+        project_id = "test_project"
+        patch_fns = mock.patch.multiple(
+            launch.__name__,
+            gcp_settings=mock.Mock(return_value=""),
+            get_user_projects=mock.Mock(return_value=["test_project"]),
+        )
+        with patch_fns:
+            job = self._mock_config(project_id=project_id).instantiate()
+            job._execute()
+
+    def test_list(self):
+        mock_jobs = {
+            "job0": BastionJob(
+                spec=new_jobspec(
+                    name="test_job0",
+                    command="command",
+                    metadata=JobMetadata(
+                        user_id="test_user",
+                        project_id="test_project",
+                        creation_time=datetime.now(),
+                        resources={"v4": 8},
+                    ),
+                ),
+                state=BastionJobState.PENDING,
+                command_proc=None,
+                cleanup_proc=None,
+            ),
+            "job1": BastionJob(
+                spec=new_jobspec(
+                    name="test_job1",
+                    command="command",
+                    metadata=JobMetadata(
+                        user_id="test_user1",
+                        project_id="test_project",
+                        creation_time=datetime.now(),
+                        resources={"v4": 8, "v5": 16},
+                    ),
+                ),
+                state=BastionJobState.ACTIVE,
+                command_proc=None,
+                cleanup_proc=None,
+            ),
+            "job2": BastionJob(
+                spec=new_jobspec(
+                    name="test_job2",
+                    command="command",
+                    metadata=JobMetadata(
+                        user_id="test_user1",
+                        project_id="test_project1",
+                        creation_time=datetime.now(),
+                        resources={"v4": 16},
+                    ),
+                ),
+                state=BastionJobState.ACTIVE,
+                command_proc=None,
+                cleanup_proc=None,
+            ),
+        }
+        with mock.patch(f"{launch.__name__}.download_job_batch", return_value=mock_jobs):
+            job = self._mock_config().instantiate()
+            out = job._list()
+            self.assertEqual(out["jobs"], mock_jobs)
+            self.assertEqual(
+                job._jobs_table(out["jobs"]),
+                dict(
+                    headings=[
+                        "NAME",
+                        "USER_ID",
+                        "JOB_STATE",
+                        "PROJECT_ID",
+                        "RESOURCES",
+                        "PRIORITY",
+                    ],
+                    rows=[
+                        [
+                            "test_job0",
+                            "test_user",
+                            BastionJobState.PENDING,
+                            "test_project",
+                            "{'v4': 8}",
+                            "5",
+                        ],
+                        [
+                            "test_job1",
+                            "test_user1",
+                            BastionJobState.ACTIVE,
+                            "test_project",
+                            "{'v4': 8, 'v5': 16}",
+                            "5",
+                        ],
+                        [
+                            "test_job2",
+                            "test_user1",
+                            BastionJobState.ACTIVE,
+                            "test_project1",
+                            "{'v4': 16}",
+                            "5",
+                        ],
+                    ],
+                ),
+            )
+            self.assertEqual(
+                job._usage_table(out["usage_by_project"]),
+                dict(
+                    headings=["PRINCIPAL", "RESOURCE", "USAGE", "COUNT"],
+                    rows=[
+                        # Note that pending jobs are excluded from usage.
+                        ["test_project", "v5", 16, 1],
+                        ["test_project1", "v4", 16, 1],
+                        ["test_project", "v4", 8, 1],
+                    ],
+                ),
+            )
+            self.assertEqual(
+                job._usage_table(out["usage_by_user"]),
+                dict(
+                    headings=["PRINCIPAL", "RESOURCE", "USAGE", "COUNT"],
+                    rows=[
+                        ["test_user1", "v5", 16, 1],
+                        ["test_user1", "v4", 24, 2],
+                    ],
+                ),
+            )
+
+
+class TestLaunchTPUJob(TestWithTemporaryCWD):
+    """Tests LaunchTPUJob."""
+
+    def test_flags(self):
+        fv = flags.FlagValues()
+        flags.DEFINE_string("instance_type", "test-type", help="test", flag_values=fv)
+        fv.mark_as_parsed()
+
+        patch_fns = mock.patch.multiple(
+            launch.__name__,
+            shared_bastion_name=mock.Mock(return_value="shared-bastion"),
+            generate_job_name=mock.Mock(return_value="job-name"),
+        )
+        with patch_fns:
+            LaunchTPUJob.define_flags(fv)
+
+        # Check some basic flags.
+        self.assertEqual(fv.bastion, "shared-bastion")
+        self.assertEqual(fv.name, "job-name")
+        self.assertIn("tpu_type", fv)
+        self.assertIn("bundler_type", fv)
+        self.assertIsNotNone(fv["name"].default)
+        self.assertIsNotNone(fv["bundler_type"].default)
+        self.assertEqual(fv["tpu_type"].default, "test-type")
+
+        # Make sure bundler config is constructed properly.
+        cfg = LaunchTPUJob.from_flags(fv, command="test command")
+        self.assertIn("tpu", cfg.bundler.extras)
+
+        # Make sure command is expected.
+        for flag in ["name", "bundler_type", "tpu_type"]:
+            self.assertIn(f"--{flag}={fv[flag].default}", cfg.command)
+        self.assertIn("test command", cfg.command)

--- a/axlearn/cloud/gcp/scripts/start_tpu.sh
+++ b/axlearn/cloud/gcp/scripts/start_tpu.sh
@@ -18,13 +18,13 @@ get_metadata() {
 }
 
 BUCKET=$(get_metadata bundle_bucket)
-TASKNAME=$(get_metadata taskname)
+JOB_NAME=$(get_metadata job_name)
 ZONE=$(get_metadata zone)
 TPU_TYPE=$(get_metadata tpu_type)
 DOCKER_REGISTRY=$(get_metadata docker_registry)
 BUNDLER_TYPE=$(get_metadata bundler_type)
 
-GS_TASK_PATH="gs://${BUCKET}/axlearn/tasks/${TASKNAME}"
+GS_JOB_PATH="gs://${BUCKET}/axlearn/jobs/${JOB_NAME}"
 BASE_LOG_ROOT="/output/logs"
 mkdir -p ${BASE_LOG_ROOT}
 chmod -R 776 ${BASE_LOG_ROOT}
@@ -91,7 +91,7 @@ gcloud auth list >> ${SETUP_LOG_PATH}
 # TPU request-create-time set when slice (or multi-slice) creation was triggered.
 CREATE_REQUEST_TIME=$(get_metadata create_request_time)
 set_ready_label() {
-  REMOTE_FLAG="${GS_TASK_PATH}/tpu_vm_ready_flags/${CREATE_REQUEST_TIME}/$(hostname)-ready"
+  REMOTE_FLAG="${GS_JOB_PATH}/tpu_vm_ready_flags/${CREATE_REQUEST_TIME}/$(hostname)-ready"
   LOCAL_FLAG="/tmp/label"
   journalctl -u google-startup-scripts.service > "${LOCAL_FLAG}"
   gsutil cp "${LOCAL_FLAG}" "${REMOTE_FLAG}"
@@ -103,4 +103,4 @@ echo "Begin setting ready label" >> ${SETUP_LOG_PATH}
 set_ready_label
 
 # Copy logs.
-gsutil cp ${SETUP_LOG_PATH} "${GS_TASK_PATH}/logs/setup_log-$(hostname)"
+gsutil cp ${SETUP_LOG_PATH} "${GS_JOB_PATH}/logs/setup_log-$(hostname)"

--- a/axlearn/cloud/gcp/scripts/start_vm.sh
+++ b/axlearn/cloud/gcp/scripts/start_vm.sh
@@ -14,7 +14,7 @@ get_metadata() {
 }
 
 BUCKET=$(get_metadata bundle_bucket)
-TASKNAME=$(get_metadata taskname)
+JOB_NAME=$(get_metadata job_name)
 ZONE=$(get_metadata zone)
 DOCKER_REGISTRY=$(get_metadata docker_registry)
 BUNDLER_TYPE=$(get_metadata bundler_type)
@@ -49,8 +49,8 @@ if [[ " ${tar_bundlers[*]} " =~ " ${BUNDLER_TYPE} " ]]; then
   yes | apt-get install screen htop tmux >> ${SETUP_LOG_PATH} 2>&1
 
   # Unpack bundle.
-  GS_TASK_PATH="gs://${BUCKET}/axlearn/tasks/${TASKNAME}"
-  GS_BUNDLE_PATH="${GS_TASK_PATH}/axlearn.tar.gz"
+  GS_JOB_PATH="gs://${BUCKET}/axlearn/jobs/${JOB_NAME}"
+  GS_BUNDLE_PATH="${GS_JOB_PATH}/axlearn.tar.gz"
   LOCAL_BUNDLE_PATH="/root"
   mkdir -p ${LOCAL_BUNDLE_PATH}
   pushd ${LOCAL_BUNDLE_PATH}
@@ -97,9 +97,9 @@ if [[ " ${docker_bundlers[*]} " =~ " ${BUNDLER_TYPE} " ]]; then
 fi
 
 # Set label if possible (not possible on TPU-VM).
-gcloud compute instances add-labels "${TASKNAME}" \
+gcloud compute instances add-labels "${JOB_NAME}" \
   --labels=boot_status=done \
   --zone ${ZONE} >> ${SETUP_LOG_PATH} 2>&1
 
 # Copy logs.
-gsutil cp ${SETUP_LOG_PATH} "${GS_TASK_PATH}/logs/setup_log-$(hostname)"
+gsutil cp ${SETUP_LOG_PATH} "${GS_JOB_PATH}/logs/setup_log-$(hostname)"

--- a/axlearn/cloud/gcp/tpu.py
+++ b/axlearn/cloud/gcp/tpu.py
@@ -159,7 +159,7 @@ def _create_legacy_tpu(
                 # Now check for when boot script is complete:
                 total_vms = infer_tpu_workers(tpu_type)
                 ready_flags_base_path = (
-                    f"gs://{gcp_settings('ttl_bucket')}/axlearn/tasks/{name}/tpu_vm_ready_flags"
+                    f"gs://{gcp_settings('ttl_bucket')}/axlearn/jobs/{name}/tpu_vm_ready_flags"
                 )
                 node = resource.get(name=f"{tpu_path_prefix}/nodes/{name}").execute()
                 ready_flags_path = (
@@ -388,7 +388,7 @@ def _create_multislice_tpu(
             # TODO(markblee,tom_gunter): Proper health checks for queued resources.
             num_vms = num_slices * infer_tpu_workers(tpu_type)
             ready_flags_base_path = (
-                f"gs://{gcp_settings('ttl_bucket')}/axlearn/tasks/{name}/tpu_vm_ready_flags"
+                f"gs://{gcp_settings('ttl_bucket')}/axlearn/jobs/{name}/tpu_vm_ready_flags"
             )
             # Only one node spec is permitted (even though it's a list).
             create_request_time = node["tpu"]["nodeSpec"][0]["node"]["metadata"][
@@ -557,7 +557,7 @@ def _tpu_body(
         "metadata": {
             "bundle_bucket": gcp_settings("ttl_bucket"),
             "enable-oslogin": "false",
-            "taskname": name,
+            "job_name": name,
             "startup-script": startup_script_contents,
             "zone": gcp_settings("zone"),
             "tpu_type": tpu_type,

--- a/axlearn/cloud/gcp/vm.py
+++ b/axlearn/cloud/gcp/vm.py
@@ -232,7 +232,7 @@ def _vm_config(
         "items": [
             {"key": "bundle_bucket", "value": gcp_settings("ttl_bucket")},
             {"key": "enable-oslogin", "value": "false"},
-            {"key": "taskname", "value": name},
+            {"key": "job_name", "value": name},
             {"key": "startup-script", "value": startup_script_contents},
             {"key": "zone", "value": gcp_settings("zone")},
             {


### PR DESCRIPTION
Adds a generic launch command, which supports arbitrary "launcher" implementations, invoked via --instance_type matching. See launch.py docstring for details.

Other changes:
- Renames taskname to job_name for consistency
- Don't require a config file if reading gcp_settings with required=False
- Makes parse_action a bit more flexible (scanning argv for the first positional arg, rather than assuming argv[1])