### PR TITLE
Adds `SpmdTrainer.Config.mesh_rules` and `--mesh_selector` to override trainer mesh configuration.

### DIFF
--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -91,7 +91,7 @@ flags.DEFINE_integer("process_id", None, "Host process id. Set this None for tpu
 flags.DEFINE_string(
     "mesh_selector",
     None,
-    "The mesh selector string. " "See `SpmdTrainer.Config.mesh_rules` for details.",
+    "The mesh selector string. See `SpmdTrainer.Config.mesh_rules` for details.",
 )
 # TODO(markblee): Remove this flag.
 flags.DEFINE_boolean(

--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -88,6 +88,11 @@ flags.DEFINE_integer(
     "num_processes", None, "Total number of hosts (nodes). Set this None for tpu backend."
 )
 flags.DEFINE_integer("process_id", None, "Host process id. Set this None for tpu backend.")
+flags.DEFINE_string(
+    "mesh_selector",
+    None,
+    "The mesh selector string. " "See `SpmdTrainer.Config.mesh_rules` for details.",
+)
 # TODO(markblee): Remove this flag.
 flags.DEFINE_boolean(
     "filter_info_logs",

--- a/axlearn/common/launch_trainer.py
+++ b/axlearn/common/launch_trainer.py
@@ -48,10 +48,10 @@ def get_trainer_config(trainer_config_fn: Optional[TrainerConfigFn] = None) -> S
         )
     trainer_config: SpmdTrainer.Config = trainer_config_fn()
     trainer_config.dir = trainer_config.dir or FLAGS.trainer_dir
-    trainer_config.mesh_axis_names = trainer_config.mesh_axis_names or ("data", "model")
-    trainer_config.mesh_shape = trainer_config.mesh_shape or (len(jax.devices()), 1)
     if FLAGS.mesh_selector is not None:
         select_mesh_config(trainer_config, mesh_selector=FLAGS.mesh_selector)
+    trainer_config.mesh_axis_names = trainer_config.mesh_axis_names or ("data", "model")
+    trainer_config.mesh_shape = trainer_config.mesh_shape or (len(jax.devices()), 1)
     trainer_config.start_trace_steps = [int(el) for el in FLAGS.trace_at_steps]
 
     for eval_cfg in trainer_config.evalers.values():

--- a/axlearn/common/launch_trainer.py
+++ b/axlearn/common/launch_trainer.py
@@ -8,7 +8,7 @@ import jax
 import tensorflow as tf
 from absl import flags, logging
 
-from axlearn.common.trainer import SpmdTrainer
+from axlearn.common.trainer import SpmdTrainer, select_mesh_config
 from axlearn.experiments import TrainerConfigFn, get_named_trainer_config
 
 # Trainer-specific flags.
@@ -50,6 +50,8 @@ def get_trainer_config(trainer_config_fn: Optional[TrainerConfigFn] = None) -> S
     trainer_config.dir = trainer_config.dir or FLAGS.trainer_dir
     trainer_config.mesh_axis_names = trainer_config.mesh_axis_names or ("data", "model")
     trainer_config.mesh_shape = trainer_config.mesh_shape or (len(jax.devices()), 1)
+    if FLAGS.mesh_selector is not None:
+        select_mesh_config(trainer_config, mesh_selector=FLAGS.mesh_selector)
     trainer_config.start_trace_steps = [int(el) for el in FLAGS.trace_at_steps]
 
     for eval_cfg in trainer_config.evalers.values():

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -103,7 +103,7 @@ class SpmdTrainer(Module):
         # An optional list of (regex, MeshShape) pairs to override the default mesh configuration.
         #
         # This is useful when we want to use different mesh shapes depending on the
-        # device types (e.g., A100_80GB vs. A100_40GB vs. TPUv4).
+        # device types (e.g., 'tpu-v4-128' vs. 'gpu-p4de.24xlarge-32').
         #
         # Given a `mesh_selector` string (usually representing the device type), the first rule
         # that with a regex that matches the selector will determine the mesh shape.

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -105,8 +105,10 @@ class SpmdTrainer(Module):
         # This is useful when we want to use different mesh shapes depending on the
         # device types (e.g., 'tpu-v4-128' vs. 'gpu-p4de.24xlarge-32').
         #
-        # Given a `mesh_selector` string (usually representing the device type), the first rule
-        # that with a regex that matches the selector will determine the mesh shape.
+        # Given a `mesh_selector` string (usually representing the device type and set by user's
+        # launch script), the first rule that with a regex that matches the selector will determine
+        # the mesh shape.
+        #
         # If no rule matches, the default mesh configuration will be used.
         mesh_rules: Optional[Sequence[Tuple[str, MeshShape]]] = None
 

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -761,7 +761,7 @@ class SpmdTrainer(Module):
         )
 
 
-def select_mesh_config(trainer_config: SpmdTrainer.Confg, *, mesh_selector: str):
+def select_mesh_config(trainer_config: SpmdTrainer.Config, *, mesh_selector: str):
     if trainer_config.mesh_rules:
         mesh = match_regex_rules(mesh_selector, rules=trainer_config.mesh_rules, default_value=None)
         logging.info("Mesh selector %s matches mesh rule %s", mesh_selector, mesh)

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -92,7 +92,8 @@ class SpmdTrainer(Module):
 
         # The default mesh configuration.
         #
-        # Each mesh shape must have the same length as mesh_axis_names.
+        # The mesh shape, if specified, must have the same length as mesh_axis_names.
+        # Use `mesh_rules` to set different mesh shapes depending on the hardware platform.
         mesh_shape: Required[MeshShape] = REQUIRED
         # The mesh axis names. The names can be referenced in ParameterSpec.mesh_axes.
         mesh_axis_names: Required[Sequence[str]] = REQUIRED


### PR DESCRIPTION
This allows a Trainer config to specify different mesh shapes for different hardware platforms.