### PR TITLE
Replaces uses of `utils.host_to_global_device_array` with `map_utils.host_local_array_to_global_array`.

### DIFF
--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -301,6 +301,7 @@ class SpmdTrainer(Module):
                     ) as f:
                         f.write(str(jax.tree_util.tree_structure(self._trainer_state)))
             self._log_trainer_state_stats()
+            self._step_log("Input partition specs: %s", self._input_partition_specs)
             # Log config.
             self.summary_writer.log_config(cfg, step=self.step)
 


### PR DESCRIPTION
This potentially allows us to specify custom partition specs instead of only sharding along the batch axis.