### PR TITLE
allow parse_kv_flags to accept multiple delimiter

### DIFF
--- a/axlearn/cloud/common/utils.py
+++ b/axlearn/cloud/common/utils.py
@@ -152,7 +152,7 @@ def parse_kv_flags(kv_flags: Sequence[str], *, delimiter: str = ":") -> Dict[str
     """
     metadata = {}
     for kv in kv_flags:
-        parts = kv.split(delimiter)
+        parts = kv.split(delimiter, maxsplit=1)
         if len(parts) != 2:
             raise ValueError(f"Expected key{delimiter}value, got {kv}")
         metadata[parts[0]] = parts[1]

--- a/axlearn/cloud/common/utils_test.py
+++ b/axlearn/cloud/common/utils_test.py
@@ -65,7 +65,7 @@ class UtilsTest(parameterized.TestCase):
         dict(kv_flags=[], expected={}),
         dict(kv_flags=["malformatted"], expected=ValueError()),
         dict(kv_flags=["a:b"], delimiter="=", expected=ValueError()),
-        dict(kv_flags=["a:b:c"], expected=ValueError()),
+        dict(kv_flags=["a=b=c"], delimiter="=", expected=dict(a="b=c")),
     )
     def test_parse_kv_flags(
         self, kv_flags: Sequence[str], expected: Union[Dict, Exception], delimiter: str = ":"


### PR DESCRIPTION
Allow parse_kv_flags to parse strings with multiple delimiter. Example use case is
`--dataflow_spec=resource_hints=min_ram=32GB`.