### PR TITLE
Use BertLMHead as vocab_mapping child of SpladePooling layer

### DIFF
--- a/axlearn/common/bert.py
+++ b/axlearn/common/bert.py
@@ -146,7 +146,10 @@ class BertLMHead(BaseClassificationHead):
     def __init__(self, cfg: Config, *, parent: Optional[Module]):
         super().__init__(cfg, parent=parent)
         cfg = self.config
-        self._add_child("inner_head", cfg.inner_head.set(dim=cfg.input_dim))
+        if hasattr(cfg.inner_head, "input_dim"):
+            self._add_child("inner_head", cfg.inner_head.set(input_dim=cfg.input_dim))
+        else:
+            self._add_child("inner_head", cfg.inner_head.set(dim=cfg.input_dim))
         self._add_child(
             "transform", cfg.transform.set(input_dim=cfg.input_dim, output_dim=cfg.input_dim)
         )

--- a/axlearn/common/poolings.py
+++ b/axlearn/common/poolings.py
@@ -23,7 +23,7 @@ from axlearn.common.attention import (
 )
 from axlearn.common.base_layer import BaseLayer, ParameterSpec
 from axlearn.common.config import REQUIRED, InstantiableConfig, Required, config_class
-from axlearn.common.layers import LayerNorm, Linear, get_activation_fn
+from axlearn.common.layers import Linear
 from axlearn.common.module import Module
 from axlearn.common.utils import Tensor
 
@@ -279,113 +279,6 @@ class LastNTokenPooling(BasePoolingLayer):
         chosen_tokens = jnp.einsum("bsd,bso->bod", tokens, dispatch)
 
         return chosen_tokens
-
-
-class SpladeMapping(BaseLayer):
-    """SpladeMapping is a simplified version of BertLM head.
-
-    The SpladeMapping maps the embedding from input_dim to intermediate_dim via input_mapping.
-    The embedding is further mapped into output_dim via vocab_mapping.
-    """
-
-    @config_class
-    class Config(BaseLayer.Config):
-        input_dim: Required[int] = REQUIRED
-        intermediate_dim: Required[int] = REQUIRED
-        output_dim: Required[int] = REQUIRED
-        input_mapping: Linear.Config = Linear.default_config()
-        activation_fn: str = "nn.gelu"
-        input_norm: LayerNorm.Config = LayerNorm.default_config()
-        vocab_mapping: InstantiableConfig = Linear.default_config()
-
-    def __init__(self, cfg: Config, *, parent: Optional[Module]):
-        super().__init__(cfg, parent=parent)
-        cfg = self.config
-        self._add_child(
-            "input_mapping",
-            cfg.input_mapping.set(input_dim=cfg.input_dim, output_dim=cfg.intermediate_dim),
-        )
-        self._add_child(
-            "input_norm",
-            cfg.input_norm.set(input_dim=cfg.intermediate_dim),
-        )
-        self._add_child(
-            "vocab_mapping",
-            cfg.vocab_mapping.set(input_dim=cfg.intermediate_dim, output_dim=cfg.output_dim),
-        )
-
-    def forward(self, inputs: Tensor) -> Tensor:
-        x = self.input_mapping(inputs)
-        x = get_activation_fn(self.config.activation_fn)(x)
-        x = self.input_norm(x)
-        output_emb = self.vocab_mapping(x)
-        return output_emb
-
-
-class SpladePooling(BasePoolingLayer):
-    """Splade pooling layer."""
-
-    @config_class
-    class Config(BasePoolingLayer.Config):
-        # Splade activation function. ReLU by default.
-        splade_activation_fn: str = "nn.relu"
-        splade_mode: str = "max"
-        vocab_mapping: InstantiableConfig = SpladeMapping.default_config()
-
-    def __init__(self, cfg: Config, *, parent: Optional[Module]):
-        super().__init__(cfg, parent=parent)
-        cfg = self.config
-        self._add_child(
-            "vocab_mapping",
-            cfg.vocab_mapping.set(
-                input_dim=cfg.input_dim,
-                output_dim=cfg.output_dim,
-            ),
-        )
-
-    def forward(  # pylint:disable=arguments-renamed
-        self, tokens: Tensor, paddings: Tensor = None
-    ) -> Tensor:
-        """Calculate the Splade Pooler.
-
-        Args:
-            tokens: A Tensor of shape [batch_size, seq_len, hidden_dim].
-            paddings: A Tensor of shape [batch_size, seq_len].
-
-        Returns:
-            A Tensor of shape [batch_size, num_outputs, vocab_size] representing Splade features,
-             where num_outputs is determined by the pooling mode.
-             Currently cfg.splade_mode supports max and sum. For both, num_outputs = 1.
-
-        Raises:
-            ValueError: If cfg.splade_mode is not supported.
-            NotImplementedError: If cfg.num_outputs > 1.
-        """
-        cfg = self.config
-        if paddings is None:
-            paddings = jnp.zeros((tokens.shape[0], tokens.shape[1]), dtype=tokens.dtype)
-        # paddings shape is expanded to [batch_size, seq_len, 1].
-        paddings = jnp.expand_dims(paddings, -1)
-        if cfg.splade_mode not in ["max", "sum"]:
-            raise ValueError(f"({cfg.splade_mode}) is not supported in Splade pooling.")
-        if cfg.num_outputs != 1:
-            raise NotImplementedError(
-                f"SPLADE pooling currently doesn't support num_outputs = ({cfg.num_outputs})."
-            )
-        # The output of MLM should have shape [batch_size, seq_len, vocab_size]
-        # BertLMHead uses predict instead of forward.
-        x = self.vocab_mapping(inputs=tokens)
-        # Splade = max( log(1 + relu(x)), dim=1)
-        # (yinfeiy@) reports doing max pooling first will reduce memory in pytorch.
-        # TODO(bwzhang@) Check the pooling order within AXLearn.
-        splade_output = jnp.log1p(get_activation_fn(cfg.splade_activation_fn)(x))
-        if cfg.splade_mode == "max":
-            splade_output += paddings * NEG_INF  # set padded values to -inf
-            splade_output = jnp.max(splade_output, axis=1, keepdims=True)
-        elif cfg.splade_mode == "sum":
-            splade_output *= 1 - paddings  # set padded values to 0
-            splade_output = jnp.sum(splade_output, axis=1, keepdims=True)
-        return splade_output
 
 
 class PoolingWithProjection(BasePoolingLayer):

--- a/axlearn/common/splade.py
+++ b/axlearn/common/splade.py
@@ -1,0 +1,96 @@
+# Copyright © 2023 Apple Inc.
+
+"""Layers for Splade.
+
+https://arxiv.org/pdf/2109.10086.pdf
+"""
+from typing import Optional
+
+import jax.numpy as jnp
+
+from axlearn.common.attention import NEG_INF
+from axlearn.common.bert import BertLMHead
+from axlearn.common.config import config_class
+from axlearn.common.layers import BaseClassificationHead, RedirectToSharedModule, get_activation_fn
+from axlearn.common.module import Module
+from axlearn.common.poolings import BasePoolingLayer
+from axlearn.common.utils import Tensor
+
+
+class SpladePooling(BasePoolingLayer):
+    """Splade pooling layer."""
+
+    SHARED_EMB_NAME = "shared_token_emb"
+
+    @config_class
+    class Config(BasePoolingLayer.Config):
+        # Splade activation function. ReLU by default.
+        splade_activation_fn: str = "nn.relu"
+        splade_mode: str = "max"
+        vocab_mapping: BaseClassificationHead.Config = BertLMHead.default_config()
+
+    @classmethod
+    def default_config(cls):
+        cfg: SpladePooling.Config = super().default_config()
+        # By default, assume `inner_head` employs tied token embedding weights.
+        cfg.vocab_mapping = BertLMHead.default_config().set(
+            inner_head=RedirectToSharedModule.default_config().set(
+                shared_module=cls.SHARED_EMB_NAME,
+                method_map=dict(forward="attend"),
+            ),
+        )
+        return cfg
+
+    def __init__(self, cfg: Config, *, parent: Optional[Module]):
+        super().__init__(cfg, parent=parent)
+        cfg = self.config
+        self._add_child(
+            "vocab_mapping",
+            cfg.vocab_mapping.set(
+                input_dim=cfg.input_dim,
+                num_classes=cfg.output_dim,
+            ),
+        )
+
+    def forward(  # pylint:disable=arguments-renamed
+        self, tokens: Tensor, paddings: Tensor = None
+    ) -> Tensor:
+        """Calculate the Splade Pooler.
+
+        Args:
+            tokens: A Tensor of shape [batch_size, seq_len, hidden_dim].
+            paddings: A Tensor of shape [batch_size, seq_len].
+
+        Returns:
+            A Tensor of shape [batch_size, num_outputs, vocab_size] representing Splade features,
+            where num_outputs is determined by the pooling mode. Currently cfg.splade_mode supports
+            max and sum. For both, num_outputs = 1.
+
+        Raises:
+            ValueError: If cfg.splade_mode is not supported.
+            NotImplementedError: If cfg.num_outputs > 1.
+        """
+        cfg = self.config
+        if paddings is None:
+            paddings = jnp.zeros((tokens.shape[0], tokens.shape[1]), dtype=tokens.dtype)
+        # paddings shape is expanded to [batch_size, seq_len, 1].
+        paddings = jnp.expand_dims(paddings, -1)
+        if cfg.splade_mode not in ["max", "sum"]:
+            raise ValueError(f"({cfg.splade_mode}) is not supported in Splade pooling.")
+        if cfg.num_outputs != 1:
+            raise NotImplementedError(
+                f"SPLADE pooling currently doesn't support num_outputs = ({cfg.num_outputs})."
+            )
+        # Output shape: [batch_size, seq_len, vocab_size].
+        x = self.vocab_mapping({"hidden_states": tokens})
+        # Splade = max(log(1 + relu(x)), dim=1)
+        if cfg.splade_mode == "max":
+            # Doing max pooling first to help reduce memory consumption.
+            x += paddings * NEG_INF  # Set padded values to -inf.
+            x = jnp.max(x, axis=1, keepdims=True)
+            splade_output = jnp.log1p(get_activation_fn(cfg.splade_activation_fn)(x))
+        elif cfg.splade_mode == "sum":
+            splade_output = jnp.log1p(get_activation_fn(cfg.splade_activation_fn)(x))
+            splade_output *= 1 - paddings  # Set padded values to 0.
+            splade_output = jnp.sum(splade_output, axis=1, keepdims=True)
+        return splade_output

--- a/axlearn/common/splade_test.py
+++ b/axlearn/common/splade_test.py
@@ -1,0 +1,201 @@
+# Copyright © 2023 Apple Inc.
+#
+# Some of the code in this file is adapted from:
+#
+# naver/splade:
+# Copyright (c) 2021-present NAVER Corp.
+# Licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+
+"""Tests Splade modules."""
+import itertools
+from typing import Optional
+
+import jax
+import jax.random
+import numpy as np
+import torch
+from absl.testing import parameterized
+from jax import numpy as jnp
+
+from axlearn.common.base_layer import BaseLayer
+from axlearn.common.config import config_class
+from axlearn.common.layers import Embedding, Linear
+from axlearn.common.module import Module
+from axlearn.common.module import functional as F
+from axlearn.common.poolings import BasePoolingLayer
+from axlearn.common.splade import SpladePooling
+from axlearn.common.test_utils import TestCase, assert_allclose
+from axlearn.common.torch_utils import parameters_from_torch_layer
+from axlearn.common.utils import Tensor
+
+
+class SpladePoolingParentLayer(BaseLayer):
+    """A test parent layer to test SpladePooling when token_emb is shared with it."""
+
+    @config_class
+    class Config(BaseLayer.Config):
+        token_emb: Embedding.Config = Embedding.default_config()
+        sparse_pooler: BasePoolingLayer.Config = SpladePooling.default_config()
+
+    def __init__(self, cfg: BaseLayer.Config, *, parent: Optional[Module]):
+        super().__init__(cfg, parent=parent)
+        cfg = self.config
+        self._add_child("token_emb", cfg.token_emb)
+        self._share_with_descendants(
+            self.token_emb,
+            shared_module_name=SpladePooling.SHARED_EMB_NAME,
+        )
+        self._add_child("sparse_pooler", cfg.sparse_pooler)
+
+    def forward(self, tokens: Tensor, paddings: Tensor = None) -> Tensor:
+        return self.sparse_pooler(tokens, paddings)
+
+
+class SpladePoolingTest(TestCase):
+    def ref_splade_implementation(
+        self, inputs, attention_mask, splade_mode, model_args
+    ):  # pylint: disable=no-self-use
+        """Reference splade implementation.
+
+        Ref: https://github.com/naver/splade/blob/main/splade/models/transformer_rep.py#L188-L193
+        """
+        mapping_layer = torch.nn.Sequential(
+            torch.nn.Linear(model_args["input_dim"], model_args["input_dim"]),
+            torch.nn.GELU("tanh"),
+            torch.nn.LayerNorm([model_args["input_dim"]], eps=1e-8),
+            torch.nn.Linear(model_args["input_dim"], model_args["output_dim"]),
+        )
+        out = mapping_layer(inputs)
+        if splade_mode == "sum":
+            values = torch.sum(
+                torch.log(1 + torch.relu(out)) * attention_mask.unsqueeze(-1), dim=1, keepdims=True
+            )
+        else:
+            values, _ = torch.max(
+                torch.log(1 + torch.relu(out)) * attention_mask.unsqueeze(-1), dim=1, keepdims=True
+            )
+        return (
+            values,
+            {
+                "token_emb": mapping_layer[3],
+                "sparse_pooler": {
+                    "vocab_mapping": {
+                        "transform": {
+                            "linear": mapping_layer[0],
+                            "norm": mapping_layer[2],
+                        },
+                    },
+                    "inner_head": mapping_layer[3],
+                },
+            },
+        )
+
+    def verify_splade_against_ref(self, inputs, splade_layer, paddings, splade_mode, model_args):
+        # Process the paddings.
+        if paddings is None:
+            torch_paddings = torch.ones((inputs.shape[:-1]))
+            axlearn_paddings = None
+        else:
+            torch_paddings = torch.from_numpy(paddings.astype(np.float))
+            # axlearn_paddings = True means padded tokens.
+            axlearn_paddings = jnp.asarray((1 - paddings).astype(np.bool))
+
+        # Reference output.
+        ref_output, ref_model_params = self.ref_splade_implementation(
+            torch.from_numpy(inputs), torch_paddings, splade_mode, model_args
+        )
+        layer_params = {
+            "vocab_mapping": {
+                "transform": {
+                    "linear": parameters_from_torch_layer(
+                        ref_model_params["sparse_pooler"]["vocab_mapping"]["transform"]["linear"]
+                    ),
+                    "norm": parameters_from_torch_layer(
+                        ref_model_params["sparse_pooler"]["vocab_mapping"]["transform"]["norm"]
+                    ),
+                },
+            }
+        }
+        if isinstance(splade_layer, SpladePooling):
+            layer_params["vocab_mapping"]["output_bias"] = parameters_from_torch_layer(
+                ref_model_params["sparse_pooler"]["inner_head"]
+            )["bias"]
+            layer_params["vocab_mapping"]["inner_head"] = {}
+            layer_params["vocab_mapping"]["inner_head"]["weight"] = parameters_from_torch_layer(
+                ref_model_params["sparse_pooler"]["inner_head"]
+            )["weight"]
+        elif isinstance(splade_layer, SpladePoolingParentLayer):
+            layer_params["vocab_mapping"]["output_bias"] = parameters_from_torch_layer(
+                ref_model_params["token_emb"]
+            )["bias"]
+            layer_params = {
+                "token_emb": {
+                    "weight": parameters_from_torch_layer(ref_model_params["token_emb"])[
+                        "weight"
+                    ].transpose()
+                },
+                "sparse_pooler": layer_params,
+            }
+        else:
+            raise ValueError("Unsupported splade_layer class!")
+
+        layer_output, _ = F(
+            splade_layer,
+            inputs=dict(tokens=jnp.asarray(inputs), paddings=axlearn_paddings),
+            state=layer_params,
+            is_training=True,
+            prng_key=jax.random.PRNGKey(0),
+        )
+        assert_allclose(layer_output, ref_output.detach().numpy())
+
+    @parameterized.parameters(
+        itertools.product(
+            ["max", "sum"],
+            [True, False],
+        )
+    )
+    def test_splade_pooling(self, mode, share_token_emb):
+        batch_size = 2
+        length = 12
+        dim = 32
+        vocab_size = 64
+
+        if share_token_emb:
+            splade_pooling_parent_layer_cfg = SpladePoolingParentLayer.default_config().set(
+                name="splade_pooling_parent_layer"
+            )
+            splade_pooling_parent_layer_cfg.token_emb.set(num_embeddings=vocab_size, dim=dim)
+            splade_pooling_parent_layer_cfg.sparse_pooler.set(
+                input_dim=dim,
+                output_dim=vocab_size,
+                splade_mode=mode,
+            )
+            splade_layer = splade_pooling_parent_layer_cfg.instantiate(parent=None)
+        else:
+            splade_pooling_layer_cfg = SpladePooling.default_config().set(
+                name="splade_pooling_layer",
+                input_dim=dim,
+                output_dim=vocab_size,
+                splade_mode=mode,
+            )
+            splade_pooling_layer_cfg.vocab_mapping.inner_head = Linear.default_config().set(
+                bias=False, input_dim=dim, output_dim=5
+            )
+            splade_layer = splade_pooling_layer_cfg.instantiate(parent=None)
+
+        model_args = {
+            "input_dim": dim,
+            "output_dim": vocab_size,
+        }
+        # test w/o paddings
+        inputs = np.random.random((batch_size, length, dim)).astype(np.float32)
+        self.verify_splade_against_ref(
+            inputs, splade_layer, paddings=None, splade_mode=mode, model_args=model_args
+        )
+
+        # test w/ paddings
+        inputs = np.random.random((batch_size, length, dim)).astype(np.float32)
+        paddings = np.random.randint(0, 2, (batch_size, length))
+        self.verify_splade_against_ref(
+            inputs, splade_layer, paddings=paddings, splade_mode=mode, model_args=model_args
+        )


### PR DESCRIPTION
Simplify Splade pooling layer by using a `BertLMHead` as vocab_mapping layer and deleting `SpladeMapping` layer, for following reasons:

-  In original Splade implementation, the vocab_mapping layer is just BertLMHead layer.
- More convenient for weights loading from pretrained HF checkpoint:
            * The simplest way to load pretrained weights from a HF BertLM model is to use HF's BertForMaskedLM class. And it has a corresponding converter implemented in axlearn. It will convert LM model into an encoder and a lm_head, which is handy for us to specify overriding of lm_head into axlearn's BertLM head. Extra efforts will be needed if we use existing SpladePooling architecture.
- More convenient to configure weights sharing between token_emb and BertLMHead's linear weight.
   - We want to reuse token_emb layer’s attend() method which won’t consider any bias and manually add a separate bias after that redirected Module call. Existing implementation will make it harder to do this.
- Meanwhile, users could also user a Linear layer as inner_head for BertLMHead if they don't want to share weights with token_emb.

