### PR TITLE
Increase sharding-spec flexibility in trainer.py and attention.py

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -2395,21 +2395,36 @@ class BottleNeckAdapterTransformerLayer(BaseTransformerLayer):
         )
 
 
-def set_double_shard_weights_config(cfg: TransformerLayer.Config):
-    """Sets `cfg` to shard FFN and attention weights over both data and model axes."""
+def set_double_shard_weights_config(
+    cfg: TransformerLayer.Config,
+    *,
+    batch_axis_names: Union[str, Sequence[str]] = "data",
+    fsdp_axis_names: Union[str, Sequence[str]] = "data",
+    tp_axis_names: Union[str, Sequence[str]] = "model",
+):
+    """Sets `cfg` to shard FFN and attention weights over both fsdp and tp axes.
+
+    TODO(tom_gunter): Replace default batch/fsdp axis names with "fsdp".
+
+    Args:
+        cfg: Transformer layer config to apply sharding spec to.
+        batch_axis_names: Axis name(s) over which we shard the batch dimension of output tensors.
+        fsdp_axis_names: Axis name(s) over which we shard fully-sharded-data-parallel tensors.
+        tp_axis_names: Axis name(s) over which we shard tensor-parallel tensors.
+    """
     # pytype: disable=attribute-error
     ff_layer = cfg.feed_forward
     # Shard weights.
-    ff_layer.linear1.param_partition_spec = ("data", "model")
-    ff_layer.linear2.param_partition_spec = ("model", "data")
+    ff_layer.linear1.param_partition_spec = (fsdp_axis_names, tp_axis_names)
+    ff_layer.linear2.param_partition_spec = (tp_axis_names, fsdp_axis_names)
     # Encourage the right activation sharding.
-    ff_layer.linear1.output_partition_spec = ("data", None, "model")
-    ff_layer.linear2.output_partition_spec = ("data", None, "model")
+    ff_layer.linear1.output_partition_spec = (batch_axis_names, None, tp_axis_names)
+    ff_layer.linear2.output_partition_spec = (batch_axis_names, None, tp_axis_names)
 
     def set_attn_partition_specs(attn_layer: MultiheadAttention.Config):
         # Shard weights.
-        attn_layer.input_linear.layer.param_partition_spec = ("data", "model", None)
-        attn_layer.output_linear.param_partition_spec = ("data", "model", None)
+        attn_layer.input_linear.layer.param_partition_spec = (fsdp_axis_names, tp_axis_names, None)
+        attn_layer.output_linear.param_partition_spec = (fsdp_axis_names, tp_axis_names, None)
 
     set_attn_partition_specs(cfg.self_attention.attention)
     if cfg.cross_attention is not None:

--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -27,8 +27,9 @@ if num_tpu_slices > 1:
     libtpu_init_args += [
         # For collectives across multiple slices.
         "--xla_tpu_enable_megascale_barrier=true",
-        # Prefer async all-gather to all-reduce implementations where async-all-gather is possible.
-        "--xla_tpu_prefer_async_allgather_to_allreduce=true",
+        # Per rwitten@google.com all reduce is put into the following layer across DCN.
+        "--xla_tpu_enable_data_parallel_all_reduce_opt=true",
+        "--xla_tpu_data_parallel_opt_different_sized_ops=true",
     ]
 
 os.environ["LIBTPU_INIT_ARGS"] = " ".join(libtpu_init_args)

--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -27,7 +27,8 @@ if num_tpu_slices > 1:
     libtpu_init_args += [
         # For collectives across multiple slices.
         "--xla_tpu_enable_megascale_barrier=true",
-        # Per rwitten@google.com all reduce is put into the following layer across DCN.
+        # Per rwitten@google.com the following two flags allow gradient all-reduce to happen
+        # concurrently with gradient computation for the following layer.
         "--xla_tpu_enable_data_parallel_all_reduce_opt=true",
         "--xla_tpu_data_parallel_opt_different_sized_ops=true",
     ]

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -92,6 +92,8 @@ class SpmdTrainer(Module):
         mesh_shape: Required[Sequence[int]] = REQUIRED
         # The mesh axis names. The names can be referenced in ParameterSpec.mesh_axes.
         mesh_axis_names: Required[Sequence[str]] = REQUIRED
+        # Subset of mesh axis names over which the leaves of the input batch are sharded.
+        batch_axis_names: Union[str, Sequence[str]] = "data"
 
         # The model config.
         model: Required[BaseModel.Config] = REQUIRED
@@ -668,7 +670,9 @@ class SpmdTrainer(Module):
         state: _TrainerState,
         input_batch: Dict[str, Any],
     ) -> Tuple[_TrainerState, NestedTensor]:
-        input_batch = utils.shard_input_batch(input_batch)
+        input_batch = utils.shard_input_batch(
+            input_batch, batch_axis_names=self.config.batch_axis_names
+        )
         new_prng_key, param_noise_key, forward_key, learner_key = jax.random.split(
             state.prng_key, 4
         )

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -436,17 +436,20 @@ def input_partition_spec() -> PartitionSpec:
     )
 
 
-def shard_input_batch(input_batch: NestedTensor) -> NestedTensor:
+def shard_input_batch(
+    input_batch: NestedTensor, *, batch_axis_names: Union[str, Sequence[str]] = "data"
+) -> NestedTensor:
     """Constrains all leaf values in the input batch to be partitioned over one axis.
 
     Args:
         input_batch: The inputs to be constrained.
+        batch_axis_names: The name(s) of the batch axes.
 
     Returns:
         Inputs wrapped with sharding constraints.
     """
     return jax.tree_util.tree_map(
-        lambda x: with_sharding_constraint(x, PartitionSpec("data")), input_batch
+        lambda x: with_sharding_constraint(x, PartitionSpec(batch_axis_names)), input_batch
     )
 
 


### PR DESCRIPTION
Three minor changes:

1. set_double_shard_weights_config now accepts batch, fsdp, and tp axes names, allowing for higher-dimensional sharding meshes.
2. The SpmdTrainer cfg now has a batch_axis_names property, which allows greater flexibility in how we force the leaves of the input batch to be sharded.
3. launch.py now sets libtpu flags to optimize for data-parallelism between slices (as opposed to FSDP between slices).