### PR TITLE
Fix RoPE dtype

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -1048,6 +1048,7 @@ class RoFormerQKVLinear(BaseQKVLinear):
         positions = jnp.arange(cfg.max_seq_length)
         # sinusoidal_pos_emb shape should be [1, num_len, 1, dim]
         sinusoidal_pos_emb = jnp.expand_dims(self.rope_pos_emb_layer.forward(positions), [0, 2])
+        sinusoidal_pos_emb = sinusoidal_pos_emb.astype(query.dtype)
         kwargs = {"sinusoidal_pos": sinusoidal_pos_emb, "query": query, "key": key, "value": value}
         query, key, value = apply_rotary_position_embeddings(**kwargs)
 


### PR DESCRIPTION
Without the fix, the out will be casted to float32 even if train_dtype is different.