### PR TITLE
Splits output summaries of repeat layers

### DIFF
--- a/axlearn/common/repeat.py
+++ b/axlearn/common/repeat.py
@@ -201,7 +201,7 @@ class Repeat(BaseLayer):
         for i in range(cfg.num_layers):
             layer_i_output = this_output_collection.add_child(f"layer{i}")
             layer_i_output.summaries.update(
-                **jax.tree_util.tree_map(lambda x: x[i], layer_output_collection.summaries)
+                **jax.tree_util.tree_map(lambda x, i=i: x[i], layer_output_collection.summaries)
             )
 
         return self.Output(carry=carry, ys=ys)

--- a/axlearn/common/repeat.py
+++ b/axlearn/common/repeat.py
@@ -194,8 +194,12 @@ class Repeat(BaseLayer):
         layer_output.module_outputs.update(**layer_output_collection.module_outputs)
         layer_output.state_updates.update(**layer_output_collection.state_updates)
 
+        # Each summary value in `layer_output_collection` has shape (num_layers, ...). For example,
+        # if a repeated layer outputs a scalar summary value, it will have shape [num_layers].
+        # Below we split the stacked values and output them separately under scope "layer{i}"
+        # so that scalar summaries can be handled correctly.
         for i in range(cfg.num_layers):
-            layer_i_output = this_output_collection.add_child(f"layer_{i}")
+            layer_i_output = this_output_collection.add_child(f"layer{i}")
             layer_i_output.summaries.update(
                 **jax.tree_util.tree_map(lambda x: x[i], layer_output_collection.summaries)
             )

--- a/axlearn/common/repeat.py
+++ b/axlearn/common/repeat.py
@@ -67,7 +67,13 @@ from axlearn.common.config import (
     config_class,
     config_for_function,
 )
-from axlearn.common.module import Module, NestedTensor, child_context, scan_in_context
+from axlearn.common.module import (
+    Module,
+    NestedTensor,
+    child_context,
+    new_output_collection,
+    scan_in_context,
+)
 from axlearn.common.utils import VDict, get_or_none, match_regex_rules, split_prng_key
 
 
@@ -170,7 +176,8 @@ class Repeat(BaseLayer):
         if xs is None:
             xs = {}
 
-        with child_context("layer") as layer_context:
+        layer_output_collection = new_output_collection()
+        with child_context("layer", output_collection=layer_output_collection) as layer_context:
             carry, ys = scan_in_context(
                 fn,
                 carry=carry,
@@ -180,6 +187,17 @@ class Repeat(BaseLayer):
                     state=layer_context.state,
                 ),
                 drop_output=self._drop_output,
+            )
+
+        this_output_collection = self.get_invocation_context().output_collection
+        layer_output = this_output_collection.add_child("layer")
+        layer_output.module_outputs.update(**layer_output_collection.module_outputs)
+        layer_output.state_updates.update(**layer_output_collection.state_updates)
+
+        for i in range(cfg.num_layers):
+            layer_i_output = this_output_collection.add_child(f"layer_{i}")
+            layer_i_output.summaries.update(
+                **jax.tree_util.tree_map(lambda x: x[i], layer_output_collection.summaries)
             )
 
         return self.Output(carry=carry, ys=ys)

--- a/axlearn/common/repeat_test.py
+++ b/axlearn/common/repeat_test.py
@@ -14,7 +14,7 @@ from axlearn.common.base_layer import BaseLayer, ParameterSpec, RematSpec
 from axlearn.common.config import REQUIRED, Required, config_class, config_for_function
 from axlearn.common.layers import RedirectToSharedModule
 from axlearn.common.layers_test import ParentLayer
-from axlearn.common.module import Module
+from axlearn.common.module import Module, OutputCollection
 from axlearn.common.module import functional as F
 from axlearn.common.repeat import Repeat, _drop_by_regex
 from axlearn.common.test_utils import TestCase, assert_allclose
@@ -39,6 +39,7 @@ class TestLayer(BaseLayer):
         forward_state = forward_state + carry
         self.add_summary("carry_mean", jnp.mean(carry))
         self.add_module_output("state", forward_state)
+        self.add_state_update("inc", 2)
         return carry + self.parameters["inc"], forward_state
 
 
@@ -166,6 +167,34 @@ class RepeatTest(TestCase):
             ),
         )
         # Check output collection.
+        self.assertEqual(
+            OutputCollection(
+                state_updates={
+                    "repeat_layer": {
+                        # State update values are stacked across layers.
+                        "layer": {"inc": (num_layers,)},
+                        **{f"layer{i}": {} for i in range(num_layers)},
+                    },
+                },
+                module_outputs={
+                    "repeat_layer": {
+                        # Module output values are stacked across layers.
+                        "layer": (
+                            {"state": (num_layers, batch_size)} if drop_output is None else {}
+                        ),
+                        **{f"layer{i}": {} for i in range(num_layers)},
+                    },
+                },
+                summaries={
+                    "repeat_layer": {
+                        "layer": {},
+                        # Summary values are unstacked and placed in separate "layer{i}" scopes.
+                        **{f"layer{i}": {"carry_mean": tuple()} for i in range(num_layers)},
+                    }
+                },
+            ),
+            shapes(output_collection),
+        )
         if drop_output is not None:
             self.assertEqual(
                 get_recursively(output_collection.module_outputs, "repeat_layer/layer"),
@@ -176,6 +205,10 @@ class RepeatTest(TestCase):
                 get_recursively(output_forward_state, "repeat_layer/layer"),
                 get_recursively(output_collection.module_outputs, "repeat_layer/layer/state"),
             )
+        assert_allclose(
+            [2] * num_layers,
+            get_recursively(output_collection.state_updates, "repeat_layer/layer/inc"),
+        )
         # Check summaries.
         self.assertEqual(
             {

--- a/axlearn/common/repeat_test.py
+++ b/axlearn/common/repeat_test.py
@@ -181,7 +181,7 @@ class RepeatTest(TestCase):
             {
                 "repeat_layer": {
                     "layer": {},
-                    **{f"layer_{i}": {"carry_mean": tuple()} for i in range(num_layers)},
+                    **{f"layer{i}": {"carry_mean": tuple()} for i in range(num_layers)},
                 }
             },
             shapes(output_collection.summaries),
@@ -189,7 +189,7 @@ class RepeatTest(TestCase):
         assert_allclose(
             0.5 * (batch_size - 1) + jnp.arange(num_layers, dtype=dtype),
             [
-                output_collection.summaries["repeat_layer"][f"layer_{i}"]["carry_mean"]
+                output_collection.summaries["repeat_layer"][f"layer{i}"]["carry_mean"]
                 for i in range(num_layers)
             ],
         )
@@ -256,7 +256,7 @@ class RepeatTest(TestCase):
             assert_allclose(
                 0.5 * (batch_size - 1) + jnp.arange(num_layers, dtype=dtype) * multiple_values,
                 [
-                    output_collection.summaries["repeat_layer"][f"layer_{i}"]["layer1"][
+                    output_collection.summaries["repeat_layer"][f"layer{i}"]["layer1"][
                         "carry_mean"
                     ]
                     for i in range(num_layers)
@@ -316,10 +316,10 @@ class RepeatTest(TestCase):
         )
 
         for forward_path, output_path, remat_methods in [
-            ("repeat", "repeat/layer_{i}/redirect/carry_mean", ["forward"]),
+            ("repeat", "repeat/layer{i}/redirect/carry_mean", ["forward"]),
             (
                 "nested/repeat",
-                "nested/repeat/layer_{i}/redirect/carry_mean",
+                "nested/repeat/layer{i}/redirect/carry_mean",
                 ["forward", "forward"],
             ),
         ]:

--- a/axlearn/common/repeat_test.py
+++ b/axlearn/common/repeat_test.py
@@ -256,9 +256,7 @@ class RepeatTest(TestCase):
             assert_allclose(
                 0.5 * (batch_size - 1) + jnp.arange(num_layers, dtype=dtype) * multiple_values,
                 [
-                    output_collection.summaries["repeat_layer"][f"layer{i}"]["layer1"][
-                        "carry_mean"
-                    ]
+                    output_collection.summaries["repeat_layer"][f"layer{i}"]["layer1"]["carry_mean"]
                     for i in range(num_layers)
                 ],
             )


### PR DESCRIPTION
Before this change, a repeated layer's summary values have shape (num_layers, ...). For example, if the inner layer outputs a scalar summary value, the output summary value will have shape [num_layers] after repeat.

With this change we split the stacked values and output them separately under scope "layer{i}". This allows the scalar summaries to be handled correctly.