### PR TITLE
Decouples bastion from GCP.

### DIFF
--- a/axlearn/cloud/common/bastion.py
+++ b/axlearn/cloud/common/bastion.py
@@ -1,0 +1,861 @@
+# Copyright © 2023 Apple Inc.
+
+"""A simple cloud-agnostic job orchestrator.
+
+The bastion is designed to have minimal dependencies:
+1. It uses a cloud storage directory (such as GCS or S3) to store job states and logs.
+2. It runs on a single VM.
+
+The cloud storage directory has the following structure:
+
+    ROOT=<cloud_storage_path>/<bastion_name>
+
+    Active jobspecs: $ROOT/jobs/active/
+    Complete jobspecs: $ROOT/jobs/complete/
+    Active job states: $ROOT/jobs/states/
+    User written job states: $ROOT/jobs/user_states/
+
+    Bastion logs: $ROOT/logs/<bastion_name>
+    Job logs: $ROOT/logs/<job_name>
+    Cleanup command logs: $ROOT/logs/<job_name>.cleanup
+
+    Job scheduling history: $ROOT/history/jobs/<job_name>
+    Project scheduling history: $ROOT/history/projects/<date>
+
+At a high level, the submit flow works as follows:
+1. User submits a job to the bastion by uploading a job spec to the 'active jobspecs' path above
+    (serialized via `JobSpec`).
+2. Bastion polls the cloud storage directory. Each update, it syncs all new jobspecs from the
+    directory and runs them asynchronously inside a docker container. Log outputs are emitted back
+    to the directory.
+3. Once a job is completed, its corresponding jobspec is removed from the cloud storage directory.
+4. The bastion also supports user interaction. For instance, if a user wants to cancel a job, a
+    "cancelling" state file (serialized via `JobState`) can be written to the cloud storage
+    directory. The bastion will read these "user states" and terminate the jobs appropriately, as
+    well as cleanup any processed "user state" files.
+
+Bastion jobs should:
+1. Be executable via invoking a bash command.
+2. Be resumable via invoking the same command. This allows the bastion to be pre-emptible; when
+    bastion restarts, it can simply resume the in-flight jobs by re-running each job command.
+3. Be responsible for cleaning up any external resources that it creates (e.g. via the cleanup
+    command in the jobspec).
+4. Sync their own artifacts/logs to external storage (like a cloud storage directory), if persisting
+    outputs is desired.
+5. Handle retries internally, if retries are desired.
+"""
+# pylint: disable=consider-using-with,too-many-branches,too-many-instance-attributes,too-many-lines
+import collections
+import dataclasses
+import enum
+import functools
+import json
+import os
+import shlex
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor, wait
+from datetime import datetime, timezone
+from subprocess import CalledProcessError
+from typing import IO, Any, Dict, List, Optional, Set, Tuple, Union
+
+from absl import flags, logging
+from tensorflow import errors as tf_errors
+from tensorflow import io as tf_io
+
+# tensorflow_io import is necessary for tf_io to understand s3:// scheme.
+try:
+    # pylint: disable-next=import-error,unused-import
+    import tensorflow_io  # pytype: disable=import-error
+except ModuleNotFoundError:
+    logging.warning("tensorflow_io is not installed -- tf_io may not work with s3://")
+
+from axlearn.cloud.common.cleaner import Cleaner
+from axlearn.cloud.common.job import Job as CloudJob
+from axlearn.cloud.common.scheduler import JobMetadata, ResourceMap, Scheduler
+from axlearn.cloud.common.uploader import Uploader
+from axlearn.cloud.common.utils import send_signal
+from axlearn.common.config import REQUIRED, Configurable, Required, config_class
+
+_LATEST_BASTION_VERSION = 1  # Determines job schema (see JobSpec).
+_LOG_DIR = "/var/tmp/logs"  # Use /var/tmp/ since /tmp/ is cleared every 10 days.
+_JOB_DIR = "/var/tmp/jobs"
+
+FLAGS = flags.FLAGS
+
+
+def bastion_job_flags(flag_values: flags.FlagValues = FLAGS):
+    flags.DEFINE_string("name", None, "Name of bastion.", flag_values=flag_values, required=True)
+    flags.DEFINE_string("job_name", None, "Name of job.", flag_values=flag_values)
+    flags.DEFINE_string("spec", None, "Path to a job spec.", flag_values=flag_values)
+
+
+# Subclass str to be JSON serializable: https://stackoverflow.com/a/51976841
+class JobState(str, enum.Enum):
+    """See Bastion._update_job for state handling."""
+
+    # Job is queued. Any running command will be forcefully terminated.
+    PENDING = "PENDING"
+    # Job is about to run, or currently running.
+    ACTIVE = "ACTIVE"
+    # Job is cancelling. Command is terminating.
+    CANCELLING = "CANCELLING"
+    # Job has completed/termianted the command, is running cleanup command (if any).
+    CLEANING = "CLEANING"
+    # Job is complete.
+    COMPLETED = "COMPLETED"
+
+
+@dataclasses.dataclass
+class JobSpec:
+    """Represents a job that is executed by bastion."""
+
+    # Version to handle schema changes.
+    version: int
+    # Name of the job (aka job_name).
+    name: str
+    # Command to run.
+    command: str
+    # Command to run when job completes (either normally or cancelled).
+    cleanup_command: Optional[str]
+    # Metadata related to a bastion job.
+    metadata: JobMetadata
+
+
+def new_jobspec(
+    *,
+    name: str,
+    command: str,
+    metadata: JobMetadata,
+    cleanup_command: Optional[str] = None,
+) -> JobSpec:
+    return JobSpec(
+        version=_LATEST_BASTION_VERSION,
+        name=name,
+        command=command,
+        cleanup_command=cleanup_command,
+        metadata=metadata,
+    )
+
+
+def serialize_jobspec(spec: JobSpec, f: Union[str, IO]):
+    """Writes job spec to filepath or file."""
+    if isinstance(f, str):
+        with open(f, "w", encoding="utf-8") as fd:
+            serialize_jobspec(spec, fd)
+            return
+
+    json.dump(dataclasses.asdict(spec), f, default=str)
+    f.flush()
+
+
+def deserialize_jobspec(f: Union[str, IO]) -> JobSpec:
+    """Loads job spec from filepath or file."""
+    if isinstance(f, str):
+        with open(f, "r", encoding="utf-8") as fd:
+            return deserialize_jobspec(fd)
+
+    data = json.load(f)
+    if data["version"] == _LATEST_BASTION_VERSION:
+        data["metadata"]["creation_time"] = datetime.strptime(
+            data["metadata"]["creation_time"], "%Y-%m-%d %H:%M:%S.%f"
+        )
+        return JobSpec(
+            version=data["version"],
+            name=data["name"],
+            command=data["command"],
+            cleanup_command=data.get("cleanup_command", None),
+            metadata=JobMetadata(**data["metadata"]),
+        )
+    raise ValueError(f"Unsupported version: {data['version']}")
+
+
+def _download_jobspec(job_name: str, *, remote_dir: str, local_dir: str = _JOB_DIR) -> JobSpec:
+    """Loads jobspec from gs path."""
+    remote_file = os.path.join(remote_dir, job_name)
+    local_file = os.path.join(local_dir, job_name)
+    tf_io.gfile.copy(remote_file, local_file, overwrite=True)
+    return deserialize_jobspec(local_file)
+
+
+def _upload_jobspec(spec: JobSpec, *, remote_dir: str, local_dir: str = _JOB_DIR):
+    """Uploads jobspec to gs path."""
+    local_file = os.path.join(local_dir, spec.name)
+    remote_file = os.path.join(remote_dir, spec.name)
+    serialize_jobspec(spec, local_file)
+    tf_io.gfile.copy(local_file, remote_file, overwrite=True)
+
+
+@dataclasses.dataclass
+class _PipedProcess:
+    """A process with outputs piped to a file."""
+
+    popen: subprocess.Popen
+    fd: IO
+
+
+def _piped_popen(cmd: str, f: str) -> _PipedProcess:
+    """Runs cmd in the background, piping stdout+stderr to a file."""
+    # Open with "a" to append to an existing logfile, if any.
+    fd = open(f, "a", encoding="utf-8")
+    popen = subprocess.Popen(shlex.split(cmd), stdout=fd, stderr=subprocess.STDOUT)
+    return _PipedProcess(popen=popen, fd=fd)
+
+
+def _is_proc_complete(proc: _PipedProcess) -> bool:
+    """Returns True iff proc exited with returncode."""
+    return proc.popen.poll() is not None
+
+
+def _catch_with_error_log(fn, *args, **kwargs) -> Any:
+    """Wraps a fn with try/except and log the error instead of raising.
+
+    Some non-critical operations like uploading logs can be flaky and shouldn't break the bastion.
+    If an exception is caught, the error will be logged and None will be returned. Otherwise, the
+    function's outputs will be returned.
+    """
+    try:
+        return fn(*args, **kwargs)
+    except Exception as e:  # pylint: disable=broad-except
+        logging.error("[Caught] %s failed with error: %s", fn, e)
+    return None
+
+
+@dataclasses.dataclass
+class Job:
+    spec: JobSpec
+    state: JobState
+    # *_proc can be None prior to commands being started.
+    command_proc: Optional[_PipedProcess]
+    cleanup_proc: Optional[_PipedProcess]
+
+
+def _download_job_state(job_name: str, *, remote_dir: str) -> JobState:
+    """Loads job state from gs path."""
+    remote_file = os.path.join(remote_dir, job_name)
+    try:
+        # Note: tf_io.gfile.GFile seems to hit libcurl errors with ThreadPoolExecutor.
+        with tempfile.NamedTemporaryFile("r+") as f:
+            tf_io.gfile.copy(remote_file, f.name, overwrite=True)
+            state = f.read().strip().upper()
+            return JobState[state]
+    except tf_errors.NotFoundError:
+        # No job state, defaults to PENDING.
+        return JobState.PENDING
+
+
+def _upload_job_state(job_name: str, state: JobState, *, remote_dir: str, verbose: bool = True):
+    """Uploads job state to gs path."""
+    remote_file = os.path.join(remote_dir, job_name)
+    logging.log_if(logging.INFO, "Writing %s to %s.", verbose, state.name, remote_file)
+    with tf_io.gfile.GFile(remote_file, mode="w") as f:
+        f.write(state.name)
+
+
+def _start_command(job: Job, *, remote_log_dir: str):
+    """Starts the given job.spec.command and sets `job.command_proc`."""
+    if job.command_proc is not None:
+        return  # Already running.
+    # If a log dir exists for this job, download it. This can happen if a job is resumed.
+    remote_log = os.path.join(remote_log_dir, job.spec.name)
+    local_log = os.path.join(_LOG_DIR, job.spec.name)
+    try:
+        tf_io.gfile.copy(remote_log, local_log, overwrite=True)
+    except tf_errors.NotFoundError:
+        pass
+    # Pipe all outputs to the local _LOG_DIR.
+    job.command_proc = _piped_popen(job.spec.command, local_log)
+    logging.info("Started command for the job %s: %s", job.spec.name, job.spec.command)
+
+
+def _start_cleanup_command(job: Job):
+    """Starts the given job.spec.cleanup_command."""
+    if not job.spec.cleanup_command:
+        logging.info("Job %s has no cleanup command.", job.spec.name)
+    elif job.cleanup_proc is None:
+        # Pipe all outputs to a local _LOG_DIR.
+        job.cleanup_proc = _piped_popen(
+            job.spec.cleanup_command, f"{os.path.join(_LOG_DIR, job.spec.name)}.cleanup"
+        )
+        logging.info(
+            "Started cleanup command for the job %s: %s",
+            job.spec.name,
+            job.spec.cleanup_command,
+        )
+
+
+def _listdir(path: str) -> List[str]:
+    """Wraps tf_io.gfile.listdir by returning empty list if dir is not found."""
+    try:
+        return tf_io.gfile.listdir(path)
+    except tf_errors.NotFoundError:
+        return []
+
+
+def _remove(path: str):
+    """Wraps tf_io.gfile.remove by catching not found errors."""
+    try:
+        tf_io.gfile.remove(path)
+    except tf_errors.NotFoundError:
+        pass
+
+
+def download_job_batch(
+    *,
+    spec_dir: str,
+    state_dir: str,
+    user_state_dir: str,
+    local_spec_dir: str = _JOB_DIR,
+    verbose: bool = False,
+) -> Tuple[Dict[str, Job], Set[str]]:
+    """Downloads a batch of jobs.
+
+    Args:
+        spec_dir: Directory to look for job specs.
+        state_dir: Directory to look for job states.
+        user_state_dir: Directory to look for user states.
+        local_spec_dir: Directory to store downloaded job specs.
+        verbose: Verbose logging.
+
+    Returns:
+        A mapping from job name to Job(spec, state), and
+        A set of job names whose state originates from user_state_dir.
+    """
+    jobspecs = _listdir(spec_dir)
+    user_states = _listdir(user_state_dir)
+    if verbose:
+        logging.info("User states %s", user_states)
+
+    # Download all files from spec_dir, state_dir, and user_state_dir.
+    with ThreadPoolExecutor() as pool:
+        download_spec_fn = functools.partial(
+            _download_jobspec,
+            remote_dir=spec_dir,
+            local_dir=local_spec_dir,
+        )
+        spec_futs = {job_name: pool.submit(download_spec_fn, job_name) for job_name in jobspecs}
+        job_state_futs = {
+            job_name: pool.submit(_download_job_state, job_name, remote_dir=state_dir)
+            for job_name in jobspecs
+        }
+        user_state_futs = {
+            job_name: pool.submit(_download_job_state, job_name, remote_dir=user_state_dir)
+            for job_name in user_states
+        }
+        wait(spec_futs.values())
+        wait(job_state_futs.values())
+        wait(user_state_futs.values())
+        # Construct Jobs for each spec. The state of the job depends on the following:
+        # 1. User state must be CANCELLING. We ignore other user states, e.g., a user should not be
+        #     able to bypass scheduling by initiating a state change to ACTIVE.
+        # 2. Job state must not be CLEANING/COMPLETED, since it doesn't make sense to progress
+        #     backwards to CANCELLING.
+        #
+        # If these conditions are met, we pick the user state; otherwise, we keep job state.
+        # We also keep track of which jobs have a user state (whether it was used or not), so that
+        # we can handle the appropriate cleanup in the update step.
+        jobs = {}
+        jobs_with_user_states = set()
+        for job_name in jobspecs:
+            try:
+                spec = spec_futs[job_name].result()
+                state = job_state_futs[job_name].result()
+                if job_name in user_state_futs:
+                    user_state = user_state_futs[job_name].result()
+                else:
+                    user_state = None
+            except Exception as e:  # pylint: disable=broad-except
+                # TODO(markblee): Distinguish transient vs non-transient errors.
+                logging.warning("Failed to load job %s with error: %s", job_name, e)
+                continue
+
+            if user_state is not None:
+                if user_state == JobState.CANCELLING and state not in (
+                    JobState.CLEANING,
+                    JobState.COMPLETED,
+                ):
+                    state = user_state
+                else:
+                    logging.warning(
+                        "User state (%s) ignored for job %s (%s).", user_state, job_name, state
+                    )
+                # Even if user_state is ignored, we still want to clean it up.
+                jobs_with_user_states.add(job_name)
+            jobs[job_name] = Job(spec=spec, state=state, command_proc=None, cleanup_proc=None)
+    return jobs, jobs_with_user_states
+
+
+class Bastion(Configurable):
+    """An orchestrator that schedules and executes jobs."""
+
+    @config_class
+    class Config(Configurable.Config):
+        """Configures Bastion."""
+
+        # Interval to sync and run jobs.
+        update_interval_seconds: float = 30
+        # Scheduler to decide whether to start/pre-empt jobs.
+        scheduler: Required[Scheduler.Config] = REQUIRED
+        # Cleaner to deprovision idle resources.
+        cleaner: Required[Cleaner.Config] = REQUIRED
+        # Utility to sync logs to output_dir.
+        uploader: Required[Uploader.Config] = REQUIRED
+        # Output directory. Must be compatible with tf_io.
+        output_dir: Required[str] = REQUIRED
+
+    def __init__(self, cfg: Config):
+        super().__init__(cfg)
+        cfg = self.config
+        # Remote directory to emit logs.
+        self._output_dir = cfg.output_dir
+        # Remote log output dir. Ensure trailing slash.
+        # Note: pathlib doesn't work well with gs:// prefix.
+        self._log_dir = os.path.join(self._output_dir, "logs")
+        self._job_dir = os.path.join(self._output_dir, "jobs")
+        # Remote history dir. Ensure trailing slash.
+        self._job_history_dir = os.path.join(self._output_dir, "history", "jobs")
+        tf_io.gfile.makedirs(self._job_history_dir)
+        self._project_history_dir = os.path.join(self._output_dir, "history", "projects")
+        tf_io.gfile.makedirs(self._project_history_dir)
+        # Mapping from project_id to previous job verdicts.
+        self._project_history_previous_verdicts = {}
+        # Jobs that have fully completed.
+        self._complete_dir = os.path.join(self._job_dir, "complete")
+        # Active jobs (all other jobs).
+        self._active_dir = os.path.join(self._job_dir, "active")
+        # All user states (e.g. "cancelling" written by user).
+        self._user_state_dir = os.path.join(self._job_dir, "user_states")
+        # All bastion-managed job states.
+        self._state_dir = os.path.join(self._job_dir, "states")
+        # Local active jobs (and respective commands, files, etc).
+        # TODO(markblee): Rename this, as it includes more than just ACTIVE jobs (e.g. PENDING).
+        self._active_jobs: Dict[str, Job] = {}
+        # A set of job names which require cleanup of user states.
+        self._jobs_with_user_states: Set[str] = set()
+
+        # Instantiate children.
+        self._scheduler = cfg.scheduler.instantiate()
+        self._cleaner = cfg.cleaner.instantiate()
+        self._uploader = cfg.uploader.set(src_dir=_LOG_DIR, dst_dir=self._log_dir).instantiate()
+
+    def _append_to_job_history(self, job: Job, msg: str):
+        with tf_io.gfile.GFile(os.path.join(self._job_history_dir, f"{job.spec.name}"), "a") as f:
+            curr_time = datetime.now(timezone.utc).strftime("%m%d %H:%M:%S")
+            f.write(f"{curr_time} {msg}\n")
+
+    def _append_to_project_history(
+        self, jobs: Dict[str, JobMetadata], schedule_results: Scheduler.ScheduleResults
+    ):
+        now = datetime.now(timezone.utc)
+        for project_id, limits in schedule_results.project_limits.items():
+            job_verdicts = schedule_results.job_verdicts.get(project_id, {})
+            verdicts = []
+            for job_id, verdict in job_verdicts.items():
+                verdicts.append((job_id, verdict.should_run()))
+            verdicts = sorted(verdicts)
+            previous_verdicts = self._project_history_previous_verdicts.get(project_id)
+            if previous_verdicts == verdicts:
+                # Nothing changed.
+                continue
+            self._project_history_previous_verdicts[project_id] = verdicts
+            # Mapping from resource types to usage.
+            project_usage = collections.defaultdict(lambda: 0)
+            running_jobs = []
+            queued_jobs = []
+            for job_id, verdict in job_verdicts.items():
+                if verdict.should_run():
+                    running_jobs.append(job_id)
+                    job_metadata = jobs[job_id]
+                    for resource_type, demand in job_metadata.resources.items():
+                        project_usage[resource_type] += demand
+                else:
+                    queued_jobs.append(job_id)
+
+            def resource_str(resource_map: ResourceMap) -> str:
+                return ", ".join(
+                    sorted(
+                        f"{resource_type}={quantity}"
+                        for resource_type, quantity in resource_map.items()
+                    )
+                )
+
+            project_dir = os.path.join(self._project_history_dir, project_id)
+            tf_io.gfile.makedirs(project_dir)
+            with tf_io.gfile.GFile(os.path.join(project_dir, now.strftime("%Y%m%d")), "a") as f:
+                curr_time = now.strftime("%m%d %H:%M:%S")
+                f.write(f"{curr_time}\n")
+                f.write(f"Effective limits: {resource_str(limits)}\n")
+                f.write(f"Usage: {resource_str(project_usage)}\n")
+                f.write("Running jobs:\n")
+                for job_id in running_jobs:
+                    f.write(f"  {job_id}\n")
+                f.write("Queued jobs:\n")
+                for job_id in queued_jobs:
+                    f.write(f"  {job_id}\n")
+
+    def _wait_and_close_proc(self, proc: _PipedProcess, kill: bool = False):
+        """Cleans up the process/fds and upload logs to gs."""
+        if kill:
+            send_signal(proc.popen, sig=signal.SIGKILL)
+        # Note: proc should already be polled and completed, so wait is nonblocking.
+        proc.popen.wait()
+        proc.fd.close()
+        # Upload outputs to log dir.
+        _catch_with_error_log(
+            tf_io.gfile.copy,
+            proc.fd.name,
+            os.path.join(self._log_dir, os.path.basename(proc.fd.name)),
+            overwrite=True,
+        )
+        # Remove the local output file.
+        if os.path.exists(proc.fd.name):
+            os.remove(proc.fd.name)
+
+    def _sync_jobs(self):
+        """Makes the local bastion state consistent with the remote state.
+
+        This function serves as a synchronization point for user-initiated state changes
+        ("user_states") and state changes from a prior `_update_job` ("states"). Users should avoid
+        writing to the "states" dir directly, as doing so can produce races with `_update_job`.
+
+        More specifically, this function:
+        1. Downloads all active jobspecs from remote job dir.
+        2. Downloads all statefiles for active jobspecs from remote state dir (see
+            `download_job_batch` for details).
+
+        We use these jobspecs to update the local self._active_jobs.
+        """
+        active_jobs, jobs_with_user_states = download_job_batch(
+            spec_dir=self._active_dir,
+            state_dir=self._state_dir,
+            user_state_dir=self._user_state_dir,
+            verbose=True,
+        )
+        self._jobs_with_user_states = jobs_with_user_states
+        # Iterate over unique job names.
+        # pylint: disable-next=use-sequence-for-iteration
+        for job_name in {*active_jobs.keys(), *self._active_jobs.keys()}:
+            # Detected new job: exists in remote, but not local.
+            if job_name not in self._active_jobs:
+                logging.info("Detected new job %s.", job_name)
+                self._active_jobs[job_name] = active_jobs[job_name]
+            # Detected removed job: exists locally, but not in remote.
+            elif job_name not in active_jobs:
+                job = self._active_jobs[job_name]
+                if job.state != JobState.COMPLETED:
+                    logging.warning("Detected orphaned job %s! Killing it...", job.spec.name)
+                    if job.command_proc is not None:
+                        self._wait_and_close_proc(job.command_proc, kill=True)
+                    if job.cleanup_proc is not None:
+                        self._wait_and_close_proc(job.cleanup_proc, kill=True)
+                logging.info("Removed job %s.", job_name)
+                del self._active_jobs[job_name]
+            # Detected updated job: exists in both.
+            else:
+                curr_job = self._active_jobs[job_name]
+                updated_job = active_jobs[job_name]
+                curr_job.spec, curr_job.state = updated_job.spec, updated_job.state
+
+    # pylint: disable-next=too-many-statements
+    def _update_single_job(self, job: Job) -> Job:
+        """Handles all state transitions for a single job.
+
+        Assumptions:
+        1. A jobspec file exists in the remote job dir at the start of each call. The job.state
+            provided to this function call is consistent with that state in the remote dir + any
+            scheduling decisions.
+        2. The function may be called by a freshly started bastion (recovering from pre-emption).
+            Thus each condition must assume nothing about the local state.
+        3. The function may be pre-empted at any point.
+        4. Job commands/cleanup commands are resumable (can invoke the same command multiple times).
+
+        Conditions that must be held at exit (either pre-emption or graceful):
+        1. A jobspec must still exist in the remote job dir.
+        2. self._active_jobs must be unmodified, besides modifying `job` itself.
+        """
+        if job.state == JobState.PENDING:
+            # Forcefully terminate the command proc and fd, if they exist, and sync logs to remote.
+            # The forceful termination is similar to the behavior when bastion itself is pre-empted.
+            #
+            # We must also ensure that:
+            # 1. command_proc is set to None, so we can resume in ACTIVE in a subsequent step
+            #    (possibly the next step).
+            # 2. Any job logs are sync'ed to remote log dir. The local log file cannot reliably be
+            #    expected to be present if/when the job is resumed.
+            if job.command_proc is not None:
+                self._append_to_job_history(job, "PENDING: pre-empting")
+                logging.info("Pre-empting job: %s", job.spec.name)
+                self._wait_and_close_proc(job.command_proc, kill=True)
+                job.command_proc = None
+                logging.info("Job is pre-empted: %s", job.spec.name)
+
+            job.state = JobState.PENDING
+
+        elif job.state == JobState.ACTIVE:
+            # Run the command if not already started. We attempt to run every time, in case bastion
+            # got pre-empted.
+            if job.command_proc is None:
+                self._append_to_job_history(
+                    job, f"ACTIVE: start process command: {job.spec.command}"
+                )
+            _start_command(job, remote_log_dir=self._log_dir)
+            assert job.command_proc is not None
+
+            # If command is completed, move to CLEANING. Otherwise, it's still RUNNING.
+            if _is_proc_complete(job.command_proc):
+                self._append_to_job_history(job, "CLEANING: process finished")
+                logging.info(
+                    "Job %s stopped gracefully: %s.",
+                    job.spec.name,
+                    job.command_proc.popen.returncode,
+                )
+                job.state = JobState.CLEANING
+
+        elif job.state == JobState.CANCELLING:
+            # If job is still running, terminate it. We stay in CANCELLING until it has fully
+            # exited, after which we move to CLEANING.
+            if job.command_proc is not None and not _is_proc_complete(job.command_proc):
+                self._append_to_job_history(job, "CANCELLING: terminating the process")
+                logging.info("Sending SIGTERM to job: %s", job.spec.name)
+                job.command_proc.popen.terminate()
+            else:
+                self._append_to_job_history(job, "CLEANING: process terminated")
+                job.state = JobState.CLEANING
+
+        elif job.state == JobState.CLEANING:
+            # If command exists, it must be fully stopped.
+            assert job.command_proc is None or _is_proc_complete(job.command_proc)
+
+            # Close the command proc and fd, if they exist.
+            if job.command_proc is not None:
+                self._wait_and_close_proc(job.command_proc)
+                job.command_proc = None
+
+            # Run the cleanup command if not already started (and if it exists). We attempt to run
+            # every time, in case bastion got pre-empted.
+            if job.spec.cleanup_command and not job.cleanup_proc:
+                self._append_to_job_history(
+                    job, f"CLEANING: start cleanup command: {job.spec.cleanup_command}"
+                )
+            _start_cleanup_command(job)
+
+            # If job has no cleanup command, or cleanup command is complete, transition to
+            # COMPLETED.
+            if job.cleanup_proc is None or _is_proc_complete(job.cleanup_proc):
+                self._append_to_job_history(job, "COMPLETED: cleanup finished")
+                logging.info("Job %s finished running cleanup.", job.spec.name)
+                if job.cleanup_proc is not None:
+                    self._wait_and_close_proc(job.cleanup_proc)
+                    job.cleanup_proc = None
+
+                job.state = JobState.COMPLETED
+
+        elif job.state == JobState.COMPLETED:
+            # Copy the jobspec to "complete" dir.
+            local_jobspec = os.path.join(_JOB_DIR, job.spec.name)
+            if os.path.exists(local_jobspec):
+                _upload_jobspec(job.spec, local_dir=_JOB_DIR, remote_dir=self._complete_dir)
+                os.remove(local_jobspec)
+
+        else:
+            raise ValueError(f"Unexpected state: {job.state}")
+
+        # Flush the state to remote.
+        # TODO(markblee): Skip the upload if we can detect the state hasn't changed.
+        # State changes can come from user_states, scheduling, or above, so probably not worth the
+        # complexity at the moment, given how small job states are.
+        _upload_job_state(job.spec.name, job.state, remote_dir=self._state_dir, verbose=False)
+
+        # Remove any remote "user_states" now that "states" dir has synchronized.
+        if job.spec.name in self._jobs_with_user_states:
+            _remove(os.path.join(self._user_state_dir, job.spec.name))
+
+        return job
+
+    def _update_jobs(self):
+        """Handles state transitions for all jobs.
+
+        The scheduler is used to determine which jobs to resume/pre-empt based on job priority.
+        The actual updates can be performed in any order (possibly in parallel).
+
+        Note that this function should respect the conditions specified in `_update_single_job`.
+        """
+        logging.info("")
+        logging.info("==Begin update step.")
+
+        # Identify jobs which are schedulable.
+        schedulable_jobs = {}
+        for job_name, job in self._active_jobs.items():
+            if job.state in {JobState.PENDING, JobState.ACTIVE}:
+                schedulable_jobs[job_name] = job.spec.metadata
+
+        # Decide which jobs to resume/pre-empt.
+        schedule_results: Scheduler.ScheduleResults = self._scheduler.schedule(schedulable_jobs)
+        self._append_to_project_history(schedulable_jobs, schedule_results)
+        for verdicts in schedule_results.job_verdicts.values():
+            for job_name, verdict in verdicts.items():
+                if verdict.should_run():  # Resume/keep running.
+                    self._active_jobs[job_name].state = JobState.ACTIVE
+                else:  # Pre-empt/stay queued.
+                    self._active_jobs[job_name].state = JobState.PENDING
+
+        # TODO(markblee): Parallelize this.
+        for job_name, job in self._active_jobs.items():
+            try:
+                self._update_single_job(job)
+            except (CalledProcessError, RuntimeError) as e:
+                logging.warning("Failed to execute %s: %s", job_name, e)
+
+        logging.info("")
+        logging.info("All job states:")
+        for job_name, job in self._active_jobs.items():
+            logging.info("%s: %s", job_name, job.state)
+
+        logging.info("==End of update step.")
+        logging.info("")
+
+    def _gc_jobs(self):
+        """Garbage collects idle jobs and completed specs.
+
+        Note that this does not modify job state or self._active_jobs. Instead, fully gc'ed
+        COMPLETED jobs will have their jobspecs removed. In the next _sync_jobs, self._active_jobs
+        will be made consistent with remote state.
+        """
+        logging.info("")
+        logging.info("==Begin gc step.")
+        cleaned = []
+
+        # Identify jobs which are idle (i.e., can be garbage collected).
+        jobs_to_clean = {}
+        for job_name, job in self._active_jobs.items():
+            if job.state in {JobState.PENDING, JobState.COMPLETED}:
+                jobs_to_clean[job_name] = job.spec.metadata.resources
+
+        # Note that this may contain PENDING jobs that have not yet started (since they will not be
+        # associated with any resources yet).
+        cleaned.extend(self._cleaner.sweep(jobs_to_clean))
+
+        def _delete_jobspec(job_name: str):
+            logging.info("Deleting jobspec for %s", job_name)
+            # Delete jobspec before state. This ensures that we won't pickup the job again in
+            # _sync_jobs, and that state files are always associated with a jobspec.
+            _remove(os.path.join(self._active_dir, job_name))
+            _remove(os.path.join(self._state_dir, job_name))
+            logging.info("Job %s is complete.", job_name)
+
+        # Remove remote jobspecs for COMPLETED jobs that finished gc'ing.
+        # TODO(markblee): GC orphaned states (e.g. if delete gets pre-empted).
+        cleaned_completed = [
+            job_name
+            for job_name in cleaned
+            if self._active_jobs[job_name].state == JobState.COMPLETED
+        ]
+        logging.info("Fully cleaned COMPLETED jobs: %s", cleaned_completed)
+        with ThreadPoolExecutor() as pool:
+            pool.map(_delete_jobspec, cleaned_completed)
+
+        logging.info("==End of gc step.")
+        logging.info("")
+
+    def execute(self):
+        """Starts the bastion."""
+        cfg: Bastion.Config = self.config
+        if os.path.exists(_JOB_DIR):
+            shutil.rmtree(_JOB_DIR)
+        os.makedirs(_LOG_DIR, exist_ok=True)
+        os.makedirs(_JOB_DIR, exist_ok=True)
+        while True:
+            start = time.time()
+            self._uploader()
+            self._sync_jobs()
+            self._update_jobs()
+            self._gc_jobs()
+            execute_s = time.time() - start
+            if execute_s > cfg.update_interval_seconds:
+                logging.warning(
+                    "Execute step exceeded interval: %s > %s",
+                    execute_s,
+                    cfg.update_interval_seconds,
+                )
+            time.sleep(max(0, cfg.update_interval_seconds - execute_s))
+
+
+class StartBastionJob(CloudJob):
+    """A job that runs the bastion."""
+
+    @config_class
+    class Config(CloudJob.Config):
+        """Configures StartBastionJob."""
+
+        bastion: Required[Bastion.Config] = REQUIRED
+
+    @classmethod
+    def default_config(cls) -> Config:
+        return super().default_config().set(command="")
+
+    def __init__(self, cfg: Config):
+        super().__init__(cfg)
+        self._bastion: Bastion = cfg.bastion.instantiate()
+
+    def _execute(self) -> Any:
+        # Wraps bastion with retries.
+        self._bastion.execute()
+
+
+class SubmitBastionJob(CloudJob):
+    """A job to submit a command to bastion."""
+
+    @config_class
+    class Config(CloudJob.Config):
+        """Configures SubmitBastionJob."""
+
+        # Name of the job. Not to be confused with cfg.name, the bastion name.
+        job_name: Required[str] = REQUIRED
+        # Job spec file local path.
+        job_spec_file: Required[str] = REQUIRED
+        # Output directory used by the bastion. Note that this must be consistent with the output
+        # directory used when creating the bastion.
+        bastion_dir: Required[str] = REQUIRED
+
+    @classmethod
+    def default_config(cls):
+        return super().default_config().set(command="")
+
+    @property
+    def bastion_dir(self):
+        return self.config.bastion_dir
+
+    def _job_dir(self):
+        return os.path.join(self.bastion_dir, "jobs")
+
+    def _delete(self):
+        cfg: SubmitBastionJob.Config = self.config
+        try:
+            jobspec = os.path.join(self._job_dir(), "active", cfg.job_name)
+            if not tf_io.gfile.exists(jobspec):
+                raise ValueError(f"Unable to locate jobspec {jobspec}")
+            _upload_job_state(
+                cfg.job_name,
+                JobState.CANCELLING,
+                remote_dir=os.path.join(self._job_dir(), "user_states"),
+            )
+            logging.info("Job %s is cancelling.", cfg.job_name)
+            # Poll for jobspec to be removed.
+            while tf_io.gfile.exists(jobspec):
+                logging.info("Waiting for job to stop (which usually takes a few minutes)...")
+                time.sleep(10)
+            logging.info("Job is stopped.")
+        except ValueError as e:
+            logging.info("Failed with error: %s -- Has the job been cancelled already?", e)
+
+    def _execute(self):
+        cfg: SubmitBastionJob.Config = self.config
+        dst = os.path.join(self._job_dir(), "active", cfg.job_name)
+        if tf_io.gfile.exists(dst):
+            logging.info("\n\nNote: Job is already running. To restart it, cancel the job first.\n")
+        else:
+            # Upload the job for bastion to pickup.
+            tf_io.gfile.copy(cfg.job_spec_file, dst)

--- a/axlearn/cloud/common/bastion_test.py
+++ b/axlearn/cloud/common/bastion_test.py
@@ -1,0 +1,828 @@
+# Copyright © 2023 Apple Inc.
+
+"""Tests bastion orchestrator."""
+# pylint: disable=no-self-use,protected-access
+import contextlib
+import os
+import subprocess
+import tempfile
+from datetime import datetime, timedelta
+from typing import Dict, Optional, Sequence
+from unittest import mock
+
+from absl.testing import parameterized
+
+from axlearn.cloud.common import bastion
+from axlearn.cloud.common.bastion import (
+    _JOB_DIR,
+    _LOG_DIR,
+    Bastion,
+    Job,
+    JobState,
+    _PipedProcess,
+    deserialize_jobspec,
+    download_job_batch,
+    new_jobspec,
+    serialize_jobspec,
+)
+from axlearn.cloud.common.cleaner import Cleaner
+from axlearn.cloud.common.scheduler import JobMetadata, JobScheduler
+from axlearn.cloud.common.scheduler_test import mock_quota_config
+from axlearn.cloud.common.types import ResourceMap
+from axlearn.cloud.common.uploader import Uploader
+from axlearn.common.config import config_for_function
+
+
+class TestDownloadJobBatch(parameterized.TestCase):
+    """Tests download utils."""
+
+    def test_download_job_batch(self):
+        spec_dir = "gs://test_spec_dir"
+        state_dir = "gs://test_state_dir"
+        user_state_dir = "gs://user_state_dir"
+
+        user_states = {
+            "job_test1": JobState.CANCELLING,
+            "job_test2": JobState.ACTIVE,
+            "job_test0": JobState.CANCELLING,
+            "job_test3": JobState.CANCELLING,
+        }
+        states = {
+            "job_test1": JobState.ACTIVE,
+            "job_test0": JobState.CLEANING,
+            "job_test3": JobState.COMPLETED,
+            "job_test4": JobState.PENDING,
+        }
+        jobspecs = {
+            "job_test2": mock.Mock(),
+            "job_test1": mock.Mock(),
+            "job_test0": mock.Mock(),
+            "job_test3": mock.Mock(),
+            "job_test4": mock.Mock(),
+        }
+        expected = {
+            # User state is invalid and is ignored. Job state defaults to PENDING, since it's
+            # missing a state.
+            "job_test2": JobState.PENDING,
+            # User state should take effect.
+            "job_test1": JobState.CANCELLING,
+            # User state should not affect CLEANING/COMPLETED.
+            "job_test0": JobState.CLEANING,
+            "job_test3": JobState.COMPLETED,
+            # Has no user state.
+            "job_test4": JobState.PENDING,
+        }
+
+        def mock_listdir(path):
+            if path == spec_dir:
+                return list(jobspecs.keys())
+            if path == state_dir:
+                return list(states.keys())
+            if path == user_state_dir:
+                return list(user_states.keys())
+            assert False  # Should not be reached.
+
+        def mock_download_jobspec(job_name, **kwargs):
+            del kwargs
+            return jobspecs[job_name]
+
+        def mock_download_job_state(job_name, *, remote_dir, **kwargs):
+            del kwargs
+            if remote_dir == state_dir:
+                # Job state may be initially missing, thus defaults to PENDING.
+                return states.get(job_name, JobState.PENDING)
+            if remote_dir == user_state_dir:
+                # We should only query user states if one exists, so don't use get().
+                return user_states[job_name]
+            assert False  # Should not be reached.
+
+        patch_fns = mock.patch.multiple(
+            bastion.__name__,
+            _download_jobspec=mock.Mock(side_effect=mock_download_jobspec),
+            _download_job_state=mock.Mock(side_effect=mock_download_job_state),
+        )
+        patch_tfio = mock.patch(f"{bastion.__name__}.tf_io.gfile.listdir", side_effect=mock_listdir)
+
+        # Ensure that results are in the right order and pairing.
+        with patch_fns, patch_tfio, tempfile.TemporaryDirectory() as tmpdir:
+            jobs, jobs_with_user_states = download_job_batch(
+                spec_dir=spec_dir,
+                state_dir=state_dir,
+                user_state_dir=user_state_dir,
+                local_spec_dir=tmpdir,
+            )
+            self.assertSameElements(expected.keys(), jobs.keys())
+            # "job_test1" is the only valid user state, but we still cleanup the others.
+            self.assertSameElements(jobs_with_user_states, user_states.keys())
+            for job_name, job in jobs.items():
+                self.assertEqual(job.state, expected[job_name])
+                self.assertEqual(job.spec, jobspecs[job_name])
+
+
+class TestJobSpec(parameterized.TestCase):
+    """Tests job specs."""
+
+    def test_serialization_job_spec(self):
+        test_spec = new_jobspec(
+            name="test_job",
+            command="test command",
+            metadata=JobMetadata(
+                user_id="test_id",
+                project_id="test_project",
+                creation_time=datetime.now(),
+                resources={"test": 8.0},
+                priority=1,
+            ),
+        )
+        with tempfile.NamedTemporaryFile("w+b") as f:
+            serialize_jobspec(test_spec, f.name)
+            deserialized_jobspec = deserialize_jobspec(f=f.name)
+            for key in test_spec.__dataclass_fields__:
+                self.assertIn(key, deserialized_jobspec.__dict__)
+                self.assertEqual(deserialized_jobspec.__dict__[key], test_spec.__dict__[key])
+
+
+# Returns a new mock Popen for each subprocess.Popen call.
+def _mock_popen_fn(mock_spec: Dict[str, Dict]):
+    """Returns a callable that outputs mocked Popens for predetermined commands.
+
+    For example:
+        Input:
+            {'my_command': {'terminate.side_effect': ValueError}}
+        Result:
+            mock = subprocess.Popen('my_command')
+            mock.terminate()  # Raises ValueError.
+    """
+
+    def popen(cmd, **kwargs):
+        del kwargs
+        if cmd not in mock_spec:
+            raise ValueError(f"Don't know how to mock: {cmd}")
+        m = mock.MagicMock()
+        m.configure_mock(**mock_spec[cmd])
+        return m
+
+    return popen
+
+
+# Returns a new mock _PipedProcess.
+def _mock_piped_popen_fn(mock_spec: Dict[str, Dict]):
+    """See `_mock_popen_fn`."""
+    mock_popen_fn = _mock_popen_fn(mock_spec)
+
+    def piped_popen(cmd, f):
+        mock_fd = mock.MagicMock()
+        mock_fd.name = f
+        return _PipedProcess(popen=mock_popen_fn(cmd), fd=mock_fd)
+
+    return piped_popen
+
+
+class BastionTest(parameterized.TestCase):
+    """Tests Bastion."""
+
+    @contextlib.contextmanager
+    def _patch_bastion(self, mock_popen_spec: Optional[Dict] = None):
+        mocks = []
+        module_name = bastion.__name__
+
+        if mock_popen_spec:
+            mock_popen = mock.patch.object(subprocess, "Popen", autospec=True)
+            mock_popen.side_effect = _mock_popen_fn(mock_popen_spec)
+            mocks.extend(
+                [
+                    mock_popen,
+                    mock.patch(
+                        f"{module_name}._piped_popen",
+                        side_effect=_mock_piped_popen_fn(mock_popen_spec),
+                    ),
+                ]
+            )
+
+        class NoOpCleaner(Cleaner):
+            def sweep(self, jobs):
+                del jobs
+
+        def noop_upload_fn(*args, **kwargs):
+            del args, kwargs
+
+        with contextlib.ExitStack() as stack, tempfile.TemporaryDirectory() as tmpdir:
+            # Boilerplate to register multiple mocks at once.
+            for m in mocks:
+                stack.enter_context(m)
+
+            cfg = Bastion.default_config().set(
+                scheduler=JobScheduler.default_config().set(
+                    quota=config_for_function(mock_quota_config)
+                ),
+                cleaner=NoOpCleaner.default_config(),
+                uploader=Uploader.default_config().set(
+                    upload_fn=config_for_function(lambda: noop_upload_fn)
+                ),
+                output_dir=tmpdir,
+            )
+            yield cfg.instantiate()
+
+    @parameterized.product(
+        [
+            dict(
+                # Command has not terminated -- expect kill() to be called.
+                # We should not need to consult terminate() or poll().
+                popen_spec={
+                    "command": {
+                        "wait.return_value": None,
+                        "poll.side_effect": ValueError,
+                        "terminate.side_effect": ValueError,
+                    },
+                    # cleanup should have no effect here, so we just raise if it's ever used.
+                    "cleanup": {
+                        "poll.side_effect": ValueError,
+                        "terminate.side_effect": ValueError,
+                    },
+                },
+            ),
+            dict(
+                # Command has already terminated. Expect state to transition to PENDING and
+                # command_proc to be None.
+                popen_spec={
+                    "cleanup": {"poll.return_value": 0, "terminate.side_effect": ValueError},
+                },
+            ),
+        ],
+        user_state_exists=[False, True],
+    )
+    def test_pending(self, popen_spec, user_state_exists):
+        """Test PENDING state transitions.
+
+        1. If command_proc is still running, it should be terminated (killed).
+        2. The state should remain PENDING, command_proc must be None, and log file should be
+            uploaded.
+        """
+        mock_proc = _mock_piped_popen_fn(popen_spec)
+        job = Job(
+            spec=new_jobspec(
+                name="test_job",
+                command="command",
+                cleanup_command="cleanup",
+                metadata=JobMetadata(
+                    user_id="test_user",
+                    project_id="test_project",
+                    creation_time=datetime.now(),
+                    resources={"v4": 8},
+                ),
+            ),
+            state=JobState.PENDING,
+            command_proc=mock_proc("command", "test_command") if "command" in popen_spec else None,
+            cleanup_proc=mock_proc("cleanup", "test_cleanup") if "cleanup" in popen_spec else None,
+        )
+        patch_fns = mock.patch.multiple(
+            bastion.__name__,
+            _upload_job_state=mock.DEFAULT,
+            send_signal=mock.DEFAULT,
+        )
+        patch_tfio = mock.patch.multiple(
+            f"{bastion.__name__}.tf_io.gfile",
+            exists=mock.Mock(return_value=user_state_exists),
+            copy=mock.DEFAULT,
+            remove=mock.DEFAULT,
+        )
+        with self._patch_bastion(
+            popen_spec
+        ) as mock_bastion, patch_fns as mock_fns, patch_tfio as mock_tfio:
+            # Run a couple updates to test transition to PENDING and staying in PENDING.
+            for _ in range(2):
+                orig_command_proc = job.command_proc
+                updated_job = mock_bastion._update_single_job(job)
+                # Job should now be in pending.
+                self.assertEqual(updated_job.state, JobState.PENDING)
+                # Command should be None.
+                self.assertIsNone(updated_job.command_proc)
+
+                if orig_command_proc is not None:
+                    # Kill should have been called, and fd should have been closed.
+                    mock_fns["send_signal"].assert_called()
+                    self.assertTrue(
+                        orig_command_proc.fd.close.called  # pytype: disable=attribute-error
+                    )
+
+                    # Log should be uploaded if command was initially running.
+                    upload_call = mock.call(
+                        orig_command_proc.fd.name,
+                        os.path.join(
+                            mock_bastion._log_dir, os.path.basename(orig_command_proc.fd.name)
+                        ),
+                        overwrite=True,
+                    )
+                    mock_tfio["copy"].assert_has_calls([upload_call], any_order=False)
+
+                # Cleanup command should not be involved.
+                updated_job.cleanup_proc.popen.poll.assert_not_called()
+                updated_job.cleanup_proc.popen.terminate.assert_not_called()
+
+                updated_job = job
+
+    @parameterized.product(
+        [
+            dict(
+                popen_spec={
+                    # Runs for one update step and then completes.
+                    # terminate() raises, since we don't expect it to be called.
+                    "command": {
+                        "poll.side_effect": [None, 0],
+                        "terminate.side_effect": ValueError,
+                    },
+                    # cleanup should have no effect here, so we just raise if it's ever used.
+                    "cleanup": {
+                        "poll.side_effect": ValueError,
+                        "terminate.side_effect": ValueError,
+                    },
+                },
+                expect_poll_calls=2,
+            ),
+            dict(
+                popen_spec={
+                    # Command terminates instantly.
+                    "command": {
+                        "poll.return_value": 1,
+                        "terminate.side_effect": ValueError,
+                    },
+                    # cleanup should have no effect here, so we just raise if it's ever used.
+                    "cleanup": {
+                        "poll.side_effect": ValueError,
+                        "terminate.side_effect": ValueError,
+                    },
+                },
+                expect_poll_calls=1,
+            ),
+        ],
+        logfile_exists=[False, True],
+    )
+    def test_active(self, popen_spec, expect_poll_calls, logfile_exists):
+        """Test ACTIVE state transitions.
+
+        1. If command_proc is not running, it should be started. If a log file exists remotely, it
+            should be downloaded.
+        2. If command_proc is already running, stay in ACTIVE.
+        3. If command_proc is completed, move to CLEANING.
+        """
+        mock_proc = _mock_piped_popen_fn(popen_spec)
+        job = Job(
+            spec=new_jobspec(
+                name="test_job",
+                command="command",
+                cleanup_command="cleanup",
+                metadata=JobMetadata(
+                    user_id="test_user",
+                    project_id="test_job",
+                    creation_time=datetime.now(),
+                    resources={"v4": 8},
+                ),
+            ),
+            state=JobState.ACTIVE,
+            command_proc=None,  # Initially, command is None.
+            cleanup_proc=mock_proc("cleanup", "test_cleanup"),
+        )
+
+        def mock_tfio_exists(f):
+            if "logs" in f and os.path.basename(f) == "test_job":
+                return logfile_exists
+            return False
+
+        patch_fns = mock.patch.multiple(
+            bastion.__name__,
+            _upload_job_state=mock.DEFAULT,
+        )
+        patch_tfio = mock.patch.multiple(
+            f"{bastion.__name__}.tf_io.gfile",
+            exists=mock.MagicMock(side_effect=mock_tfio_exists),
+            copy=mock.DEFAULT,
+        )
+        with patch_fns, self._patch_bastion(popen_spec) as mock_bastion, patch_tfio as mock_tfio:
+            # Initially, job should have no command.
+            self.assertIsNone(job.command_proc)
+
+            # Run single update step to start the job.
+            updated_job = mock_bastion._update_single_job(job)
+
+            # Command should be started on the first update.
+            self.assertIsNotNone(updated_job.command_proc)
+            # Log should be downloaded if it exists.
+            download_call = mock.call(
+                os.path.join(mock_bastion._log_dir, job.spec.name),
+                os.path.join(_LOG_DIR, job.spec.name),
+                overwrite=True,
+            )
+            mock_tfio["copy"].assert_has_calls([download_call], any_order=False)
+
+            # Run until expected job completion.
+            for _ in range(expect_poll_calls - 1):
+                self.assertEqual(updated_job.state, JobState.ACTIVE)
+                updated_job = mock_bastion._update_single_job(updated_job)
+
+            # Job state should be CLEANING.
+            self.assertEqual(updated_job.state, JobState.CLEANING)
+
+    # pylint: disable-next=too-many-branches
+    def test_update_jobs(self):
+        """Tests the global update step."""
+
+        def popen_spec(command_poll=2, cleanup_poll=2):
+            return {
+                # Constructs a command_proc that "completes" after `command_poll` updates.
+                "command": {
+                    "wait.return_value": None,
+                    "poll.side_effect": [None] * (command_poll - 1) + [0],
+                    "terminate.side_effect": None,
+                },
+                # Constructs a cleanup_proc that completes after `cleanup_poll` updates.
+                "cleanup": {
+                    "poll.side_effect": [None] * (cleanup_poll - 1) + [0],
+                    "terminate.side_effect": ValueError,
+                },
+            }
+
+        def mock_proc(cmd, **kwargs):
+            fn = _mock_piped_popen_fn(popen_spec(**kwargs))
+            return fn(cmd, "test_file")
+
+        yesterday = datetime.now() - timedelta(days=1)
+
+        # Test state transitions w/ interactions between jobs (scheduling).
+        # See also `mock_quota_config` for mock project quotas and limits.
+        active_jobs = {
+            # This job will stay PENDING, since user "b" has higher priority.
+            "pending": Job(
+                spec=new_jobspec(
+                    name="pending",
+                    command="command",
+                    cleanup_command="cleanup",
+                    metadata=JobMetadata(
+                        user_id="a",
+                        project_id="project2",
+                        creation_time=yesterday + timedelta(seconds=3),
+                        resources={"v4": 12},  # Doesn't fit if "resume" job is scheduled.
+                    ),
+                ),
+                state=JobState.PENDING,
+                command_proc=None,  # No command proc for PENDING jobs.
+                cleanup_proc=None,
+            ),
+            # This job will go from PENDING to ACTIVE.
+            "resume": Job(
+                spec=new_jobspec(
+                    name="resume",
+                    command="command",
+                    cleanup_command="cleanup",
+                    metadata=JobMetadata(
+                        user_id="b",
+                        project_id="project2",
+                        creation_time=yesterday + timedelta(seconds=2),
+                        resources={"v4": 5},  # Fits within v4 budget in project2.
+                    ),
+                ),
+                state=JobState.PENDING,
+                command_proc=None,  # No command proc for PENDING jobs.
+                cleanup_proc=None,
+            ),
+            # This job will stay in ACTIVE, since it takes 2 updates to complete.
+            "active": Job(
+                spec=new_jobspec(
+                    name="active",
+                    command="command",
+                    cleanup_command="cleanup",
+                    metadata=JobMetadata(
+                        user_id="c",
+                        project_id="project2",
+                        creation_time=yesterday + timedelta(seconds=2),
+                        resources={"v3": 2},  # Fits within the v3 budget in project2.
+                    ),
+                ),
+                state=JobState.PENDING,
+                command_proc=mock_proc("command"),
+                cleanup_proc=None,  # No cleanup_proc for ACTIVE jobs.
+            ),
+            # This job will go from ACTIVE to PENDING, since it's using part of project2's v4
+            # quota, and "b" is requesting project2's v4 quota.
+            # Even though poll()+terminate() typically takes a few steps, we instead go through
+            # kill() to forcefully terminate within one step.
+            "preempt": Job(
+                spec=new_jobspec(
+                    name="preempt",
+                    command="command",
+                    cleanup_command="cleanup",
+                    metadata=JobMetadata(
+                        user_id="d",
+                        project_id="project1",
+                        creation_time=yesterday + timedelta(seconds=2),
+                        resources={"v4": 12},  # Uses part of project2 budget.
+                    ),
+                ),
+                state=JobState.ACTIVE,
+                command_proc=mock_proc("command"),
+                cleanup_proc=None,  # No cleanup_proc for ACTIVE.
+            ),
+            # This job will go from ACTIVE to CLEANING.
+            "cleaning": Job(
+                spec=new_jobspec(
+                    name="cleaning",
+                    command="command",
+                    cleanup_command="cleanup",
+                    metadata=JobMetadata(
+                        user_id="f",
+                        project_id="project2",
+                        creation_time=yesterday + timedelta(seconds=2),
+                        resources={"v3": 2},  # Fits within the v3 budget in project2.
+                    ),
+                ),
+                state=JobState.ACTIVE,
+                command_proc=mock_proc("command", command_poll=1),
+                cleanup_proc=None,
+            ),
+            # This job will go from CANCELLING to CLEANING.
+            # Note that CANCELLING jobs will not be "pre-empted" by scheduler; even though this job
+            # is out-of-budget, it will go to CLEANING instead of SUSPENDING.
+            "cleaning_cancel": Job(
+                spec=new_jobspec(
+                    name="cleaning_cancel",
+                    command="command",
+                    cleanup_command="cleanup",
+                    metadata=JobMetadata(
+                        user_id="g",
+                        project_id="project2",
+                        creation_time=yesterday + timedelta(seconds=4),
+                        resources={"v4": 100},  # Does not fit into v4 budget.
+                    ),
+                ),
+                state=JobState.CANCELLING,
+                command_proc=mock_proc("command", command_poll=1),
+                cleanup_proc=None,
+            ),
+            # This job will go from CLEANING to COMPLETED.
+            "completed": Job(
+                spec=new_jobspec(
+                    name="completed",
+                    command="command",
+                    cleanup_command="cleanup",
+                    metadata=JobMetadata(
+                        user_id="e",
+                        project_id="project3",
+                        creation_time=yesterday + timedelta(seconds=2),
+                        resources={"v5": 2.5},
+                    ),
+                ),
+                state=JobState.CLEANING,
+                command_proc=None,
+                cleanup_proc=mock_proc("cleanup", cleanup_poll=1),  # Should have cleanup_proc.
+            ),
+        }
+        # Pretend that only 'cleaning_cancel' came from a user state.
+        jobs_with_user_states = {"cleaning_cancel"}
+
+        # Patch all network calls and utils.
+        patch_fns = mock.patch.multiple(
+            bastion.__name__,
+            _upload_job_state=mock.DEFAULT,
+            send_signal=mock.DEFAULT,
+        )
+        patch_tfio = mock.patch.multiple(
+            f"{bastion.__name__}.tf_io.gfile",
+            exists=mock.DEFAULT,
+            copy=mock.DEFAULT,
+            remove=mock.DEFAULT,
+        )
+        with self._patch_bastion(
+            popen_spec()
+        ) as mock_bastion, patch_fns as mock_fns, patch_tfio as mock_tfio:
+            mock_bastion._active_jobs = active_jobs
+            mock_bastion._jobs_with_user_states = jobs_with_user_states
+            mock_bastion._update_jobs()
+
+            # Ensure _active_jobs membership stays same.
+            self.assertEqual(mock_bastion._active_jobs.keys(), active_jobs.keys())
+
+            expected_states = {
+                "pending": JobState.PENDING,
+                "resume": JobState.ACTIVE,
+                "active": JobState.ACTIVE,
+                "preempt": JobState.PENDING,
+                "cleaning": JobState.CLEANING,
+                "cleaning_cancel": JobState.CLEANING,
+                "completed": JobState.COMPLETED,
+            }
+            for job_name in active_jobs:
+                self.assertEqual(
+                    mock_bastion._active_jobs[job_name].state, expected_states[job_name]
+                )
+
+            for job in mock_bastion._active_jobs.values():
+                # For jobs that are ACTIVE, expect command_proc to be non-None.
+                if job.state == JobState.ACTIVE:
+                    self.assertIsNotNone(job.command_proc)
+                    self.assertIsNone(job.cleanup_proc)
+                # For jobs that are COMPLETED, expect both procs to be None.
+                elif job.state == JobState.COMPLETED:
+                    self.assertIsNone(job.command_proc)
+                    self.assertIsNone(job.cleanup_proc)
+
+                    # Remote jobspec should not be deleted until gc.
+                    for delete_call in mock_tfio["remove"].mock_calls:
+                        self.assertNotIn(
+                            os.path.join(_JOB_DIR, job.spec.name),
+                            delete_call.args,
+                        )
+
+                # User states should only be deleted if the job's state was read from
+                # user_state_dir.
+                self.assertEqual(
+                    any(
+                        os.path.join(mock_bastion._user_state_dir, job.spec.name)
+                        in delete_call.args
+                        for delete_call in mock_tfio["remove"].mock_calls
+                    ),
+                    job.spec.name in mock_bastion._jobs_with_user_states,
+                )
+
+                # For jobs that went from ACTIVE to PENDING, expect kill() to have been called.
+                if active_jobs[job.spec.name] == JobState.ACTIVE and job.state == JobState.PENDING:
+                    mock_fns["send_signal"].assert_called()
+                    self.assertFalse(
+                        active_jobs[
+                            job.spec.name
+                        ].command_proc.popen.terminate.called  # pytype: disable=attribute-error
+                    )
+
+            for job_name in active_jobs:
+                history_file = os.path.join(mock_bastion._job_history_dir, job_name)
+                if job_name in ("active", "pending"):
+                    # The 'active'/'pending' jobs do not generate hisotry.
+                    self.assertFalse(os.path.exists(history_file), msg=history_file)
+                else:
+                    self.assertTrue(os.path.exists(history_file), msg=history_file)
+                    with open(history_file, "r", encoding="utf-8") as f:
+                        history = f.read()
+                        expected_msg = {
+                            "resume": "ACTIVE: start process command",
+                            "preempt": "PENDING: pre-empting",
+                            "cleaning": "CLEANING: process finished",
+                            "cleaning_cancel": "CLEANING: process terminated",
+                            "completed": "COMPLETED: cleanup finished",
+                        }
+                        self.assertIn(expected_msg[job_name], history)
+
+            all_history_files = []
+            for project_id in [f"project{i}" for i in range(1, 3)]:
+                project_history_dir = os.path.join(mock_bastion._project_history_dir, project_id)
+                project_history_files = list(os.scandir(project_history_dir))
+                for history_file in project_history_files:
+                    with open(history_file, "r", encoding="utf-8") as f:
+                        history = f.read()
+                        print(f"[{project_id}] {history}")
+                all_history_files.extend(project_history_files)
+            # "project1" and "project2".
+            self.assertLen(all_history_files, 2)
+
+    def test_gc_jobs(self):
+        """Tests GC mechanism.
+
+        1. Only PENDING/COMPLETED jobs are cleaned.
+        2. COMPLETED jobs that finish gc'ing should remove jobspecs.
+        """
+        # Note: command_proc and cleanup_proc shouldn't matter for GC. We only look at state +
+        # resources.
+        active_jobs = {}
+        init_job_states = {
+            "pending": JobState.PENDING,
+            "active": JobState.ACTIVE,
+            "cleaning": JobState.CLEANING,
+            "completed": JobState.COMPLETED,
+            "completed_gced": JobState.COMPLETED,
+        }
+        for job_name, job_state in init_job_states.items():
+            active_jobs[job_name] = Job(
+                spec=new_jobspec(
+                    name=job_name,
+                    command="command",
+                    cleanup_command="cleanup",
+                    metadata=JobMetadata(
+                        user_id=f"{job_name}_user",
+                        project_id="project1",
+                        creation_time=datetime.now() - timedelta(days=1),
+                        resources={"v4": 1},
+                    ),
+                ),
+                state=job_state,
+                command_proc=None,
+                cleanup_proc=None,
+            )
+        # We pretend that only some jobs are "fully gc'ed".
+        fully_gced = ["completed_gced"]
+
+        patch_tfio = mock.patch.multiple(
+            f"{bastion.__name__}.tf_io.gfile",
+            remove=mock.DEFAULT,
+        )
+        with self._patch_bastion() as mock_bastion, patch_tfio as mock_tfio:
+
+            def mock_clean(jobs: Dict[str, ResourceMap]) -> Sequence[str]:
+                self.assertTrue(
+                    all(
+                        active_jobs[job_name].state in {JobState.PENDING, JobState.COMPLETED}
+                        for job_name in jobs
+                    )
+                )
+                return fully_gced
+
+            with mock.patch.object(mock_bastion, "_cleaner") as mock_cleaner:
+                mock_cleaner.configure_mock(**{"sweep.side_effect": mock_clean})
+                mock_bastion._active_jobs = active_jobs
+                mock_bastion._gc_jobs()
+
+            # Ensure that each fully GC'ed COMPLETED job deletes jobspec and state.
+            for job_name in fully_gced:
+                deleted_state = any(
+                    os.path.join(mock_bastion._state_dir, job_name) in delete_call.args
+                    for delete_call in mock_tfio["remove"].mock_calls
+                )
+                deleted_jobspec = any(
+                    os.path.join(mock_bastion._active_dir, job_name) in delete_call.args
+                    for delete_call in mock_tfio["remove"].mock_calls
+                )
+                self.assertEqual(
+                    active_jobs[job_name].state == JobState.COMPLETED,
+                    deleted_state and deleted_jobspec,
+                )
+
+
+class StartBastionJobTest(parameterized.TestCase):
+    """Tests StartBastionJob."""
+
+    def test_execute(self):
+        mock_bastion = mock.MagicMock()
+        cfg = bastion.StartBastionJob.default_config().set(
+            name="test",
+            bastion=config_for_function(lambda: mock_bastion),
+            max_tries=1,
+            retry_interval=1,
+        )
+        job = cfg.instantiate()
+        job.execute()
+        self.assertTrue(mock_bastion.execute.called)
+
+
+def _mock_submit_config():
+    return bastion.SubmitBastionJob.default_config().set(
+        name="test",
+        job_name="test-job",
+        job_spec_file="spec",
+        max_tries=1,
+        retry_interval=1,
+        bastion_dir="test-output",
+    )
+
+
+class SubmitBastionJobTest(parameterized.TestCase):
+    """Tests SubmitBastionJob."""
+
+    @parameterized.parameters(True, False)
+    def test_execute(self, spec_exists):
+        cfg = _mock_submit_config()
+        job = cfg.instantiate()
+
+        patch_tfio = mock.patch.multiple(
+            f"{bastion.__name__}.tf_io.gfile",
+            exists=mock.MagicMock(return_value=spec_exists),
+            copy=mock.DEFAULT,
+        )
+        with patch_tfio as mock_tfio:
+            job.execute()
+            if not spec_exists:
+                mock_tfio["copy"].assert_called_with(
+                    cfg.job_spec_file,
+                    os.path.join(job._job_dir(), "active", cfg.job_name),
+                )
+            else:
+                mock_tfio["copy"].assert_not_called()
+
+    @parameterized.parameters(True, False)
+    def test_delete(self, spec_exists):
+        cfg = _mock_submit_config()
+        job = cfg.instantiate()
+        patch_tfio = mock.patch.multiple(
+            f"{bastion.__name__}.tf_io.gfile",
+            exists=mock.MagicMock(side_effect=[spec_exists, False]),
+            copy=mock.DEFAULT,
+        )
+        patch_fns = mock.patch.multiple(
+            bastion.__name__,
+            _upload_job_state=mock.DEFAULT,
+        )
+        with patch_tfio, patch_fns as mock_fns:
+            job._delete()
+            if not spec_exists:
+                mock_fns["_upload_job_state"].assert_not_called()
+            else:
+                mock_fns["_upload_job_state"].assert_called_with(
+                    cfg.job_name,
+                    JobState.CANCELLING,
+                    remote_dir=os.path.join(job._job_dir(), "user_states"),
+                )

--- a/axlearn/cloud/common/quota.py
+++ b/axlearn/cloud/common/quota.py
@@ -4,56 +4,74 @@
 
 import re
 from collections import defaultdict
-from typing import Dict, List
+from dataclasses import dataclass
+from typing import List, Protocol
 
-import tensorflow as tf
 import toml
+from tensorflow import io as tf_io
+
+from axlearn.cloud.common.types import ProjectResourceMap, ResourceMap
 
 QUOTA_CONFIG_PATH = "project-quotas/project-quotas.config"
 
 
-def get_resource_limits(path: str) -> Dict[str, Dict[str, float]]:
+@dataclass
+class QuotaInfo:
+    """Quota information for job scheduling."""
+
+    # A mapping from resource type to total resource limits.
+    total_resources: ResourceMap
+    # A nested mapping. Key is project identifier, value is mapping from resource type to allocated
+    # amount of resources.
+    project_resources: ProjectResourceMap
+
+
+class QuotaFn(Protocol):
+    def __call__(self) -> QuotaInfo:
+        """A callable that returns quota information for scheduling."""
+
+
+def get_resource_limits(path: str) -> QuotaInfo:
     """Attempts to read resource limits, both total and per-project.
 
     Args:
         path: Absolute path to the quota config file.
 
     Returns:
-        A dict with the following keys:
-        - resource_limits: A mapping from resource type to total resource limits.
-        - project_resources: A nested mapping. Key is project identifier, value is mapping from
-            resource type to allocated amount of resources (as percentages).
+        QuotaInfo for scheduling.
 
     Raises:
         ValueError: If unable to parse quota config file.
     """
-    with tf.io.gfile.GFile(path, mode="r") as f:
+    with tf_io.gfile.GFile(path, mode="r") as f:
         cfg = toml.loads(f.read())
         if cfg["toml-schema"]["version"] == "1":
-            total_resources = cfg["total_resources"]
-            project_resources = cfg["project_resources"]
-
-            # Project resources are typically expressed as percentages.
-            # Here we convert them to actual values.
-            total_project_resources = defaultdict(float)
-            for resources in project_resources.values():
-                for resource_type, fraction in resources.items():
-                    value = fraction * total_resources[resource_type]
-                    total_project_resources[resource_type] += value
-                    resources[resource_type] = value
-
-            for resource_type, total in total_project_resources.items():
-                if total > total_resources[resource_type]:
-                    raise ValueError(
-                        f"Sum of {resource_type} project resources ({total}) "
-                        f"exceeds total ({total_resources[resource_type]})"
-                    )
-
-            return dict(
-                total_resources=total_resources,
-                project_resources=project_resources,
+            return _convert_and_validate_resources(
+                QuotaInfo(
+                    total_resources=cfg["total_resources"],
+                    project_resources=cfg["project_resources"],
+                )
             )
         raise ValueError(f"Unsupported schema version {cfg['toml-schema']['version']}")
+
+
+def _convert_and_validate_resources(info: QuotaInfo) -> QuotaInfo:
+    # Project resources are typically expressed as percentages.
+    # Here we convert them to actual values. Conversion happens in-place.
+    total_project_resources = defaultdict(float)
+    for resources in info.project_resources.values():
+        for resource_type, fraction in resources.items():
+            value = fraction * float(info.total_resources[resource_type])
+            total_project_resources[resource_type] += value
+            resources[resource_type] = value
+
+    for resource_type, total in total_project_resources.items():
+        if total > info.total_resources[resource_type]:
+            raise ValueError(
+                f"Sum of {resource_type} project resources ({total}) "
+                f"exceeds total ({info.total_resources[resource_type]})"
+            )
+    return info
 
 
 def get_user_projects(path: str, user_id: str) -> List[str]:
@@ -69,7 +87,7 @@ def get_user_projects(path: str, user_id: str) -> List[str]:
     Raises:
         ValueError: If unable to parse quota config file.
     """
-    with tf.io.gfile.GFile(path, mode="r") as f:
+    with tf_io.gfile.GFile(path, mode="r") as f:
         cfg = toml.loads(f.read())
         if cfg["toml-schema"]["version"] == "1":
             user_in_projects = []

--- a/axlearn/cloud/common/quota_test.py
+++ b/axlearn/cloud/common/quota_test.py
@@ -8,7 +8,7 @@ from typing import Sequence
 import toml
 from absl.testing import parameterized
 
-from axlearn.cloud.common.quota import get_resource_limits, get_user_projects
+from axlearn.cloud.common.quota import QuotaInfo, get_resource_limits, get_user_projects
 
 _mock_config = {
     "toml-schema": {"version": "1"},
@@ -33,7 +33,7 @@ class QuotaUtilsTest(parameterized.TestCase):
 
     def test_resource_limits(self):
         # Make sure fractions are converted properly.
-        expected = dict(
+        expected = QuotaInfo(
             total_resources=dict(resource_type1=16, resource_type2=8),
             project_resources=dict(
                 team1=dict(resource_type1=8),

--- a/axlearn/cloud/common/uploader.py
+++ b/axlearn/cloud/common/uploader.py
@@ -1,0 +1,97 @@
+# Copyright © 2023 Apple Inc.
+
+"""A simple artifact uploader."""
+
+import multiprocessing
+import time
+from typing import Protocol
+
+from absl import logging
+
+from axlearn.common.config import REQUIRED, Configurable, InstantiableConfig, Required, config_class
+
+
+class UploadFn(Protocol):
+    def __call__(self, *, src_dir: str, dst_dir: str):
+        """Uploads contents of `src_dir` to `dst_dir`."""
+
+
+def with_interval(upload_fn: UploadFn, interval_seconds: int = 10) -> UploadFn:
+    """Wraps `upload_fn` with a loop that uploads every `interval_seconds`."""
+
+    def fn(*, src_dir: str, dst_dir: str):
+        upload_s = 0
+        while True:
+            logging.log_every_n(
+                logging.INFO,
+                "Uploading outputs %s -> %s. Last duration: %s",
+                6,
+                src_dir,
+                dst_dir,
+                upload_s,
+            )
+            start = time.time()
+            try:
+                upload_fn(src_dir=src_dir, dst_dir=dst_dir)
+            except Exception as e:  # pylint: disable=broad-except
+                logging.warning("Upload failed: %s", e)
+            upload_s = time.time() - start
+            if upload_s > interval_seconds:
+                logging.warning(
+                    "Uploading outputs exceeded interval: %s > %s",
+                    upload_s,
+                    interval_seconds,
+                )
+            time.sleep(max(0, interval_seconds - upload_s))
+
+    return fn
+
+
+class Uploader(Configurable):
+    """A utility to periodically upload artifacts."""
+
+    @config_class
+    class Config(Configurable.Config):
+        """Configures Uploader."""
+
+        src_dir: Required[str] = REQUIRED
+        dst_dir: Required[str] = REQUIRED
+        upload_fn: Required[InstantiableConfig[UploadFn]] = REQUIRED
+
+    def __init__(self, cfg: Config):
+        super().__init__(cfg)
+        cfg = self.config
+        self._upload_proc = None
+        self._upload_fn = cfg.upload_fn.instantiate()
+
+    def __call__(self):
+        """Uploads outputs from `self.config.src_dir` to `self.config.dst_dir`.
+
+        Internally, this uses a separate process to periodically perform the upload without
+        blocking. This can be invoked multiple times to poll the status of the upload process and
+        restart it if it has terminated.
+
+        The upload implementation depends on `self.config.upload_fn`.
+        """
+        cfg: Uploader.Config = self.config
+
+        if self._upload_proc is not None:
+            self._upload_proc.join(timeout=0)
+            if not self._upload_proc.is_alive():
+                logging.info("Upload process died, removing...")
+                self._upload_proc.kill()
+                self._upload_proc.join()
+                self._upload_proc = None
+                logging.info("Upload process removed. Will restart...")
+
+        if self._upload_proc is None:
+            logging.info("Starting upload process.")
+            self._upload_proc = multiprocessing.Process(
+                target=self._upload_fn,
+                kwargs=dict(src_dir=cfg.src_dir, dst_dir=cfg.dst_dir),
+                daemon=True,
+            )
+            self._upload_proc.start()
+            logging.info("Upload process started.")
+        else:
+            logging.info("Upload process is still running.")

--- a/axlearn/cloud/common/uploader_test.py
+++ b/axlearn/cloud/common/uploader_test.py
@@ -1,0 +1,46 @@
+# Copyright © 2023 Apple Inc.
+
+"""Tests artifact uploader."""
+# pylint: disable=protected-access
+
+from unittest import mock
+
+from absl.testing import parameterized
+
+from axlearn.cloud.common.uploader import Uploader
+from axlearn.common.config import config_for_function
+
+
+class UploaderTest(parameterized.TestCase):
+    """Tests Uploader."""
+
+    def test_upload(self):
+        mock_upload_fn = mock.Mock()
+        mock_proc = mock.Mock()
+        mock_proc.is_alive.side_effect = [True, False]
+        with mock.patch("multiprocessing.Process", return_value=mock_proc) as mock_multiproc:
+            cfg = Uploader.default_config().set(
+                src_dir="test-src",
+                dst_dir="test-dst",
+                upload_fn=config_for_function(lambda: mock_upload_fn),
+            )
+            up = cfg.instantiate()
+
+            # First call should start the process.
+            up()
+            self.assertEqual(mock_proc.start.call_count, 1)
+            self.assertIsNotNone(up._upload_proc)
+            self.assertEqual(
+                dict(src_dir="test-src", dst_dir="test-dst"),
+                mock_multiproc.call_args.kwargs["kwargs"],
+            )
+
+            # Second call should do nothing, since process is still alive.
+            up()
+            self.assertEqual(mock_proc.start.call_count, 1)
+            self.assertIsNotNone(up._upload_proc)
+
+            # Third call should restart the process.
+            up()
+            self.assertEqual(mock_proc.start.call_count, 2)
+            self.assertIsNotNone(up._upload_proc)

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -1,32 +1,8 @@
 # Copyright © 2023 Apple Inc.
 
-"""Launches a bastion VM and executes a command on it.
+"""Launches a bastion VM on Google Cloud Platform (GCP).
 
-We use GCS as a registry for jobs that have been submitted to bastion. This ensures that if the
-bastion is pre-empted, it can restart and resume monitoring the same jobs. We assume that jobs are
-generally resumable via invoking the same command.
-
-More concretely, the submit flow works as follows:
-1. The bastion is started by using `axlearn gcp bastion create --name=...`.
-    This provisions (creates) and starts the bastion on a remote VM, with the given name.
-2. User submits a job using `axlearn gcp bastion submit --spec=...`.
-    This simply uploads a job spec to a GCS bucket (serialized via `BastionJobSpec`).
-3. Bastion pulls latest docker image (if just started), and polls the bucket in GCS. Each update, it
-    syncs all new jobspecs from GCS and runs them asynchronously inside the docker container. Log
-    outputs are emitted to GCS.
-4. Once a job is completed, its corresponding jobspec is removed from the GCS job registry. Log
-    outputs are also synced to GCS.
-5. To stop a job, run `axlearn gcp bastion cancel --job_name=...`, which simply writes a
-    "cancelling" statefile (serialized via `JobState`) to GCS. The job will be terminated, and any
-    configured "cleanup command" will be run (e.g. to cleanup external resources). Writing a
-    "cancelling" statefile is necessary to ensure that cleanup commands can be re-run if the bastion
-    is pre-empted midway.
-
-Note that emitted logs are "client-side" logs, i.e., logs visible from the bastion. Jobs that use
-remote compute like TPUs are expected to sync their own artifacts/logs to a user-accessible location
-(see tpu_runner for an example). Jobs are also expected to handle retries on their own.
-
-The bastion itself is pre-emptible; on restart, it will sync in-flight jobs from GCS and run them.
+See `axlearn/cloud/common/bastion.py` for bastion details.
 
 Possible actions: [create|delete|start|stop|submit|cancel]
 
@@ -73,23 +49,6 @@ Examples:
         --bundler_spec=dockerfile=Dockerfile \
         --bundler_spec=target=bastion
 
-The following paths may provide useful debugging information:
-
-    BUCKET=gs://my-bucket/my-bastion-name
-
-    Active jobspecs: $BUCKET/jobs/active/
-    Complete jobspecs: $BUCKET/jobs/complete/
-
-    Active job states: $BUCKET/jobs/states/
-    User written job states: $BUCKET/jobs/user_states/
-
-    Bastion logs: $BUCKET/logs/$BASTION
-    Job logs: $BUCKET/logs/<job_name>
-    Cleanup command logs: $BUCKET/logs/<job_name>.cleanup
-
-    Job scheduling history: $BUCKET/history/jobs/<job_name>
-    Project scheduling history: $BUCKET/history/projects/
-
 To test changes to bastion:
 
     # 1. Build a custom image.
@@ -127,62 +86,61 @@ On "start" vs "create":
 
 """
 # pylint: disable=consider-using-with,too-many-branches,too-many-instance-attributes,too-many-lines
-import collections
-import dataclasses
-import enum
 import functools
-import json
-import multiprocessing
 import os
 import re
 import shlex
-import signal
 import subprocess
-import tempfile
 import time
-from concurrent.futures import ThreadPoolExecutor, wait
-from datetime import datetime, timezone
-from subprocess import CalledProcessError
-from typing import IO, Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Sequence
 
-import tensorflow as tf
 from absl import app, flags, logging
 
+from axlearn.cloud.common.bastion import _LOG_DIR, Bastion, StartBastionJob
+from axlearn.cloud.common.bastion import SubmitBastionJob as BaseSubmitBastionJob
+from axlearn.cloud.common.bastion import bastion_job_flags, deserialize_jobspec
 from axlearn.cloud.common.bundler import DockerBundler, get_bundler_config
-from axlearn.cloud.common.quota import QUOTA_CONFIG_PATH
-from axlearn.cloud.common.scheduler import JobMetadata, JobScheduler, ResourceMap, Scheduler
-from axlearn.cloud.common.utils import configure_logging, parse_action, send_signal
+from axlearn.cloud.common.quota import QUOTA_CONFIG_PATH, get_resource_limits
+from axlearn.cloud.common.scheduler import JobScheduler
+from axlearn.cloud.common.uploader import Uploader, with_interval
+from axlearn.cloud.common.utils import configure_logging, parse_action
 from axlearn.cloud.gcp.config import gcp_settings
-from axlearn.cloud.gcp.job import CPUJob, GCPJob, docker_command
-from axlearn.cloud.gcp.tpu_cleaner import Cleaner, TPUCleaner
-from axlearn.cloud.gcp.utils import common_flags
+from axlearn.cloud.gcp.job import CPUJob, docker_command
+from axlearn.cloud.gcp.tpu_cleaner import TPUCleaner
+from axlearn.cloud.gcp.utils import catch_auth, common_flags, get_credentials
 from axlearn.cloud.gcp.vm import _compute_resource, create_vm, delete_vm, get_vm_node
-from axlearn.common.config import REQUIRED, Required, config_class
+from axlearn.common.config import REQUIRED, Required, config_class, config_for_function
 
 _SHARED_BASTION_SUFFIX = "shared-bastion"
-_LATEST_BASTION_VERSION = 1  # Determines job schema (see BastionJobSpec).
-_LOG_DIR = "/var/tmp/logs"  # Use /var/tmp/ since /tmp/ is cleared every 10 days.
-_JOB_DIR = "/var/tmp/jobs"
+
+FLAGS = flags.FLAGS
 
 
-def _private_flags():
-    common_flags()
-    FLAGS.set_default("project", gcp_settings("project", required=False))
-    FLAGS.set_default("zone", gcp_settings("zone", required=False))
+def _private_flags(flag_values: flags.FlagValues = FLAGS):
+    common_flags(flag_values=flag_values)
+    bastion_job_flags(flag_values=flag_values)
+    flag_values.set_default("project", gcp_settings("project", required=False))
+    flag_values.set_default("zone", gcp_settings("zone", required=False))
 
-    flags.DEFINE_string("name", None, "Name of bastion.", required=True)
-    flags.DEFINE_string("job_name", None, "Name of job.")
-    flags.DEFINE_string("vm_type", "n2-standard-128", "Machine spec to boot for VM.")
-    flags.DEFINE_integer("disk_size", 256, "VM disk size in GB.")
-    flags.DEFINE_integer("max_tries", 1, "Max attempts to run the command.")
-    flags.DEFINE_integer("retry_interval", 60, "Interval in seconds between tries.")
-    flags.DEFINE_string("spec", None, "Path to a job spec.")
-    flags.DEFINE_bool("dry_run", False, "Whether to run with dry-run scheduling.")
+    flags.DEFINE_bool(
+        "dry_run", False, "Whether to run with dry-run scheduling.", flag_values=flag_values
+    )
+    flags.DEFINE_string(
+        "vm_type", "n2-standard-128", "Machine spec to boot for VM.", flag_values=flag_values
+    )
+    flags.DEFINE_integer("disk_size", 256, "VM disk size in GB.", flag_values=flag_values)
+    flags.DEFINE_integer(
+        "max_tries", 1, "Max attempts to run the command.", flag_values=flag_values
+    )
+    flags.DEFINE_integer(
+        "retry_interval", 60, "Interval in seconds between tries.", flag_values=flag_values
+    )
     flags.DEFINE_multi_string(
         "bundler_spec",
         [],
         "Bundler spec provided as key=value. "
         "Refer to each bundler's `from_spec` method docstring for details.",
+        flag_values=flag_values,
     )
 
     def _validate_name(name: str):
@@ -195,9 +153,13 @@ def _private_flags():
         "name",
         _validate_name,
         message="Must be < 64 chars and match <name>-bastion.",
+        flag_values=flag_values,
     )
     flags.register_validator(
-        "max_tries", lambda tries: tries > 0, message="Max tries must be positive."
+        "max_tries",
+        lambda tries: tries > 0,
+        message="Max tries must be positive.",
+        flag_values=flag_values,
     )
 
 
@@ -212,120 +174,25 @@ def shared_bastion_name() -> str:
     )
 
 
-FLAGS = flags.FLAGS
-
-
-# Subclass str to be JSON serializable: https://stackoverflow.com/a/51976841
-class JobState(str, enum.Enum):
-    """See BastionJob._update_job for state handling."""
-
-    # Job is queued. Any running command will be forcefully terminated.
-    PENDING = "PENDING"
-    # Job is about to run, or currently running.
-    ACTIVE = "ACTIVE"
-    # Job is cancelling. Command is terminating.
-    CANCELLING = "CANCELLING"
-    # Job has completed/termianted the command, is running cleanup command (if any).
-    CLEANING = "CLEANING"
-    # Job is complete.
-    COMPLETED = "COMPLETED"
-
-
-@dataclasses.dataclass
-class BastionJobSpec:
-    """Represents a job that is executed by bastion."""
-
-    # Version to handle schema changes.
-    version: int
-    # Name of the job (aka job_name).
-    name: str
-    # Command to run.
-    command: str
-    # Command to run when job completes (either normally or cancelled).
-    cleanup_command: Optional[str]
-    # Metadata related to a bastion job.
-    metadata: JobMetadata
-
-
-def new_jobspec(
-    *,
-    name: str,
-    command: str,
-    metadata: JobMetadata,
-    cleanup_command: Optional[str] = None,
-) -> BastionJobSpec:
-    return BastionJobSpec(
-        version=_LATEST_BASTION_VERSION,
-        name=name,
-        command=command,
-        cleanup_command=cleanup_command,
-        metadata=metadata,
-    )
-
-
-def serialize_jobspec(spec: BastionJobSpec, f: Union[str, IO]):
-    """Writes job spec to filepath or file."""
-    if isinstance(f, str):
-        with open(f, "w", encoding="utf-8") as fd:
-            serialize_jobspec(spec, fd)
-            return
-
-    json.dump(dataclasses.asdict(spec), f, default=str)
-    f.flush()
-
-
-def deserialize_jobspec(f: Union[str, IO]) -> BastionJobSpec:
-    """Loads job spec from filepath or file."""
-    if isinstance(f, str):
-        with open(f, "r", encoding="utf-8") as fd:
-            return deserialize_jobspec(fd)
-
-    data = json.load(f)
-    if data["version"] == _LATEST_BASTION_VERSION:
-        data["metadata"]["creation_time"] = datetime.strptime(
-            data["metadata"]["creation_time"], "%Y-%m-%d %H:%M:%S.%f"
-        )
-        return BastionJobSpec(
-            version=data["version"],
-            name=data["name"],
-            command=data["command"],
-            cleanup_command=data.get("cleanup_command", None),
-            metadata=JobMetadata(**data["metadata"]),
-        )
-    raise ValueError(f"Unsupported version: {data['version']}")
-
-
-def _download_jobspec(
-    job_name: str, *, remote_dir: str, local_dir: str = _JOB_DIR
-) -> BastionJobSpec:
-    """Loads jobspec from gs path."""
-    remote_file = os.path.join(remote_dir, job_name)
-    local_file = os.path.join(local_dir, job_name)
-    tf.io.gfile.copy(remote_file, local_file, overwrite=True)
-    return deserialize_jobspec(local_file)
-
-
-def _upload_jobspec(spec: BastionJobSpec, *, remote_dir: str, local_dir: str = _JOB_DIR):
-    """Uploads jobspec to gs path."""
-    local_file = os.path.join(local_dir, spec.name)
-    remote_file = os.path.join(remote_dir, spec.name)
-    serialize_jobspec(spec, local_file)
-    tf.io.gfile.copy(local_file, remote_file, overwrite=True)
-
-
-def _bastion_dir(bastion: str) -> str:
+def output_dir(bastion: str) -> str:
     """Directory in gs where jobs are recorded."""
     return os.path.join("gs://", gcp_settings("permanent_bucket"), bastion)
 
 
-def _sync_dir(
-    *, src: str, dst: str, max_tries: int = 5, interval_s: float = 30, timeout_s: float = 5 * 60
+def _gsutil_rsync(
+    *,
+    src_dir: str,
+    dst_dir: str,
+    max_tries: int = 5,
+    interval_s: float = 30,
+    timeout_s: float = 5 * 60,
 ):
-    """Syncs from src to dst."""
+    """An upload fn that uses `gsutil rsync`."""
+
     for i in range(max_tries):
         # Ensure trailing slash, if not already present, for rsync.
-        src = os.path.join(src, "")
-        dst = os.path.join(dst, "")
+        src = os.path.join(src_dir, "")
+        dst = os.path.join(dst_dir, "")
         # Attempt to sync, raising TimeoutError on timeout.
         proc = subprocess.run(
             ["gsutil", "-m", "rsync", "-r", src, dst],
@@ -344,643 +211,6 @@ def _sync_dir(
     raise ValueError(f"Failed to sync jobs from {src}")
 
 
-@dataclasses.dataclass
-class _PipedProcess:
-    """A process with outputs piped to a file."""
-
-    popen: subprocess.Popen
-    fd: IO
-
-
-def _piped_popen(cmd: str, f: str) -> _PipedProcess:
-    """Runs cmd in the background, piping stdout+stderr to a file."""
-    # Open with "a" to append to an existing logfile, if any.
-    fd = open(f, "a", encoding="utf-8")
-    popen = subprocess.Popen(shlex.split(cmd), stdout=fd, stderr=subprocess.STDOUT)
-    return _PipedProcess(popen=popen, fd=fd)
-
-
-def _is_proc_complete(proc: _PipedProcess) -> bool:
-    """Returns True iff proc exited with returncode."""
-    return proc.popen.poll() is not None
-
-
-def _catch_with_error_log(fn, *args, **kwargs) -> Any:
-    """Wraps a fn with try/except and log the error instead of raising.
-
-    Some non-critical operations like uploading logs can be flaky and shouldn't break the bastion.
-    If an exception is caught, the error will be logged and None will be returned. Otherwise, the
-    function's outputs will be returned.
-    """
-    try:
-        return fn(*args, **kwargs)
-    except Exception as e:  # pylint: disable=broad-except
-        logging.error("[Caught] %s failed with error: %s", fn, e)
-    return None
-
-
-@dataclasses.dataclass
-class Job:
-    spec: BastionJobSpec
-    state: JobState
-    # *_proc can be None prior to commands being started.
-    command_proc: Optional[_PipedProcess]
-    cleanup_proc: Optional[_PipedProcess]
-
-
-def _download_job_state(job_name: str, *, remote_dir: str) -> JobState:
-    """Loads job state from gs path."""
-    remote_file = os.path.join(remote_dir, job_name)
-    try:
-        # Note: tf.io.gfile.GFile seems to hit libcurl errors with ThreadPoolExecutor.
-        with tempfile.NamedTemporaryFile("r+") as f:
-            tf.io.gfile.copy(remote_file, f.name, overwrite=True)
-            state = f.read().strip().upper()
-            return JobState[state]
-    except tf.errors.NotFoundError:
-        # No job state, defaults to PENDING.
-        return JobState.PENDING
-
-
-def _upload_job_state(job_name: str, state: JobState, *, remote_dir: str, verbose: bool = True):
-    """Uploads job state to gs path."""
-    remote_file = os.path.join(remote_dir, job_name)
-    logging.log_if(logging.INFO, "Writing %s to %s.", verbose, state.name, remote_file)
-    with tf.io.gfile.GFile(remote_file, mode="w") as f:
-        f.write(state.name)
-
-
-def _start_command(job: Job, *, remote_log_dir: str):
-    """Starts the given job.spec.command and sets `job.command_proc`."""
-    if job.command_proc is not None:
-        return  # Already running.
-    # If a log dir exists for this job, download it. This can happen if a job is resumed.
-    remote_log = os.path.join(remote_log_dir, job.spec.name)
-    local_log = os.path.join(_LOG_DIR, job.spec.name)
-    try:
-        tf.io.gfile.copy(remote_log, local_log, overwrite=True)
-    except tf.errors.NotFoundError:
-        pass
-    # Pipe all outputs to the local _LOG_DIR.
-    job.command_proc = _piped_popen(job.spec.command, local_log)
-    logging.info("Started command for the job %s: %s", job.spec.name, job.spec.command)
-
-
-def _start_cleanup_command(job: Job):
-    """Starts the given job.spec.cleanup_command."""
-    if not job.spec.cleanup_command:
-        logging.info("Job %s has no cleanup command.", job.spec.name)
-    elif job.cleanup_proc is None:
-        # Pipe all outputs to a local _LOG_DIR.
-        job.cleanup_proc = _piped_popen(
-            job.spec.cleanup_command, f"{os.path.join(_LOG_DIR, job.spec.name)}.cleanup"
-        )
-        logging.info(
-            "Started cleanup command for the job %s: %s",
-            job.spec.name,
-            job.spec.cleanup_command,
-        )
-
-
-def _listdir(path: str) -> List[str]:
-    """Wraps tf.io.gfile.listdir by returning empty list if dir is not found."""
-    try:
-        return tf.io.gfile.listdir(path)
-    except tf.errors.NotFoundError:
-        return []
-
-
-def _remove(path: str):
-    """Wraps tf.io.gfile.remove by catching not found errors."""
-    try:
-        tf.io.gfile.remove(path)
-    except tf.errors.NotFoundError:
-        pass
-
-
-def download_job_batch(
-    *,
-    spec_dir: str,
-    state_dir: str,
-    user_state_dir: str,
-    local_spec_dir: str = _JOB_DIR,
-    verbose: bool = False,
-) -> Tuple[Dict[str, Job], Set[str]]:
-    """Downloads a batch of jobs.
-
-    Args:
-        spec_dir: Directory to look for job specs.
-        state_dir: Directory to look for job states.
-        user_state_dir: Directory to look for user states.
-        local_spec_dir: Directory to store downloaded job specs.
-        verbose: Verbose logging.
-
-    Returns:
-        A mapping from job name to Job(spec, state), and
-        A set of job names whose state originates from user_state_dir.
-    """
-    jobspecs = _listdir(spec_dir)
-    user_states = _listdir(user_state_dir)
-    if verbose:
-        logging.info("User states %s", user_states)
-
-    # Download all files from spec_dir, state_dir, and user_state_dir.
-    with ThreadPoolExecutor() as pool:
-        download_spec_fn = functools.partial(
-            _download_jobspec,
-            remote_dir=spec_dir,
-            local_dir=local_spec_dir,
-        )
-        spec_futs = {job_name: pool.submit(download_spec_fn, job_name) for job_name in jobspecs}
-        job_state_futs = {
-            job_name: pool.submit(_download_job_state, job_name, remote_dir=state_dir)
-            for job_name in jobspecs
-        }
-        user_state_futs = {
-            job_name: pool.submit(_download_job_state, job_name, remote_dir=user_state_dir)
-            for job_name in user_states
-        }
-        wait(spec_futs.values())
-        wait(job_state_futs.values())
-        wait(user_state_futs.values())
-        # Construct Jobs for each spec. The state of the job depends on the following:
-        # 1. User state must be CANCELLING. We ignore other user states, e.g., a user should not be
-        #     able to bypass scheduling by initiating a state change to ACTIVE.
-        # 2. Job state must not be CLEANING/COMPLETED, since it doesn't make sense to progress
-        #     backwards to CANCELLING.
-        #
-        # If these conditions are met, we pick the user state; otherwise, we keep job state.
-        # We also keep track of which jobs have a user state (whether it was used or not), so that
-        # we can handle the appropriate cleanup in the update step.
-        jobs = {}
-        jobs_with_user_states = set()
-        for job_name in jobspecs:
-            try:
-                spec = spec_futs[job_name].result()
-                state = job_state_futs[job_name].result()
-                if job_name in user_state_futs:
-                    user_state = user_state_futs[job_name].result()
-                else:
-                    user_state = None
-            except Exception as e:  # pylint: disable=broad-except
-                # TODO(markblee): Distinguish transient vs non-transient errors.
-                logging.warning("Failed to load job %s with error: %s", job_name, e)
-                continue
-
-            if user_state is not None:
-                if user_state == JobState.CANCELLING and state not in (
-                    JobState.CLEANING,
-                    JobState.COMPLETED,
-                ):
-                    state = user_state
-                else:
-                    logging.warning(
-                        "User state (%s) ignored for job %s (%s).", user_state, job_name, state
-                    )
-                # Even if user_state is ignored, we still want to clean it up.
-                jobs_with_user_states.add(job_name)
-            jobs[job_name] = Job(spec=spec, state=state, command_proc=None, cleanup_proc=None)
-    return jobs, jobs_with_user_states
-
-
-class BastionJob(GCPJob):
-    """A job that runs on a remote VM, which executes arbitrary user commands."""
-
-    @config_class
-    class Config(GCPJob.Config):
-        """Configures BastionJob."""
-
-        # Interval to sync and run jobs.
-        update_interval_seconds: float = 30
-        # Scheduler to decide whether to start/pre-empt jobs.
-        scheduler: Required[Scheduler.Config] = REQUIRED
-        # Cleaner to deprovision idle resources.
-        cleaner: Required[Cleaner.Config] = REQUIRED
-
-    def __init__(self, cfg: Config):
-        super().__init__(cfg)
-        cfg = self.config
-        # Remote gs directory to emit logs.
-        self._output_dir = _bastion_dir(cfg.name)
-        # Remote log output dir. Ensure trailing slash.
-        self._log_dir = os.path.join(self._output_dir, "logs")
-        # Note: pathlib doesn't work well with gs:// prefix.
-        self._job_dir = os.path.join(self._output_dir, "jobs")
-        # Remote history dir. Ensure trailing slash.
-        self._job_history_dir = os.path.join(self._output_dir, "history", "jobs")
-        tf.io.gfile.makedirs(self._job_history_dir)
-        self._project_history_dir = os.path.join(self._output_dir, "history", "projects")
-        tf.io.gfile.makedirs(self._project_history_dir)
-        # Mapping from project_id to previous job verdicts.
-        self._project_history_previous_verdicts = {}
-        # Jobs that have fully completed.
-        self._complete_dir = os.path.join(self._job_dir, "complete")
-        # Active jobs (all other jobs).
-        self._active_dir = os.path.join(self._job_dir, "active")
-        # All user states (e.g. "cancelling" written by user).
-        self._user_state_dir = os.path.join(self._job_dir, "user_states")
-        # All bastion-managed job states.
-        self._state_dir = os.path.join(self._job_dir, "states")
-        # Local active jobs (and respective commands, files, etc).
-        # TODO(markblee): Rename this, as it includes more than just ACTIVE jobs (e.g. PENDING).
-        self._active_jobs: Dict[str, Job] = {}
-        # A set of job names which require cleanup of user states.
-        self._jobs_with_user_states: Set[str] = set()
-        # Log sync process.
-        self._sync_log_proc = None
-
-        # Instantiate children.
-        self._scheduler = cfg.scheduler.instantiate()
-        self._cleaner = cfg.cleaner.instantiate()
-
-    @classmethod
-    def default_config(cls) -> Config:
-        cfg = super().default_config()
-        cfg.command = ""  # Unused.
-        return cfg
-
-    def _append_to_job_history(self, job: Job, msg: str):
-        with tf.io.gfile.GFile(os.path.join(self._job_history_dir, f"{job.spec.name}"), "a") as f:
-            curr_time = datetime.now(timezone.utc).strftime("%m%d %H:%M:%S")
-            f.write(f"{curr_time} {msg}\n")
-
-    def _append_to_project_history(
-        self, jobs: Dict[str, JobMetadata], schedule_results: Scheduler.ScheduleResults
-    ):
-        now = datetime.now(timezone.utc)
-        for project_id, limits in schedule_results.project_limits.items():
-            job_verdicts = schedule_results.job_verdicts.get(project_id, {})
-            verdicts = []
-            for job_id, verdict in job_verdicts.items():
-                verdicts.append((job_id, verdict.should_run()))
-            verdicts = sorted(verdicts)
-            previous_verdicts = self._project_history_previous_verdicts.get(project_id)
-            if previous_verdicts == verdicts:
-                # Nothing changed.
-                continue
-            self._project_history_previous_verdicts[project_id] = verdicts
-            # Mapping from resource types to usage.
-            project_usage = collections.defaultdict(lambda: 0)
-            running_jobs = []
-            queued_jobs = []
-            for job_id, verdict in job_verdicts.items():
-                if verdict.should_run():
-                    running_jobs.append(job_id)
-                    job_metadata = jobs[job_id]
-                    for resource_type, demand in job_metadata.resources.items():
-                        project_usage[resource_type] += demand
-                else:
-                    queued_jobs.append(job_id)
-
-            def resource_str(resource_map: ResourceMap) -> str:
-                return ", ".join(
-                    sorted(
-                        f"{resource_type}={quantity}"
-                        for resource_type, quantity in resource_map.items()
-                    )
-                )
-
-            project_dir = os.path.join(self._project_history_dir, project_id)
-            tf.io.gfile.makedirs(project_dir)
-            with tf.io.gfile.GFile(os.path.join(project_dir, now.strftime("%Y%m%d")), "a") as f:
-                curr_time = now.strftime("%m%d %H:%M:%S")
-                f.write(f"{curr_time}\n")
-                f.write(f"Effective limits: {resource_str(limits)}\n")
-                f.write(f"Usage: {resource_str(project_usage)}\n")
-                f.write("Running jobs:\n")
-                for job_id in running_jobs:
-                    f.write(f"  {job_id}\n")
-                f.write("Queued jobs:\n")
-                for job_id in queued_jobs:
-                    f.write(f"  {job_id}\n")
-
-    def _sync_logs(self, interval_s: float = 10):
-        """Periodically sync output logs to gs in a separate process.
-
-        If the log sync process has died, it will be restarted.
-        """
-
-        def fn():
-            sync_s = 0
-            while True:
-                src, dst = _LOG_DIR, self._log_dir
-                logging.log_every_n(
-                    logging.INFO, "Syncing outputs %s -> %s. Last duration: %s", 6, src, dst, sync_s
-                )
-                start = time.time()
-                try:
-                    _sync_dir(src=src, dst=dst, max_tries=1)
-                except Exception as e:  # pylint: disable=broad-except
-                    logging.warning("Sync failed: %s", e)
-                sync_s = time.time() - start
-                if sync_s > interval_s:
-                    logging.warning(
-                        "Syncing outputs exceeded interval: %s > %s", sync_s, interval_s
-                    )
-                time.sleep(max(0, interval_s - sync_s))
-
-        if self._sync_log_proc is not None:
-            self._sync_log_proc.join(timeout=0)
-            if not self._sync_log_proc.is_alive():
-                logging.info("Log sync process died, removing...")
-                self._sync_log_proc.kill()
-                self._sync_log_proc.join()
-                self._sync_log_proc = None
-                logging.info("Log process removed. Will restart...")
-
-        if self._sync_log_proc is None:
-            logging.info("Starting log sync process.")
-            self._sync_log_proc = multiprocessing.Process(target=fn, daemon=True)
-            self._sync_log_proc.start()
-            logging.info("Log sync started.")
-        else:
-            logging.info("Log sync is still running.")
-
-    def _wait_and_close_proc(self, proc: _PipedProcess, kill: bool = False):
-        """Cleans up the process/fds and upload logs to gs."""
-        if kill:
-            send_signal(proc.popen, sig=signal.SIGKILL)
-        # Note: proc should already be polled and completed, so wait is nonblocking.
-        proc.popen.wait()
-        proc.fd.close()
-        # Upload outputs to log dir.
-        _catch_with_error_log(
-            tf.io.gfile.copy,
-            proc.fd.name,
-            os.path.join(self._log_dir, os.path.basename(proc.fd.name)),
-            overwrite=True,
-        )
-        # Remove the local output file.
-        if os.path.exists(proc.fd.name):
-            os.remove(proc.fd.name)
-
-    def _sync_jobs(self):
-        """Makes the local bastion state consistent with the remote GCS state.
-
-        This function serves as a synchronization point for user-initiated state changes
-        ("user_states") and state changes from a prior `_update_job` ("states"). Users should avoid
-        writing to the "states" dir directly, as doing so can produce races with `_update_job`.
-
-        More specifically, this function:
-        1. Downloads all active jobspecs from GCS.
-        2. Downloads all statefiles for active jobspecs from GCS (see `download_job_batch` for
-            details).
-
-        We use these jobspecs to update the local self._active_jobs.
-        """
-        active_jobs, jobs_with_user_states = download_job_batch(
-            spec_dir=self._active_dir,
-            state_dir=self._state_dir,
-            user_state_dir=self._user_state_dir,
-            verbose=True,
-        )
-        self._jobs_with_user_states = jobs_with_user_states
-        # Iterate over unique job names.
-        # pylint: disable-next=use-sequence-for-iteration
-        for job_name in {*active_jobs.keys(), *self._active_jobs.keys()}:
-            # Detected new job: exists in GCS, but not local.
-            if job_name not in self._active_jobs:
-                logging.info("Detected new job %s.", job_name)
-                self._active_jobs[job_name] = active_jobs[job_name]
-            # Detected removed job: exists locally, but not in GCS.
-            elif job_name not in active_jobs:
-                job = self._active_jobs[job_name]
-                if job.state != JobState.COMPLETED:
-                    logging.warning("Detected orphaned job %s! Killing it...", job.spec.name)
-                    if job.command_proc is not None:
-                        self._wait_and_close_proc(job.command_proc, kill=True)
-                    if job.cleanup_proc is not None:
-                        self._wait_and_close_proc(job.cleanup_proc, kill=True)
-                logging.info("Removed job %s.", job_name)
-                del self._active_jobs[job_name]
-            # Detected updated job: exists in both.
-            else:
-                curr_job = self._active_jobs[job_name]
-                updated_job = active_jobs[job_name]
-                curr_job.spec, curr_job.state = updated_job.spec, updated_job.state
-
-    # pylint: disable-next=too-many-statements
-    def _update_single_job(self, job: Job) -> Job:
-        """Handles all state transitions for a single job.
-
-        Assumptions:
-        1. A jobspec file exists in GCS at the start of each call. The job.state provided to this
-            function call is consistent with that state in GCS + any scheduling decisions.
-        2. The function may be called by a freshly started bastion (recovering from pre-emption).
-            Thus each condition must assume nothing about the local state.
-        3. The function may be pre-empted at any point.
-        4. Job commands/cleanup commands are resumable (can invoke the same command multiple times).
-
-        Conditions that must be held at exit (either pre-emption or graceful):
-        1. A jobspec must still exist in GCS.
-        2. self._active_jobs must be unmodified, besides modifying `job` itself.
-        """
-        if job.state == JobState.PENDING:
-            # Forcefully terminate the command proc and fd, if they exist, and sync logs to remote.
-            # The forceful termination is similar to the behavior when bastion itself is pre-empted.
-            #
-            # We must also ensure that:
-            # 1. command_proc is set to None, so we can resume in ACTIVE in a subsequent step
-            #    (possibly the next step).
-            # 2. Any job logs are sync'ed to remote log dir. The local log file cannot reliably be
-            #    expected to be present if/when the job is resumed.
-            if job.command_proc is not None:
-                self._append_to_job_history(job, "PENDING: pre-empting")
-                logging.info("Pre-empting job: %s", job.spec.name)
-                self._wait_and_close_proc(job.command_proc, kill=True)
-                job.command_proc = None
-                logging.info("Job is pre-empted: %s", job.spec.name)
-
-            job.state = JobState.PENDING
-
-        elif job.state == JobState.ACTIVE:
-            # Run the command if not already started. We attempt to run every time, in case bastion
-            # got pre-empted.
-            if job.command_proc is None:
-                self._append_to_job_history(
-                    job, f"ACTIVE: start process command: {job.spec.command}"
-                )
-            _start_command(job, remote_log_dir=self._log_dir)
-            assert job.command_proc is not None
-
-            # If command is completed, move to CLEANING. Otherwise, it's still RUNNING.
-            if _is_proc_complete(job.command_proc):
-                self._append_to_job_history(job, "CLEANING: process finished")
-                logging.info(
-                    "Job %s stopped gracefully: %s.",
-                    job.spec.name,
-                    job.command_proc.popen.returncode,
-                )
-                job.state = JobState.CLEANING
-
-        elif job.state == JobState.CANCELLING:
-            # If job is still running, terminate it. We stay in CANCELLING until it has fully
-            # exited, after which we move to CLEANING.
-            if job.command_proc is not None and not _is_proc_complete(job.command_proc):
-                self._append_to_job_history(job, "CANCELLING: terminating the process")
-                logging.info("Sending SIGTERM to job: %s", job.spec.name)
-                job.command_proc.popen.terminate()
-            else:
-                self._append_to_job_history(job, "CLEANING: process terminated")
-                job.state = JobState.CLEANING
-
-        elif job.state == JobState.CLEANING:
-            # If command exists, it must be fully stopped.
-            assert job.command_proc is None or _is_proc_complete(job.command_proc)
-
-            # Close the command proc and fd, if they exist.
-            if job.command_proc is not None:
-                self._wait_and_close_proc(job.command_proc)
-                job.command_proc = None
-
-            # Run the cleanup command if not already started (and if it exists). We attempt to run
-            # every time, in case bastion got pre-empted.
-            if job.spec.cleanup_command and not job.cleanup_proc:
-                self._append_to_job_history(
-                    job, f"CLEANING: start cleanup command: {job.spec.cleanup_command}"
-                )
-            _start_cleanup_command(job)
-
-            # If job has no cleanup command, or cleanup command is complete, transition to
-            # COMPLETED.
-            if job.cleanup_proc is None or _is_proc_complete(job.cleanup_proc):
-                self._append_to_job_history(job, "COMPLETED: cleanup finished")
-                logging.info("Job %s finished running cleanup.", job.spec.name)
-                if job.cleanup_proc is not None:
-                    self._wait_and_close_proc(job.cleanup_proc)
-                    job.cleanup_proc = None
-
-                job.state = JobState.COMPLETED
-
-        elif job.state == JobState.COMPLETED:
-            # Copy the jobspec to "complete" dir.
-            local_jobspec = os.path.join(_JOB_DIR, job.spec.name)
-            if os.path.exists(local_jobspec):
-                _upload_jobspec(job.spec, local_dir=_JOB_DIR, remote_dir=self._complete_dir)
-                os.remove(local_jobspec)
-
-        else:
-            raise ValueError(f"Unexpected state: {job.state}")
-
-        # Flush the state to GCS.
-        # TODO(markblee): Skip the upload if we can detect the state hasn't changed.
-        # State changes can come from user_states, scheduling, or above, so probably not worth the
-        # complexity at the moment, given how small job states are.
-        _upload_job_state(job.spec.name, job.state, remote_dir=self._state_dir, verbose=False)
-
-        # Remove any remote "user_states" now that "states" dir has synchronized.
-        if job.spec.name in self._jobs_with_user_states:
-            _remove(os.path.join(self._user_state_dir, job.spec.name))
-
-        return job
-
-    def _update_jobs(self):
-        """Handles state transitions for all jobs.
-
-        The scheduler is used to determine which jobs to resume/pre-empt based on job priority.
-        The actual updates can be performed in any order (possibly in parallel).
-
-        Note that this function should respect the conditions specified in `_update_single_job`.
-        """
-        logging.info("")
-        logging.info("==Begin update step.")
-
-        # Identify jobs which are schedulable.
-        schedulable_jobs = {}
-        for job_name, job in self._active_jobs.items():
-            if job.state in {JobState.PENDING, JobState.ACTIVE}:
-                schedulable_jobs[job_name] = job.spec.metadata
-
-        # Decide which jobs to resume/pre-empt.
-        schedule_results: Scheduler.ScheduleResults = self._scheduler.schedule(schedulable_jobs)
-        self._append_to_project_history(schedulable_jobs, schedule_results)
-        for verdicts in schedule_results.job_verdicts.values():
-            for job_name, verdict in verdicts.items():
-                if verdict.should_run():  # Resume/keep running.
-                    self._active_jobs[job_name].state = JobState.ACTIVE
-                else:  # Pre-empt/stay queued.
-                    self._active_jobs[job_name].state = JobState.PENDING
-
-        # TODO(markblee): Parallelize this.
-        for job_name, job in self._active_jobs.items():
-            try:
-                self._update_single_job(job)
-            except (CalledProcessError, RuntimeError) as e:
-                logging.warning("Failed to execute %s: %s", job_name, e)
-
-        logging.info("")
-        logging.info("All job states:")
-        for job_name, job in self._active_jobs.items():
-            logging.info("%s: %s", job_name, job.state)
-
-        logging.info("==End of update step.")
-        logging.info("")
-
-    def _gc_jobs(self):
-        """Garbage collects idle jobs and completed specs.
-
-        Note that this does not modify job state or self._active_jobs. Instead, fully gc'ed
-        COMPLETED jobs will have their jobspecs removed. In the next _sync_jobs, self._active_jobs
-        will be made consistent with GCS state.
-        """
-        logging.info("")
-        logging.info("==Begin gc step.")
-        cleaned = []
-
-        # Identify jobs which are idle (i.e., can be garbage collected).
-        jobs_to_clean = {}
-        for job_name, job in self._active_jobs.items():
-            if job.state in {JobState.PENDING, JobState.COMPLETED}:
-                jobs_to_clean[job_name] = job.spec.metadata.resources
-
-        # Note that this may contain PENDING jobs that have not yet started (since they will not be
-        # associated with any resources yet).
-        cleaned.extend(self._cleaner.sweep(jobs_to_clean))
-
-        def _delete_jobspec(job_name: str):
-            logging.info("Deleting jobspec for %s", job_name)
-            # Delete jobspec before state. This ensures that we won't pickup the job again in
-            # _sync_jobs, and that state files are always associated with a jobspec.
-            _remove(os.path.join(self._active_dir, job_name))
-            _remove(os.path.join(self._state_dir, job_name))
-            logging.info("Job %s is complete.", job_name)
-
-        # Remove remote jobspecs for COMPLETED jobs that finished gc'ing.
-        # TODO(markblee): GC orphaned states (e.g. if delete gets pre-empted).
-        cleaned_completed = [
-            job_name
-            for job_name in cleaned
-            if self._active_jobs[job_name].state == JobState.COMPLETED
-        ]
-        logging.info("Fully cleaned COMPLETED jobs: %s", cleaned_completed)
-        with ThreadPoolExecutor() as pool:
-            pool.map(_delete_jobspec, cleaned_completed)
-
-        logging.info("==End of gc step.")
-        logging.info("")
-
-    def _execute(self):
-        """Provisions and launches a command on a VM."""
-        cfg: BastionJob.Config = self.config
-        os.makedirs(_LOG_DIR, exist_ok=True)
-        os.makedirs(_JOB_DIR, exist_ok=True)
-        while True:
-            start = time.time()
-            self._sync_logs()
-            self._sync_jobs()
-            self._update_jobs()
-            self._gc_jobs()
-            execute_s = time.time() - start
-            if execute_s > cfg.update_interval_seconds:
-                logging.warning(
-                    "Execute step exceeded interval: %s > %s",
-                    execute_s,
-                    cfg.update_interval_seconds,
-                )
-            time.sleep(max(0, cfg.update_interval_seconds - execute_s))
-
-
-# TODO(markblee): Add more unit tests.
 class CreateBastionJob(CPUJob):
     """A job to create and start the remote bastion."""
 
@@ -997,9 +227,7 @@ class CreateBastionJob(CPUJob):
 
     @classmethod
     def default_config(cls) -> Config:
-        cfg = super().default_config()
-        cfg.command = ""
-        return cfg
+        return super().default_config().set(command="")
 
     def _delete(self):
         cfg = self.config
@@ -1050,74 +278,37 @@ class CreateBastionJob(CPUJob):
         )
 
 
-# TODO(markblee): Add more unit tests.
-class SubmitBastionJob(CPUJob):
-    """A job to submit a command to bastion."""
+class SubmitBastionJob(BaseSubmitBastionJob):
+    """A job to submit a command to bastion.
 
-    @config_class
-    class Config(CPUJob.Config):
-        """Configures SubmitBastionJob."""
-
-        # Name of the job. Not to be confused with cfg.name, the bastion name.
-        job_name: Required[str] = REQUIRED
-        # Job spec file local path.
-        job_spec_file: Required[str] = REQUIRED
-
-    @classmethod
-    def default_config(cls):
-        cfg = super().default_config()
-        cfg.command = ""
-        return cfg
-
-    def _output_dir(self):
-        return _bastion_dir(self.config.name)
-
-    def _job_dir(self):
-        return os.path.join(self._output_dir(), "jobs")
-
-    def _delete(self):
-        cfg: SubmitBastionJob.Config = self.config
-        try:
-            jobspec = os.path.join(self._job_dir(), "active", cfg.job_name)
-            if not tf.io.gfile.exists(jobspec):
-                raise ValueError(f"Unable to locate jobspec {jobspec}")
-            _upload_job_state(
-                cfg.job_name,
-                JobState.CANCELLING,
-                remote_dir=os.path.join(self._job_dir(), "user_states"),
-            )
-            logging.info(
-                "Job %s is cancelling.\nView bastion outputs with:\ngsutil cat %s",
-                cfg.job_name,
-                os.path.join(self._output_dir(), "logs", f"{cfg.job_name}.cleanup"),
-            )
-        except ValueError as e:
-            logging.info("Failed with error: %s -- Has the job been cancelled already?", e)
+    Main differences from base submit:
+    - Emits gsutil commands to view logs.
+    - Emits a warning if the bastion doesn't exist in GCE.
+    """
 
     def _execute(self):
         cfg: SubmitBastionJob.Config = self.config
-        node = get_vm_node(cfg.name, _compute_resource(self._get_job_credentials()))
+        node = get_vm_node(cfg.name, _compute_resource(get_credentials()))
         if node is None or node.get("status", None) != "RUNNING":
             logging.warning(
                 "Bastion %s does not appear to be running yet. "
                 "It will need to be running before jobs will execute.",
                 cfg.name,
             )
-        logging.info("Submitting command to bastion: %s", cfg.command)
-        dst = os.path.join(self._job_dir(), "active", cfg.job_name)
-        if tf.io.gfile.exists(dst):
-            logging.info("\n\nNote: Job is already running. To restart it, cancel the job first.\n")
-        else:
-            # Upload the job for bastion to pickup.
-            tf.io.gfile.copy(cfg.job_spec_file, dst)
-
         print(
             "\nView bastion outputs with:\n"
-            f"gsutil cat {os.path.join(self._output_dir(), 'logs', cfg.job_name)}",
+            f"gsutil cat {os.path.join(self.bastion_dir, 'logs', cfg.job_name)}",
         )
+        return super()._execute()
 
 
-def main(argv):
+def _project_quotas_from_file(quota_file: str):
+    """Returns a callable that fetches quota information."""
+    return functools.partial(get_resource_limits, path=quota_file)
+
+
+@catch_auth
+def main(argv: Sequence[str], *, flag_values: flags.FlagValues = FLAGS):
     action = parse_action(argv, options=["create", "delete", "start", "stop", "submit", "cancel"])
 
     if action == "create":
@@ -1127,9 +318,10 @@ def main(argv):
         # Note: The bundler here is only used for inferring the bundle ID. The actual image is built
         # separately, either through automation or with the bundle command (see docstring for
         # details).
-        bundler_cfg = get_bundler_config(bundler_type=DockerBundler.TYPE, spec=FLAGS.bundler_spec)
-        cfg = CreateBastionJob.from_flags(FLAGS)
-        cfg.set(
+        bundler_cfg = get_bundler_config(
+            bundler_type=DockerBundler.TYPE, spec=flag_values.bundler_spec
+        )
+        cfg = CreateBastionJob.from_flags(flag_values).set(
             bundler=bundler_cfg.set(
                 image=bundler_cfg.image or "base",
                 repo=bundler_cfg.repo or gcp_settings("docker_repo", required=False),
@@ -1141,58 +333,59 @@ def main(argv):
         job = cfg.instantiate()
         job.execute()
     elif action == "delete":
-        cfg = CreateBastionJob.from_flags(FLAGS)
+        cfg = CreateBastionJob.from_flags(flag_values)
         job = cfg.instantiate()
         job._delete()  # pylint: disable=protected-access
     elif action == "start":
+        quota_file = os.path.join(
+            "gs://",
+            gcp_settings("private_bucket"),
+            flag_values.name,
+            QUOTA_CONFIG_PATH,
+        )
         # Start the bastion. This should run on the bastion itself.
-        quota_file = f"gs://{gcp_settings('private_bucket')}/{FLAGS.name}/{QUOTA_CONFIG_PATH}"
-        cfg = BastionJob.from_flags(FLAGS).set(
-            max_tries=-1,
+        bastion_cfg = Bastion.default_config().set(
+            output_dir=output_dir(flag_values.name),
             scheduler=JobScheduler.default_config().set(
-                project_quota_file=quota_file,
-                dry_run=FLAGS.dry_run,
+                quota=config_for_function(_project_quotas_from_file).set(quota_file=quota_file),
+                dry_run=flag_values.dry_run,
             ),
             cleaner=TPUCleaner.default_config(),
+            uploader=Uploader.default_config().set(
+                upload_fn=config_for_function(with_interval).set(upload_fn=_gsutil_rsync),
+            ),
         )
+        cfg = StartBastionJob.from_flags(flag_values).set(max_tries=-1, bastion=bastion_cfg)
         job = cfg.instantiate()
         job.execute()
     elif action == "stop":
         # Stop the bastion. This typically runs locally.
-        cfg = CPUJob.from_flags(FLAGS).set(
-            command=f"docker stop {FLAGS.name}; rm -r {_JOB_DIR}",
-            max_tries=1,
+        cfg = CPUJob.from_flags(flag_values).set(
+            command=f"docker stop {flag_values.name}", max_tries=1
         )
         job = cfg.instantiate()
         job.execute()
     elif action == "submit":
-        spec = deserialize_jobspec(FLAGS.spec)
+        spec = deserialize_jobspec(flag_values.spec)
         # Construct a job for bastion to execute. This typically runs locally.
         # The spec file provided from the flags will be used and submitted to bastion vm.
-        cfg = SubmitBastionJob.from_flags(FLAGS).set(job_name=spec.name, job_spec_file=FLAGS.spec)
+        cfg = SubmitBastionJob.from_flags(flag_values).set(
+            job_name=spec.name,
+            job_spec_file=flag_values.spec,
+            bastion_dir=output_dir(flag_values.name),
+        )
         # Execute the job.
         job = cfg.instantiate()
         job.execute()
     elif action == "cancel":
-        if not FLAGS.job_name:
+        if not flag_values.job_name:
             raise app.UsageError("--job_name must be provided if running 'cancel'.")
         # Cancel a job that bastion is running (or planning to run).
-        cfg = SubmitBastionJob.from_flags(FLAGS).set(job_spec_file="")
+        cfg = SubmitBastionJob.from_flags(flag_values).set(
+            job_spec_file="", bastion_dir=output_dir(flag_values.name)
+        )
         job = cfg.instantiate()
         job._delete()  # pylint: disable=protected-access
-        # Poll for jobspec to be removed.
-        try:
-            while True:
-                # pylint: disable-next=protected-access
-                dst = os.path.join(job._job_dir(), "active", cfg.job_name)
-                if tf.io.gfile.exists(dst):
-                    logging.info("Waiting for job to stop (use ctrl+c to stop waiting)...")
-                    time.sleep(10)
-                else:
-                    break
-            logging.info("Job is stopped.")
-        except KeyboardInterrupt:
-            logging.info("Job is stopping in the background.")
     else:
         raise ValueError(f"Unknown action {action}")
 

--- a/axlearn/cloud/gcp/jobs/bastion_vm_test.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm_test.py
@@ -1,741 +1,151 @@
 # Copyright © 2023 Apple Inc.
 
 """Tests bastion VM."""
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=protected-access
+
 import contextlib
-import os
-import subprocess
-import tempfile
-from datetime import datetime, timedelta
-from typing import Dict, Optional, Sequence
 from unittest import mock
 
-from absl.testing import parameterized
+from absl import flags
 
-from axlearn.cloud.common.scheduler import JobMetadata, JobScheduler
-from axlearn.cloud.common.scheduler_test import mock_scheduler
-from axlearn.cloud.common.types import ResourceMap
 from axlearn.cloud.gcp.jobs import bastion_vm
-from axlearn.cloud.gcp.jobs.bastion_vm import (
-    _JOB_DIR,
-    _LOG_DIR,
-    BastionJob,
-    Job,
-    JobState,
-    _PipedProcess,
-    deserialize_jobspec,
-    download_job_batch,
-    new_jobspec,
-    serialize_jobspec,
-)
-from axlearn.cloud.gcp.tpu_cleaner import TPUCleaner
+from axlearn.cloud.gcp.jobs.bastion_vm import CreateBastionJob
+from axlearn.cloud.gcp.test_utils import mock_gcp_settings
+from axlearn.common.config import _validate_required_fields, config_for_function
+from axlearn.common.test_utils import TestWithTemporaryCWD
 
 
-class TestDownloadJobBatch(parameterized.TestCase):
-    """Tests download utils."""
+@contextlib.contextmanager
+def mock_vm(module_name: str):
+    """Mocks out VM create and delete."""
 
-    def test_download_job_batch(self):
-        spec_dir = "gs://test_spec_dir"
-        state_dir = "gs://test_state_dir"
-        user_state_dir = "gs://user_state_dir"
+    def mock_create_vm(*args, **kwargs):
+        del args, kwargs
 
-        user_states = {
-            "job_test1": JobState.CANCELLING,
-            "job_test2": JobState.ACTIVE,
-            "job_test0": JobState.CANCELLING,
-            "job_test3": JobState.CANCELLING,
+    def mock_delete_vm(*args, **kwargs):
+        del args, kwargs
+
+    mocks = {
+        "create_vm": mock_create_vm,
+        "delete_vm": mock_delete_vm,
+    }
+    with contextlib.ExitStack() as stack:
+        # Boilerplate to register multiple mocks at once, and return the mocks.
+        mocks = {
+            name: stack.enter_context(mock.patch(f"{module_name}.{name}", side_effect=method))
+            for name, method in mocks.items()
         }
-        states = {
-            "job_test1": JobState.ACTIVE,
-            "job_test0": JobState.CLEANING,
-            "job_test3": JobState.COMPLETED,
-            "job_test4": JobState.PENDING,
-        }
-        jobspecs = {
-            "job_test2": mock.Mock(),
-            "job_test1": mock.Mock(),
-            "job_test0": mock.Mock(),
-            "job_test3": mock.Mock(),
-            "job_test4": mock.Mock(),
-        }
-        expected = {
-            # User state is invalid and is ignored. Job state defaults to PENDING, since it's
-            # missing a state.
-            "job_test2": JobState.PENDING,
-            # User state should take effect.
-            "job_test1": JobState.CANCELLING,
-            # User state should not affect CLEANING/COMPLETED.
-            "job_test0": JobState.CLEANING,
-            "job_test3": JobState.COMPLETED,
-            # Has no user state.
-            "job_test4": JobState.PENDING,
-        }
-
-        def mock_listdir(path):
-            if path == spec_dir:
-                return list(jobspecs.keys())
-            if path == state_dir:
-                return list(states.keys())
-            if path == user_state_dir:
-                return list(user_states.keys())
-            assert False  # Should not be reached.
-
-        def mock_download_jobspec(job_name, **kwargs):
-            del kwargs
-            return jobspecs[job_name]
-
-        def mock_download_job_state(job_name, *, remote_dir, **kwargs):
-            del kwargs
-            if remote_dir == state_dir:
-                # Job state may be initially missing, thus defaults to PENDING.
-                return states.get(job_name, JobState.PENDING)
-            if remote_dir == user_state_dir:
-                # We should only query user states if one exists, so don't use get().
-                return user_states[job_name]
-            assert False  # Should not be reached.
-
-        patch_fns = mock.patch.multiple(
-            bastion_vm.__name__,
-            _download_jobspec=mock.Mock(side_effect=mock_download_jobspec),
-            _download_job_state=mock.Mock(side_effect=mock_download_job_state),
-        )
-        patch_tfio = mock.patch(
-            f"{bastion_vm.__name__}.tf.io.gfile.listdir", side_effect=mock_listdir
-        )
-
-        # Ensure that results are in the right order and pairing.
-        with patch_fns, patch_tfio, tempfile.TemporaryDirectory() as tmpdir:
-            jobs, jobs_with_user_states = download_job_batch(
-                spec_dir=spec_dir,
-                state_dir=state_dir,
-                user_state_dir=user_state_dir,
-                local_spec_dir=tmpdir,
-            )
-            self.assertSameElements(expected.keys(), jobs.keys())
-            # "job_test1" is the only valid user state, but we still cleanup the others.
-            self.assertSameElements(jobs_with_user_states, user_states.keys())
-            for job_name, job in jobs.items():
-                self.assertEqual(job.state, expected[job_name])
-                self.assertEqual(job.spec, jobspecs[job_name])
+        yield mocks
 
 
-class TestJobSpec(parameterized.TestCase):
-    """Tests job specs."""
-
-    def test_serialization_job_spec(self):
-        test_spec = new_jobspec(
-            name="test_job",
-            command="test command",
-            metadata=JobMetadata(
-                user_id="test_id",
-                project_id="test_project",
-                creation_time=datetime.now(),
-                resources={"test": 8.0},
-                priority=1,
-            ),
-        )
-        with tempfile.NamedTemporaryFile("w+b") as f:
-            serialize_jobspec(test_spec, f.name)
-            deserialized_jobspec = deserialize_jobspec(f=f.name)
-            for key in test_spec.__dataclass_fields__:
-                self.assertIn(key, deserialized_jobspec.__dict__)
-                self.assertEqual(deserialized_jobspec.__dict__[key], test_spec.__dict__[key])
-
-
-# Returns a new mock Popen for each subprocess.Popen call.
-def _mock_popen_fn(mock_spec: Dict[str, Dict]):
-    """Returns a callable that outputs mocked Popens for predetermined commands.
-
-    For example:
-        Input:
-            {'my_command': {'terminate.side_effect': ValueError}}
-        Result:
-            mock = subprocess.Popen('my_command')
-            mock.terminate()  # Raises ValueError.
-    """
-
-    def popen(cmd, **kwargs):
-        del kwargs
-        if cmd not in mock_spec:
-            raise ValueError(f"Don't know how to mock: {cmd}")
-        m = mock.MagicMock()
-        m.configure_mock(**mock_spec[cmd])
-        return m
-
-    return popen
-
-
-# Returns a new mock _PipedProcess.
-def _mock_piped_popen_fn(mock_spec: Dict[str, Dict]):
-    """See `_mock_popen_fn`."""
-    mock_popen_fn = _mock_popen_fn(mock_spec)
-
-    def piped_popen(cmd, f):
-        mock_fd = mock.MagicMock()
-        mock_fd.name = f
-        return _PipedProcess(popen=mock_popen_fn(cmd), fd=mock_fd)
-
-    return piped_popen
-
-
-class BastionJobTest(parameterized.TestCase):
-    """Tests BastionJob."""
-
-    @contextlib.contextmanager
-    def _patch_bastion(self, mock_popen_spec: Optional[Dict] = None):
-        mocks = [mock_scheduler()]
-        module_name = bastion_vm.__name__
-
-        if mock_popen_spec:
-            mock_popen = mock.patch.object(subprocess, "Popen", autospec=True)
-            mock_popen.side_effect = _mock_popen_fn(mock_popen_spec)
-            mocks.extend(
-                [
-                    mock_popen,
-                    mock.patch(
-                        f"{module_name}._piped_popen",
-                        side_effect=_mock_piped_popen_fn(mock_popen_spec),
-                    ),
-                ]
-            )
-
-        with contextlib.ExitStack() as stack, tempfile.TemporaryDirectory() as tmpdir:
-            # Boilerplate to register multiple mocks at once.
-            for m in mocks:
-                stack.enter_context(m)
-
-            with mock.patch(f"{module_name}._bastion_dir", return_value=tmpdir):
-                cfg = BastionJob.default_config().set(
-                    scheduler=JobScheduler.default_config().set(project_quota_file="test"),
-                    cleaner=TPUCleaner.default_config(),
-                    max_tries=1,
-                )
-                bastion = cfg.set(
-                    name="test", project="test", zone="test", retry_interval=30, command=""
-                ).instantiate()
-
-                yield bastion
-
-    @parameterized.product(
-        [
-            dict(
-                # Command has not terminated -- expect kill() to be called.
-                # We should not need to consult terminate() or poll().
-                popen_spec={
-                    "command": {
-                        "wait.return_value": None,
-                        "poll.side_effect": ValueError,
-                        "terminate.side_effect": ValueError,
-                    },
-                    # cleanup should have no effect here, so we just raise if it's ever used.
-                    "cleanup": {
-                        "poll.side_effect": ValueError,
-                        "terminate.side_effect": ValueError,
-                    },
-                },
-            ),
-            dict(
-                # Command has already terminated. Expect state to transition to PENDING and
-                # command_proc to be None.
-                popen_spec={
-                    "cleanup": {"poll.return_value": 0, "terminate.side_effect": ValueError},
-                },
-            ),
-        ],
-        user_state_exists=[False, True],
+def _mock_create_config():
+    mock_bundler = mock.MagicMock()
+    mock_bundler.TYPE = "test-bundler"
+    mock_bundler.install_command.return_value = "test_install"
+    return CreateBastionJob.default_config().set(
+        name="test",
+        project="test-project",
+        zone="test-zone",
+        vm_type="test-vm",
+        disk_size=123,
+        max_tries=1,
+        retry_interval=1,
+        bundler=config_for_function(lambda: mock_bundler),
     )
-    def test_pending(self, popen_spec, user_state_exists):
-        """Test PENDING state transitions.
 
-        1. If command_proc is still running, it should be terminated (killed).
-        2. The state should remain PENDING, command_proc must be None, and log file should be
-            uploaded.
-        """
-        mock_proc = _mock_piped_popen_fn(popen_spec)
-        job = Job(
-            spec=new_jobspec(
-                name="test_job",
-                command="command",
-                cleanup_command="cleanup",
-                metadata=JobMetadata(
-                    user_id="test_user",
-                    project_id="test_project",
-                    creation_time=datetime.now(),
-                    resources={"v4": 8},
-                ),
-            ),
-            state=JobState.PENDING,
-            command_proc=mock_proc("command", "test_command") if "command" in popen_spec else None,
-            cleanup_proc=mock_proc("cleanup", "test_cleanup") if "cleanup" in popen_spec else None,
-        )
-        patch_fns = mock.patch.multiple(
-            bastion_vm.__name__,
-            _upload_job_state=mock.DEFAULT,
-            send_signal=mock.DEFAULT,
-        )
-        patch_tfio = mock.patch.multiple(
-            f"{bastion_vm.__name__}.tf.io.gfile",
-            exists=mock.Mock(return_value=user_state_exists),
-            copy=mock.DEFAULT,
-            remove=mock.DEFAULT,
-        )
-        with self._patch_bastion(
-            popen_spec
-        ) as bastion, patch_fns as mock_fns, patch_tfio as mock_tfio:
-            # Run a couple updates to test transition to PENDING and staying in PENDING.
-            for _ in range(2):
-                orig_command_proc = job.command_proc
-                updated_job = bastion._update_single_job(job)
-                # Job should now be in pending.
-                self.assertEqual(updated_job.state, JobState.PENDING)
-                # Command should be None.
-                self.assertIsNone(updated_job.command_proc)
 
-                if orig_command_proc is not None:
-                    # Kill should have been called, and fd should have been closed.
-                    mock_fns["send_signal"].assert_called()
-                    self.assertTrue(
-                        orig_command_proc.fd.close.called  # pytype: disable=attribute-error
-                    )
+class CreateBastionJobTest(TestWithTemporaryCWD):
+    """Tests CreateBastionJob."""
 
-                    # Log should be uploaded if command was initially running.
-                    upload_call = mock.call(
-                        orig_command_proc.fd.name,
-                        os.path.join(bastion._log_dir, os.path.basename(orig_command_proc.fd.name)),
-                        overwrite=True,
-                    )
-                    mock_tfio["copy"].assert_has_calls([upload_call], any_order=False)
+    def test_create(self):
+        cfg = _mock_create_config()
+        job = cfg.instantiate()
 
-                # Cleanup command should not be involved.
-                updated_job.cleanup_proc.popen.poll.assert_not_called()
-                updated_job.cleanup_proc.popen.terminate.assert_not_called()
+        mock_execute = mock.patch.object(job, "_execute_remote_cmd", return_value=None)
+        mock_creds = mock.patch.object(job, "_get_job_credentials", return_value=None)
+        with mock_execute, mock_creds, mock_vm(bastion_vm.__name__) as mocks:
+            job._execute()
+            self.assertTrue(mocks["create_vm"].called)
+            self.assertIn(cfg.name, mocks["create_vm"].call_args.args)
+            self.assertEqual(cfg.vm_type, mocks["create_vm"].call_args.kwargs["vm_type"])
+            self.assertEqual(cfg.disk_size, mocks["create_vm"].call_args.kwargs["disk_size"])
+            self.assertEqual("test-bundler", mocks["create_vm"].call_args.kwargs["bundler_type"])
 
-                updated_job = job
+    def test_delete(self):
+        cfg = _mock_create_config()
+        job = cfg.instantiate()
 
-    @parameterized.product(
-        [
-            dict(
-                popen_spec={
-                    # Runs for one update step and then completes.
-                    # terminate() raises, since we don't expect it to be called.
-                    "command": {
-                        "poll.side_effect": [None, 0],
-                        "terminate.side_effect": ValueError,
-                    },
-                    # cleanup should have no effect here, so we just raise if it's ever used.
-                    "cleanup": {
-                        "poll.side_effect": ValueError,
-                        "terminate.side_effect": ValueError,
-                    },
-                },
-                expect_poll_calls=2,
-            ),
-            dict(
-                popen_spec={
-                    # Command terminates instantly.
-                    "command": {
-                        "poll.return_value": 1,
-                        "terminate.side_effect": ValueError,
-                    },
-                    # cleanup should have no effect here, so we just raise if it's ever used.
-                    "cleanup": {
-                        "poll.side_effect": ValueError,
-                        "terminate.side_effect": ValueError,
-                    },
-                },
-                expect_poll_calls=1,
-            ),
-        ],
-        logfile_exists=[False, True],
+        mock_creds = mock.patch.object(job, "_get_job_credentials", return_value=None)
+        with mock_creds, mock_vm(bastion_vm.__name__) as mocks:
+            job._delete()
+            self.assertTrue(mocks["delete_vm"].called)
+            self.assertIn(cfg.name, mocks["delete_vm"].call_args.args)
+
+
+@contextlib.contextmanager
+def _mock_job(job, *, bundler_kwargs, settings_kwargs):
+    mock_job = mock.MagicMock()
+    mock_bundler = mock.MagicMock(**bundler_kwargs)
+    mock_cfg = mock.MagicMock(**{"instantiate.return_value": mock_job})
+    mock_from_flags = mock.patch.object(job, "from_flags", return_value=mock_cfg)
+    mock_get_bundler = mock.patch(
+        f"{bastion_vm.__name__}.get_bundler_config", return_value=mock_bundler
     )
-    def test_active(self, popen_spec, expect_poll_calls, logfile_exists):
-        """Test ACTIVE state transitions.
+    mock_settings = mock_gcp_settings(bastion_vm.__name__, settings_kwargs)
+    with mock_from_flags, mock_get_bundler, mock_settings, mock_vm(bastion_vm.__name__):
+        yield mock_cfg, mock_bundler
 
-        1. If command_proc is not running, it should be started. If a log file exists remotely, it
-            should be downloaded.
-        2. If command_proc is already running, stay in ACTIVE.
-        3. If command_proc is completed, move to CLEANING.
-        """
-        mock_proc = _mock_piped_popen_fn(popen_spec)
-        job = Job(
-            spec=new_jobspec(
-                name="test_job",
-                command="command",
-                cleanup_command="cleanup",
-                metadata=JobMetadata(
-                    user_id="test_user",
-                    project_id="test_job",
-                    creation_time=datetime.now(),
-                    resources={"v4": 8},
-                ),
-            ),
-            state=JobState.ACTIVE,
-            command_proc=None,  # Initially, command is None.
-            cleanup_proc=mock_proc("cleanup", "test_cleanup"),
-        )
 
-        def mock_tfio_exists(f):
-            if "logs" in f and os.path.basename(f) == "test_job":
-                return logfile_exists
-            return False
+class MainTest(TestWithTemporaryCWD):
+    """Tests CLI entrypoint."""
 
-        patch_fns = mock.patch.multiple(
-            bastion_vm.__name__,
-            _upload_job_state=mock.DEFAULT,
-        )
-        patch_tfio = mock.patch.multiple(
-            f"{bastion_vm.__name__}.tf.io.gfile",
-            exists=mock.MagicMock(side_effect=mock_tfio_exists),
-            copy=mock.DEFAULT,
-        )
-        with patch_fns, self._patch_bastion(popen_spec) as bastion, patch_tfio as mock_tfio:
-            # Initially, job should have no command.
-            self.assertIsNone(job.command_proc)
+    def test_private_flags(self):
+        fv = flags.FlagValues()
+        bastion_vm._private_flags(flag_values=fv)
+        # Basic sanity check.
+        self.assertIsNotNone(fv["vm_type"].default)
 
-            # Run single update step to start the job.
-            updated_job = bastion._update_single_job(job)
+    def test_create(self):
+        fv = flags.FlagValues()
+        bastion_vm._private_flags(flag_values=fv)
+        fv.set_default("name", "test-bastion")
+        fv.mark_as_parsed()
 
-            # Command should be started on the first update.
-            self.assertIsNotNone(updated_job.command_proc)
-            # Log should be downloaded if it exists.
-            download_call = mock.call(
-                os.path.join(bastion._log_dir, job.spec.name),
-                os.path.join(_LOG_DIR, job.spec.name),
-                overwrite=True,
-            )
-            mock_tfio["copy"].assert_has_calls([download_call], any_order=False)
-
-            # Run until expected job completion.
-            for _ in range(expect_poll_calls - 1):
-                self.assertEqual(updated_job.state, JobState.ACTIVE)
-                updated_job = bastion._update_single_job(updated_job)
-
-            # Job state should be CLEANING.
-            self.assertEqual(updated_job.state, JobState.CLEANING)
-
-    # pylint: disable-next=too-many-branches
-    def test_update_jobs(self):
-        """Tests the global update step."""
-
-        def popen_spec(command_poll=2, cleanup_poll=2):
-            return {
-                # Constructs a command_proc that "completes" after `command_poll` updates.
-                "command": {
-                    "wait.return_value": None,
-                    "poll.side_effect": [None] * (command_poll - 1) + [0],
-                    "terminate.side_effect": None,
-                },
-                # Constructs a cleanup_proc that completes after `cleanup_poll` updates.
-                "cleanup": {
-                    "poll.side_effect": [None] * (cleanup_poll - 1) + [0],
-                    "terminate.side_effect": ValueError,
-                },
-            }
-
-        def mock_proc(cmd, **kwargs):
-            fn = _mock_piped_popen_fn(popen_spec(**kwargs))
-            return fn(cmd, "test_file")
-
-        yesterday = datetime.now() - timedelta(days=1)
-
-        # Test state transitions w/ interactions between jobs (scheduling).
-        # See also `mock_scheduler` for mock project quotas and limits.
-        active_jobs = {
-            # This job will stay PENDING, since user "b" has higher priority.
-            "pending": Job(
-                spec=new_jobspec(
-                    name="pending",
-                    command="command",
-                    cleanup_command="cleanup",
-                    metadata=JobMetadata(
-                        user_id="a",
-                        project_id="project2",
-                        creation_time=yesterday + timedelta(seconds=3),
-                        resources={"v4": 12},  # Doesn't fit if "resume" job is scheduled.
-                    ),
-                ),
-                state=JobState.PENDING,
-                command_proc=None,  # No command proc for PENDING jobs.
-                cleanup_proc=None,
-            ),
-            # This job will go from PENDING to ACTIVE.
-            "resume": Job(
-                spec=new_jobspec(
-                    name="resume",
-                    command="command",
-                    cleanup_command="cleanup",
-                    metadata=JobMetadata(
-                        user_id="b",
-                        project_id="project2",
-                        creation_time=yesterday + timedelta(seconds=2),
-                        resources={"v4": 5},  # Fits within v4 budget in project2.
-                    ),
-                ),
-                state=JobState.PENDING,
-                command_proc=None,  # No command proc for PENDING jobs.
-                cleanup_proc=None,
-            ),
-            # This job will stay in ACTIVE, since it takes 2 updates to complete.
-            "active": Job(
-                spec=new_jobspec(
-                    name="active",
-                    command="command",
-                    cleanup_command="cleanup",
-                    metadata=JobMetadata(
-                        user_id="c",
-                        project_id="project2",
-                        creation_time=yesterday + timedelta(seconds=2),
-                        resources={"v3": 2},  # Fits within the v3 budget in project2.
-                    ),
-                ),
-                state=JobState.PENDING,
-                command_proc=mock_proc("command"),
-                cleanup_proc=None,  # No cleanup_proc for ACTIVE jobs.
-            ),
-            # This job will go from ACTIVE to PENDING, since it's using part of project2's v4
-            # quota, and "b" is requesting project2's v4 quota.
-            # Even though poll()+terminate() typically takes a few steps, we instead go through
-            # kill() to forcefully terminate within one step.
-            "preempt": Job(
-                spec=new_jobspec(
-                    name="preempt",
-                    command="command",
-                    cleanup_command="cleanup",
-                    metadata=JobMetadata(
-                        user_id="d",
-                        project_id="project1",
-                        creation_time=yesterday + timedelta(seconds=2),
-                        resources={"v4": 12},  # Uses part of project2 budget.
-                    ),
-                ),
-                state=JobState.ACTIVE,
-                command_proc=mock_proc("command"),
-                cleanup_proc=None,  # No cleanup_proc for ACTIVE.
-            ),
-            # This job will go from ACTIVE to CLEANING.
-            "cleaning": Job(
-                spec=new_jobspec(
-                    name="cleaning",
-                    command="command",
-                    cleanup_command="cleanup",
-                    metadata=JobMetadata(
-                        user_id="f",
-                        project_id="project2",
-                        creation_time=yesterday + timedelta(seconds=2),
-                        resources={"v3": 2},  # Fits within the v3 budget in project2.
-                    ),
-                ),
-                state=JobState.ACTIVE,
-                command_proc=mock_proc("command", command_poll=1),
-                cleanup_proc=None,
-            ),
-            # This job will go from CANCELLING to CLEANING.
-            # Note that CANCELLING jobs will not be "pre-empted" by scheduler; even though this job
-            # is out-of-budget, it will go to CLEANING instead of SUSPENDING.
-            "cleaning_cancel": Job(
-                spec=new_jobspec(
-                    name="cleaning_cancel",
-                    command="command",
-                    cleanup_command="cleanup",
-                    metadata=JobMetadata(
-                        user_id="g",
-                        project_id="project2",
-                        creation_time=yesterday + timedelta(seconds=4),
-                        resources={"v4": 100},  # Does not fit into v4 budget.
-                    ),
-                ),
-                state=JobState.CANCELLING,
-                command_proc=mock_proc("command", command_poll=1),
-                cleanup_proc=None,
-            ),
-            # This job will go from CLEANING to COMPLETED.
-            "completed": Job(
-                spec=new_jobspec(
-                    name="completed",
-                    command="command",
-                    cleanup_command="cleanup",
-                    metadata=JobMetadata(
-                        user_id="e",
-                        project_id="project3",
-                        creation_time=yesterday + timedelta(seconds=2),
-                        resources={"v5": 2.5},
-                    ),
-                ),
-                state=JobState.CLEANING,
-                command_proc=None,
-                cleanup_proc=mock_proc("cleanup", cleanup_poll=1),  # Should have cleanup_proc.
-            ),
+        # Bundler should use params from spec or fallback to defaults.
+        bundler_kwargs = {"image": "test-image", "repo": "test-repo", "dockerfile": None}
+        settings_kwargs = {
+            "docker_repo": "default-repo",
+            "default_dockerfile": "default-dockerfile",
         }
-        # Pretend that only 'cleaning_cancel' came from a user state.
-        jobs_with_user_states = {"cleaning_cancel"}
-
-        # Patch all network calls and utils.
-        patch_fns = mock.patch.multiple(
-            bastion_vm.__name__,
-            _upload_job_state=mock.DEFAULT,
-            send_signal=mock.DEFAULT,
+        mock_job = _mock_job(
+            bastion_vm.CreateBastionJob,
+            bundler_kwargs=bundler_kwargs,
+            settings_kwargs=settings_kwargs,
         )
-        patch_tfio = mock.patch.multiple(
-            f"{bastion_vm.__name__}.tf.io.gfile",
-            exists=mock.DEFAULT,
-            copy=mock.DEFAULT,
-            remove=mock.DEFAULT,
-        )
-        with self._patch_bastion(
-            popen_spec()
-        ) as bastion, patch_fns as mock_fns, patch_tfio as mock_tfio:
-            bastion._active_jobs = active_jobs
-            bastion._jobs_with_user_states = jobs_with_user_states
-            bastion._update_jobs()
+        # Check that the bundler is constructed properly.
+        with mock_job as (_, mock_bundler):
+            bastion_vm.main(["cli", "create"], flag_values=fv)
+            self.assertEqual("test-image", mock_bundler.set.call_args.kwargs["image"])
+            self.assertEqual("test-repo", mock_bundler.set.call_args.kwargs["repo"])
+            self.assertEqual("default-dockerfile", mock_bundler.set.call_args.kwargs["dockerfile"])
 
-            # Ensure _active_jobs membership stays same.
-            self.assertEqual(bastion._active_jobs.keys(), active_jobs.keys())
+    def test_start(self):
+        fv = flags.FlagValues()
+        bastion_vm._private_flags(flag_values=fv)
+        fv.set_default("name", "test-bastion")
+        fv.mark_as_parsed()
 
-            expected_states = {
-                "pending": JobState.PENDING,
-                "resume": JobState.ACTIVE,
-                "active": JobState.ACTIVE,
-                "preempt": JobState.PENDING,
-                "cleaning": JobState.CLEANING,
-                "cleaning_cancel": JobState.CLEANING,
-                "completed": JobState.COMPLETED,
-            }
-            for job_name in active_jobs:
-                self.assertEqual(bastion._active_jobs[job_name].state, expected_states[job_name])
-
-            for job in bastion._active_jobs.values():
-                # For jobs that are ACTIVE, expect command_proc to be non-None.
-                if job.state == JobState.ACTIVE:
-                    self.assertIsNotNone(job.command_proc)
-                    self.assertIsNone(job.cleanup_proc)
-                # For jobs that are COMPLETED, expect both procs to be None.
-                elif job.state == JobState.COMPLETED:
-                    self.assertIsNone(job.command_proc)
-                    self.assertIsNone(job.cleanup_proc)
-
-                    # Remote jobspec should not be deleted until gc.
-                    for delete_call in mock_tfio["remove"].mock_calls:
-                        self.assertNotIn(
-                            os.path.join(_JOB_DIR, job.spec.name),
-                            delete_call.args,
-                        )
-
-                # User states should only be deleted if the job's state was read from
-                # user_state_dir.
-                self.assertEqual(
-                    any(
-                        os.path.join(bastion._user_state_dir, job.spec.name) in delete_call.args
-                        for delete_call in mock_tfio["remove"].mock_calls
-                    ),
-                    job.spec.name in bastion._jobs_with_user_states,
-                )
-
-                # For jobs that went from ACTIVE to PENDING, expect kill() to have been called.
-                if active_jobs[job.spec.name] == JobState.ACTIVE and job.state == JobState.PENDING:
-                    mock_fns["send_signal"].assert_called()
-                    self.assertFalse(
-                        active_jobs[
-                            job.spec.name
-                        ].command_proc.popen.terminate.called  # pytype: disable=attribute-error
-                    )
-
-            for job_name in active_jobs:
-                history_file = os.path.join(bastion._job_history_dir, job_name)
-                if job_name in ("active", "pending"):
-                    # The 'active'/'pending' jobs do not generate hisotry.
-                    self.assertFalse(os.path.exists(history_file), msg=history_file)
-                else:
-                    self.assertTrue(os.path.exists(history_file), msg=history_file)
-                    with open(history_file, "r", encoding="utf-8") as f:
-                        history = f.read()
-                        expected_msg = {
-                            "resume": "ACTIVE: start process command",
-                            "preempt": "PENDING: pre-empting",
-                            "cleaning": "CLEANING: process finished",
-                            "cleaning_cancel": "CLEANING: process terminated",
-                            "completed": "COMPLETED: cleanup finished",
-                        }
-                        self.assertIn(expected_msg[job_name], history)
-
-            all_history_files = []
-            for project_id in [f"project{i}" for i in range(1, 3)]:
-                project_history_dir = os.path.join(bastion._project_history_dir, project_id)
-                project_history_files = list(os.scandir(project_history_dir))
-                for history_file in project_history_files:
-                    with open(history_file, "r", encoding="utf-8") as f:
-                        history = f.read()
-                        print(f"[{project_id}] {history}")
-                all_history_files.extend(project_history_files)
-            # "project1" and "project2".
-            self.assertLen(all_history_files, 2)
-
-    def test_gc_jobs(self):
-        """Tests GC mechanism.
-
-        1. Only PENDING/COMPLETED jobs are cleaned.
-        2. COMPLETED jobs that finish gc'ing should remove jobspecs.
-        """
-        # Note: command_proc and cleanup_proc shouldn't matter for GC. We only look at state +
-        # resources.
-        active_jobs = {}
-        init_job_states = {
-            "pending": JobState.PENDING,
-            "active": JobState.ACTIVE,
-            "cleaning": JobState.CLEANING,
-            "completed": JobState.COMPLETED,
-            "completed_gced": JobState.COMPLETED,
+        settings_kwargs = {
+            "permanent_bucket": "test-bucket",
+            "private_bucket": "test-private",
         }
-        for job_name, job_state in init_job_states.items():
-            active_jobs[job_name] = Job(
-                spec=new_jobspec(
-                    name=job_name,
-                    command="command",
-                    cleanup_command="cleanup",
-                    metadata=JobMetadata(
-                        user_id=f"{job_name}_user",
-                        project_id="project1",
-                        creation_time=datetime.now() - timedelta(days=1),
-                        resources={"v4": 1},
-                    ),
-                ),
-                state=job_state,
-                command_proc=None,
-                cleanup_proc=None,
-            )
-        # We pretend that only some jobs are "fully gc'ed".
-        fully_gced = ["completed_gced"]
-
-        patch_tfio = mock.patch.multiple(
-            f"{bastion_vm.__name__}.tf.io.gfile",
-            remove=mock.DEFAULT,
+        mock_job = _mock_job(
+            bastion_vm.StartBastionJob, bundler_kwargs={}, settings_kwargs=settings_kwargs
         )
-        with self._patch_bastion() as bastion, patch_tfio as mock_tfio:
-
-            def mock_clean(jobs: Dict[str, ResourceMap]) -> Sequence[str]:
-                self.assertTrue(
-                    all(
-                        active_jobs[job_name].state in {JobState.PENDING, JobState.COMPLETED}
-                        for job_name in jobs
-                    )
-                )
-                return fully_gced
-
-            with mock.patch.object(bastion, "_cleaner") as mock_cleaner:
-                mock_cleaner.configure_mock(**{"sweep.side_effect": mock_clean})
-                bastion._active_jobs = active_jobs
-                bastion._gc_jobs()
-
-            # Ensure that each fully GC'ed COMPLETED job deletes jobspec and state.
-            for job_name in fully_gced:
-                deleted_state = any(
-                    os.path.join(bastion._state_dir, job_name) in delete_call.args
-                    for delete_call in mock_tfio["remove"].mock_calls
-                )
-                deleted_jobspec = any(
-                    os.path.join(bastion._active_dir, job_name) in delete_call.args
-                    for delete_call in mock_tfio["remove"].mock_calls
-                )
-                self.assertEqual(
-                    active_jobs[job_name].state == JobState.COMPLETED,
-                    deleted_state and deleted_jobspec,
-                )
+        with mock_job as (mock_cfg, _):
+            bastion_vm.main(["cli", "start"], flag_values=fv)
+            bastion_cfg = mock_cfg.set.call_args.kwargs["bastion"]
+            _validate_required_fields(bastion_cfg)
+            self.assertIn("test-bucket", bastion_cfg.output_dir)
+            self.assertIn("test-bastion", bastion_cfg.output_dir)
+            self.assertIn("test-private", bastion_cfg.scheduler.quota.quota_file)

--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -178,6 +178,7 @@ class TPURunnerJob(TPUJob):
     @classmethod
     def from_flags(cls, fv: flags.FlagValues, **kwargs):
         cfg = super().from_flags(fv, **kwargs)
+        # NOTE: if running on TPU, name is required as there may not be a $USER.
         cfg.name = cfg.name or generate_job_name()
         cfg.output_dir = (
             cfg.output_dir or f"gs://{gcp_settings('ttl_bucket')}/axlearn/jobs/{cfg.name}"

--- a/axlearn/cloud/gcp/vertexai_tensorboard.py
+++ b/axlearn/cloud/gcp/vertexai_tensorboard.py
@@ -118,9 +118,7 @@ class VertexAITensorboardUploader(Configurable):
     def upload(self):
         """Uploads summaries in output_dir to Vertex AI. Runs/Keeps uploader process alive."""
         cfg = self.config
-        # TODO(vivekrathod): Refactor this pattern into a reusable class so we can apply it to all
-        # the helper processes associated with a Jobs such as syncing logs, uploading summaries
-        # among others.
+        # TODO(vivekrathod,markblee): Use Uploader.
         if self._uploader_proc is not None:
             self._uploader_proc.join(timeout=0)
             if not self._uploader_proc.is_alive():


### PR DESCRIPTION
- Introduces generic `Bastion`, `StartBastionJob`, and `SubmitBastionJob` in `bastion.py`. These can run outside of GCP.
- Changes `Scheduler.quota_config_file` into a configurable `Scheduler.quota`. This supports flexible quota management (not limited to quota file).
- Split out the bastion log upload into an `Uploader` class -- this allows for other synchronization mechanisms, not necessarily `gsutil rsync`. Eventually, we can also reuse for `VertexAITensorboardUploader`.
- Adds more testing in various places.