### PR TITLE
Adds a pointer to https://github.com/apple/axlearn/blob/main/docs/01-start.md#preparing-the-cli in the error message.

### DIFF
--- a/axlearn/cli/gcp.py
+++ b/axlearn/cli/gcp.py
@@ -16,7 +16,7 @@ def add_cmd_group(*, parent: CommandGroup):
 
     gcp_cmd = CommandGroup("gcp", parent=parent)
 
-    _, gcp_configs = load_configs(CONFIG_NAMESPACE)
+    _, gcp_configs = load_configs(CONFIG_NAMESPACE, required=True)
     active_config = gcp_configs.get("_active", None)
 
     if active_config is None:

--- a/axlearn/cli/utils_test.py
+++ b/axlearn/cli/utils_test.py
@@ -85,9 +85,7 @@ class TestUtils(parameterized.TestCase):
             self.assertEqual(e.exception.code, 0)
 
             helpstring = stdout.getvalue()
-            self.assertRegex(
-                helpstring, r"usage: .* child1 \[-h\] \[--helpfull\] \[--child1\] {grandchild1}"
-            )
+            self.assertRegex(helpstring, r"usage: .* child1 .*")
 
         # Test that passing --help exits without error.
         with mock.patch("sys.stdout", new=StringIO()) as stdout:
@@ -96,10 +94,7 @@ class TestUtils(parameterized.TestCase):
             self.assertEqual(e.exception.code, 0)
 
             helpstring = stdout.getvalue()
-            self.assertRegex(
-                helpstring,
-                r"usage: .* child1 grandchild1 \[-h\] \[--helpfull\] {command1,command2}",
-            )
+            self.assertRegex(helpstring, r"usage: .* child1 grandchild1 .*")
 
     def test_invoke_basic(self):
         # Test invoking a command.

--- a/axlearn/cli/utils_test.py
+++ b/axlearn/cli/utils_test.py
@@ -70,8 +70,8 @@ class TestUtils(parameterized.TestCase):
 
         # Test that invoking CLI by itself prints the help message.
         returncode, stdout, stderr = _run(_parse([self.root_module]))
-        self.assertRegex(stdout, r"usage: .*")
-        self.assertEqual(returncode, 0, msg=stderr)
+        self.assertRegex(stderr, r".*A config file could not be found.*", msg=(stdout, stderr))
+        self.assertEqual(returncode, 1, msg=stderr)
 
         # Test that invoking subcommand by itself injects --help.
         args = _parse([self.root_module, "child1"])

--- a/axlearn/cloud/common/config.py
+++ b/axlearn/cloud/common/config.py
@@ -62,11 +62,11 @@ def load_configs(
         config_file = user_config_file
 
     if required and config_file is None:
-        # TODO(markblee): Link to docs once available.
         logging.error(
             "A config file could not be found; please create one first. "
-            "Please refer to the docs for instructions. Please also make sure the config file "
-            "can be found in one of: %s",
+            "Please refer to the docs for instructions: "
+            "https://github.com/apple/axlearn/blob/main/docs/01-start.md#preparing-the-cli. "
+            "Please also make sure the config file can be found in one of: %s",
             _config_search_paths(),
         )
         sys.exit(1)


### PR DESCRIPTION
Before this change:
```
% axlearn gcp config help
WARNING: Logging before flag parsing goes to stderr.
W1012 10:04:07.627535 8347255104 gcp.py:23] No GCP project has been activated; please run `axlearn gcp config activate`.
```

With this change:
```
 % axlearn gcp config help
WARNING: Logging before flag parsing goes to stderr.
E1012 10:06:21.044147 8347255104 config.py:65] A config file could not be found; please create one first. Please refer to the docs for instructions: https://github.com/apple/axlearn/blob/main/docs/01-start.md#preparing-the-cli. Please also make sure the config file can be found in one of: ['.../.axlearn.config', '/Users/rpang/.axlearn.config']
```