### PR TITLE
Pins pyOpenSSL.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ gcp = [
     "crcmod",  # for file uploads.
     "google-api-python-client==1.8.0",
     "google-auth==2.23.0",
+    "google-auth[pyopenssl]",  # Ensures that we have the right pyopenssl/cryptography pins.
     "google-cloud-storage==2.2.1",
     "google-cloud-core==2.3.3",
 ]


### PR DESCRIPTION
The newer google-auth depends on a newer openssl/cryptography, which sometimes do not get installed. This PR pins them.

Without it, `gsutil` can run into `AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'`.
