### PR TITLE
Tighten cryptography/pyopenssl pins.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,8 @@ gcp = [
     "crcmod",  # for file uploads.
     "google-api-python-client==1.8.0",
     "google-auth==2.23.0",
-    "google-auth[pyopenssl]",  # Ensures that we have the right pyopenssl/cryptography pins.
+    "google-auth[pyopenssl]",  # Ensures that we have compatible pyopenssl/cryptography pins.
+    "pyOpenSSL>=22.1.0",  # compat with cryptography version.
     "google-cloud-storage==2.2.1",
     "google-cloud-core==2.3.3",
 ]


### PR DESCRIPTION
On v5e we sometimes get `pyopenssl==21.0.0` and `cryptography==41.0.4` despite the `google-auth[pyopenssl]` pin. This leads to error `AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms'`. We ensure that `pyopenssl>=22.1.0` which specifies min/max bounds on compatible `cryptography` versions.