### PR TITLE
Support remat and its HF weights conversion for Bert-based text embedding encoder

### DIFF
--- a/axlearn/common/neural_retrieval.py
+++ b/axlearn/common/neural_retrieval.py
@@ -42,6 +42,7 @@ def set_bert_dpr_encoder_config(
     pad_token_id: int = 0,
     feed_forward_act: str = "exact_gelu",
     output_norm: Optional[InstantiableConfig] = None,
+    remat: bool = False,
 ) -> TextEmbeddingStreamEncoder.Config:
     """Configure the Bert based DPR stream encoder.
 
@@ -56,6 +57,8 @@ def set_bert_dpr_encoder_config(
         pad_token_id: The token_id for the padded tokens.
         feed_forward_act: The nonlinear function used in the feedforward layer in transformer block.
         output_norm: The normalization applied on the output embeddings. Default is None.
+        remat: If True, use RepeatedTransformerLayer instead of StackedTransformerLayer and remat
+            spec to save memory.
 
     Returns:
         An instantiable Bert based DPR text encoder.
@@ -70,6 +73,7 @@ def set_bert_dpr_encoder_config(
         output_dim=model_dim,
         output_proj=None,
         output_norm=output_norm,
+        remat=remat,
     )
     text_encoder_cfg.text_encoder.encoder.transformer.layer.feed_forward.activation = (
         feed_forward_act

--- a/axlearn/common/param_converter.py
+++ b/axlearn/common/param_converter.py
@@ -42,6 +42,7 @@ from transformers.models.xlnet import modeling_xlnet as hf_xlnet
 
 from axlearn.common.attention import (
     BaseMultiheadLinear,
+    BaseStackedTransformerLayer,
     FusedQKVLinear,
     LearnedPositionalEmbedding,
     MultiheadAttention,
@@ -68,7 +69,7 @@ from axlearn.common.dit import (
     TimeStepEmbedding,
 )
 from axlearn.common.embedding import TransformerTextEmbeddings
-from axlearn.common.encoder import EncoderModel
+from axlearn.common.encoder import Encoder, EncoderModel
 from axlearn.common.layers import Conv2D, Embedding, LayerNorm, LayerNormStateless, Linear, RMSNorm
 from axlearn.common.t5 import T5Decoder, T5Encoder, T5EncoderDecoderModel
 from axlearn.common.text_encoder import TextEmbeddingEncoder
@@ -716,7 +717,9 @@ def torch_to_axlearn(
     elif isinstance(src, hf_encoder_decoder.EncoderDecoderModel):
         dst = _parameters_from_encoder_decoder_model(src)
     elif isinstance(src, hf_bert.BertModel):
-        dst = _parameters_from_bert_model(src)
+        dst = _parameters_from_bert_model(src, dst_layer=dst_layer)
+    elif isinstance(src, (hf_bert.BertEncoder, hf_roberta.RobertaEncoder)):
+        dst = _parameters_from_bert_encoder(src, dst_layer=dst_layer)
     elif isinstance(src, hf_roberta.RobertaModel):
         dst = _parameters_from_roberta_model(src)
     elif isinstance(src, hf_xlnet.XLNetRelativeAttention):
@@ -1142,9 +1145,10 @@ def _parameters_from_attention_dense(
         )
         i_proj[dst_proj] = dense_params
     output_dense = output.dense
+    o_proj = torch_to_axlearn(output_dense)
     o_proj = dict(
-        weight=output_dense.weight.view(-1, num_heads, per_head_dim),
-        bias=output_dense.bias,
+        weight=o_proj["weight"].transpose().reshape(-1, num_heads, per_head_dim),
+        bias=o_proj["bias"],
     )
     return dict(i_proj=i_proj, o_proj=o_proj, dropout={})
 
@@ -1399,10 +1403,26 @@ def _parameters_from_bert_pooler(src: hf_bert.BertPooler):
     )
 
 
-def _parameters_from_bert_encoder(src: Union[hf_bert.BertEncoder, hf_roberta.RobertaEncoder]):
-    return {
-        f"layer{i}": _parameters_from_roberta_layer(module) for i, module in enumerate(src.layer)
+def _parameters_from_bert_encoder(
+    src: Union[hf_bert.BertEncoder, hf_roberta.RobertaEncoder],
+    dst_layer: Optional[BaseStackedTransformerLayer] = None,
+):
+    transformer_layers = {
+        i: _parameters_from_roberta_layer(module) for i, module in enumerate(src.layer)
     }
+    num_layers = len(transformer_layers)
+    if dst_layer is not None and isinstance(dst_layer, RepeatedTransformerLayer):
+        return dict(
+            repeat=VDict(
+                # pylint: disable-next=no-value-for-parameter
+                layer=jax.tree_util.tree_map(
+                    lambda *inputs: jnp.stack(inputs),
+                    *[transformer_layers[i] for i in range(num_layers)],
+                )
+            )
+        )
+    else:
+        return {f"layer{i}": transformer_layers[i] for i in range(num_layers)}
 
 
 # Note: Hugging Face RoBERTa uses slightly different embeddings from BERT.
@@ -1416,10 +1436,12 @@ def _parameters_from_roberta_model(src: hf_roberta.RobertaModel):
     return params
 
 
-def _parameters_from_bert_model(src: hf_bert.BertModel):
+def _parameters_from_bert_model(src: hf_bert.BertModel, dst_layer: Optional[Encoder] = None):
     encoder = dict(
         emb=_parameters_from_bert_embeddings(src.embeddings),
-        transformer=_parameters_from_bert_encoder(src.encoder),
+        transformer=_parameters_from_bert_encoder(
+            src.encoder, dst_layer=dst_layer.transformer if dst_layer is not None else None
+        ),
         attention_mask={},
     )
     params = dict(encoder=encoder)

--- a/axlearn/common/param_converter_test.py
+++ b/axlearn/common/param_converter_test.py
@@ -411,9 +411,11 @@ class ParameterTest(BaseParamConverterTest):
         self.assertNestedAllClose(out.data, hf_out[0])
 
     @parameterized.product(
-        hf_model=[hf_bert.BertEncoder, hf_roberta.RobertaEncoder], remat=[False, True]
+        hf_model=[hf_bert.BertEncoder, hf_roberta.RobertaEncoder],
+        remat=[False, True],
+        test_torch_to_axlearn=[False, True],
     )
-    def test_bert_encoder(self, hf_model, remat):
+    def test_bert_encoder(self, hf_model, remat, test_torch_to_axlearn):
         batch = 3
         cfg = self._param_converter_bert_encoder_config_from_hf(self.hf_cfg, remat)
         cfg = cfg.transformer.set(input_dim=self.hf_cfg.hidden_size)
@@ -434,6 +436,7 @@ class ParameterTest(BaseParamConverterTest):
                 hidden_states=as_torch_tensor(inputs),
                 return_dict=False,
             ),
+            test_torch_to_axlearn=test_torch_to_axlearn,
         )
         self.assertNestedAllClose(out.data, hf_out[0])
 

--- a/axlearn/common/utils_text_dual_encoder.py
+++ b/axlearn/common/utils_text_dual_encoder.py
@@ -3,6 +3,11 @@
 """Text dual encoder utils."""
 from typing import List, Optional
 
+from axlearn.common.attention import (
+    RepeatedTransformerLayer,
+    StackedTransformerLayer,
+    build_remat_spec,
+)
 from axlearn.common.base_layer import BaseLayer
 from axlearn.common.bert import bert_embedding_config, bert_model_config, bert_transformer_config
 from axlearn.common.config import config_for_function
@@ -42,6 +47,7 @@ def bert_text_embedding_stream_encoder_config(
     output_proj: Optional[Linear.Config] = Linear.default_config().set(bias=True),
     output_norm: Optional[BaseLayer.Config] = L2Norm.default_config(),
     pooler: BasePoolingLayer.Config = FirstNTokenPooling.default_config(),
+    remat: bool = False,
 ) -> TextEmbeddingStreamEncoder.Config:
     """Constructs Config for BERT-based TextEmbeddingStreamEncoder.
 
@@ -58,11 +64,13 @@ def bert_text_embedding_stream_encoder_config(
         output_norm: Optional normalization layer applied on embedding from text_encoder and after
             potential projection layer. If None, no normalization will be applied.
         pooler: Pooler of the underlying TextEmbeddingEncoder.
+        remat: If True, use RepeatedTransformerLayer instead of StackedTransformerLayer and remat
+            spec to save memory.
 
     Returns:
         BERT-based TextEmbeddingStreamEncoder Config.
     """
-    return TextEmbeddingStreamEncoder.default_config().set(
+    text_encoder_cfg = TextEmbeddingStreamEncoder.default_config().set(
         text_encoder=TextEmbeddingEncoder.default_config().set(
             pad_token_id=pad_token_id,
             encoder=bert_model_config(
@@ -77,6 +85,9 @@ def bert_text_embedding_stream_encoder_config(
                     num_layers=num_layers,
                     num_heads=num_heads,
                     layer_norm_epsilon=1e-12,
+                    base_cfg=RepeatedTransformerLayer.default_config()
+                    if remat
+                    else StackedTransformerLayer.default_config(),
                 ),
             ).encoder,
             pooler=pooler,
@@ -86,6 +97,11 @@ def bert_text_embedding_stream_encoder_config(
         output_norm=output_norm,
         hidden_dim=hidden_dim,
     )
+    if remat:
+        transformer_cfg = text_encoder_cfg.text_encoder.encoder.transformer
+        transformer_cfg.layer.remat_spec = build_remat_spec(transformer_cfg)
+
+    return text_encoder_cfg
 
 
 ################################################################################

--- a/axlearn/common/utils_text_dual_encoder_test.py
+++ b/axlearn/common/utils_text_dual_encoder_test.py
@@ -1,0 +1,99 @@
+# Copyright © 2023 Apple Inc.
+
+"""Tests text dual encoder utils."""
+from typing import Tuple
+
+# pylint: disable=no-self-use
+import jax
+import jax.numpy as jnp
+import numpy as np
+import torch
+from absl.testing import parameterized
+from transformers import BertConfig, BertModel
+
+from axlearn.common.module import functional as F
+from axlearn.common.test_utils import assert_allclose
+from axlearn.common.text_dual_encoder import POSITIVE_EMBEDDINGS, POSITIVE_INPUT_IDS
+from axlearn.common.torch_utils import parameters_from_torch_layer
+from axlearn.common.utils import as_tensor
+from axlearn.common.utils_text_dual_encoder import bert_text_embedding_stream_encoder_config
+
+
+def generate_random_tokenized_text(
+    *, batch_size: int, max_seq_len: int
+) -> Tuple[np.ndarray, torch.Tensor]:
+    # Generate a random text.
+    input_ids = np.random.randint(low=3, high=30522, size=[batch_size, max_seq_len - 1])
+
+    # Generate a random EOS position.
+    eos_position = np.random.randint(low=1, high=max_seq_len - 1)
+
+    input_ids[:, eos_position + 1 :] = 0
+    attention_mask = np.ones(input_ids.shape)
+    attention_mask[:, eos_position + 1 :] = 0
+    return input_ids, torch.as_tensor(attention_mask)
+
+
+class TestBertStreamEncoderConfig(parameterized.TestCase):
+    """Tests against HF BertModel."""
+
+    @parameterized.parameters(True, False)
+    def test_bert_stream_encoder_config(self, remat: bool):
+        model_dim = 32
+        num_layers = 3
+        num_heads = 8
+        batch_size = 2
+        max_seq_len = 12
+
+        hf_bert_config = BertConfig(
+            hidden_size=model_dim,
+            intermediate_size=model_dim,
+            num_hidden_layers=num_layers,
+            num_attention_heads=num_heads,
+            max_position_embeddings=max_seq_len,
+            hidden_act="gelu_new",
+        )
+        hf_bert_model = BertModel(hf_bert_config)
+        hf_bert_model.eval()
+
+        kwargs = {
+            "pad_token_id": 0,
+            "max_seq_len": max_seq_len,
+            "vocab_size": 30522,
+            "num_layers": num_layers,
+            "hidden_dim": model_dim,
+            "output_dim": model_dim,
+            "num_heads": num_heads,
+            "output_proj": None,
+            "output_norm": None,
+            "remat": remat,
+        }
+        text_encoder_cfg = bert_text_embedding_stream_encoder_config(**kwargs)
+        text_encoder_cfg.set(name="test")
+
+        axlearn_text_encoder = text_encoder_cfg.instantiate(parent=None)
+
+        dst_layer = None
+        if remat:
+            dst_layer = axlearn_text_encoder.text_encoder.encoder
+
+        layer_params = parameters_from_torch_layer(hf_bert_model, dst_layer=dst_layer)
+
+        input_ids, attention_mask = generate_random_tokenized_text(
+            batch_size=batch_size, max_seq_len=max_seq_len
+        )
+
+        ref_outputs = hf_bert_model.forward(torch.as_tensor(input_ids), attention_mask)
+        emb = ref_outputs.last_hidden_state[:, 0, :]
+
+        layer_outputs, _ = F(
+            axlearn_text_encoder,
+            inputs=dict(
+                input_batch={POSITIVE_INPUT_IDS: jnp.asarray(np.expand_dims(input_ids, 1))}
+            ),
+            state=dict(text_encoder=layer_params),
+            is_training=False,
+            prng_key=jax.random.PRNGKey(0),
+        )
+
+        assert_allclose(layer_outputs[POSITIVE_EMBEDDINGS], as_tensor(emb.unsqueeze(1)))


### PR DESCRIPTION
A set of changes needed to support remat for Bert-based text embedding encoder; and also converting HF Bert weights to axlearn when target config uses remat and RepeatedTransformer.