### PR TITLE
Inherit GCP pins in TPU extras.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ gcp = [
 # For TPU training.
 # Note: Specify -f https://storage.googleapis.com/jax-releases/libtpu_releases.html during install.
 tpu = [
+    "axlearn[gcp]",
     "jax[tpu]==0.4.13",
 ]
 # Note: Currently tested on x86.


### PR DESCRIPTION
So that TPU deps will be consistent even if we don't specify `--bundler_spec=extras=gcp`.