### PR TITLE
Bump jax/jaxlib to 0.4.18.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG TARGET=base
-ARG BASE_IMAGE=python:3.8-slim
+ARG BASE_IMAGE=python:3.9-slim
 
 FROM ${BASE_IMAGE} AS base
 

--- a/axlearn/cloud/gcp/tpu.py
+++ b/axlearn/cloud/gcp/tpu.py
@@ -592,13 +592,9 @@ def _tpu_body(
         startup_script_contents = of.read()
     docker_repo = gcp_settings("docker_repo", required=False)
 
-    if tpu_type.startswith("v4"):
-        runtime_version = "tpu-vm-v4-base"
-    elif tpu_type.startswith("v5lite"):
-        runtime_version = "v2-alpha-tpuv5-lite"
-    else:
-        # TODO(markblee): Verify whether this is still applicable on tf>2.8.0.
-        runtime_version = "tpu-vm-tf-2.8.0"
+    runtime_version = "tpu-ubuntu2204-base"
+    if not (tpu_type.startswith("v4") or tpu_type.startswith("v5lite")):
+        raise ValueError(f"Unknown TPU-VM runtime version for {tpu_type}.")
 
     body = {
         "acceleratorType": tpu_type,

--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -976,7 +976,7 @@ class RoFormerSinusoidalPositionalEmbeddingAgainstLLaMATest(TestCase):
             prng_key=jax.random.PRNGKey(0),
         )
         llama_rope = self.llama_ref_precompute_freqs_cis(dim=dim, end=max_len, theta=theta)
-        axlearn_imag, axlearn_real = axlearn_rope.split(2, axis=-1)
+        axlearn_imag, axlearn_real = jnp.split(axlearn_rope, 2, axis=-1)
         llama_real, llama_imag = llama_rope.real, llama_rope.imag
         assert_allclose(llama_real, as_tensor(axlearn_real))
         assert_allclose(llama_imag, as_tensor(axlearn_imag))

--- a/axlearn/common/base_layer_test.py
+++ b/axlearn/common/base_layer_test.py
@@ -119,7 +119,7 @@ def _callback_primitive(forward, backward):
     prim = jax.core.Primitive("passthrough_with_callback")
     prim.def_impl(forward_impl)
     prim.def_abstract_eval(forward_impl)
-    jax.ad.deflinear(prim, backward_impl)
+    jax.interpreters.ad.deflinear(prim, backward_impl)
     return prim.bind
 
 

--- a/axlearn/common/gda_test.py
+++ b/axlearn/common/gda_test.py
@@ -59,7 +59,7 @@ class GDATest(TestCase):
             pjit_fn = pjit.pjit(
                 lambda x: x,
                 in_shardings=(partition_spec,),
-                out_axis_resources=partition_spec,
+                out_shardings=partition_spec,
             )
             output = pjit_fn(global_input_batch)
             self.assertIsInstance(output["x"], Tensor)

--- a/axlearn/common/inference.py
+++ b/axlearn/common/inference.py
@@ -202,8 +202,6 @@ class InferenceRunner(Module):
             utils.validate_float_dtype(cfg.inference_dtype)
 
         # Create device mesh.
-        if not jax.config.jax_array:  # pylint: disable=no-member
-            raise NotImplementedError(f"{self.__class__.__name__} requires jax_array=True")
         logging.info(
             "Devices: global=%s local=%s %s",
             jax.device_count(),
@@ -345,7 +343,7 @@ class InferenceRunner(Module):
                     self._inference_runner_state_partition_specs.prng_key,
                     data_partition_spec,  # Input batch.
                 ),
-                out_axis_resources=(
+                out_shardings=(
                     self._inference_runner_state_partition_specs.prng_key,
                     data_partition_spec,  # Output batch.
                     None,  # Summaries.

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -50,17 +50,6 @@ from axlearn.common.utils import (
 )
 from axlearn.experiments.trainer_config_utils import TrainerConfigFn
 
-# Instead of running setup() in TestCase.setUp(), we need to run it here, because setUp() runs
-# after parameterized.parameters(), so if we have
-#     @parameterized.parameters(
-#         {
-#             "data": jnp.array([[1.0, 0.8, 0, 0]], dtype=jnp.float32),
-#         }
-#     )
-# `data` will be of type jax.DeviceArray() instead of jax.Array() because we haven't called
-# jax.config.update("jax_array", True) yet.
-utils_spmd.setup()
-
 # See utils_spmd.py for where we set "jax_default_prng_impl".
 _default_prng_impl = "rbg"
 _PYTEST_OPT_REGISTERED = {}
@@ -123,6 +112,7 @@ class TestCase(parameterized.TestCase):
         return "FAKE"
 
     def setUp(self):
+        utils_spmd.setup()
         push_data_dir(self.data_dir)
 
     def tearDown(self) -> None:

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -167,8 +167,6 @@ class SpmdTrainer(Module):
             utils.validate_float_dtype(cfg.train_dtype)
 
         # Create the device mesh.
-        if not jax.config.jax_array:  # pylint: disable=no-member
-            raise NotImplementedError(f"{self.__class__.__name__} requires jax_array=True")
         self._step_log(
             "Devices: global=%s local=%s %s",
             jax.device_count(),

--- a/axlearn/common/utils_spmd.py
+++ b/axlearn/common/utils_spmd.py
@@ -41,9 +41,6 @@ def setup(
     """
     # Use a GSPMD-friendly PRNG implementation.
     jax.config.update("jax_default_prng_impl", "rbg")
-    # Use JAX array.
-    # https://jax.readthedocs.io/en/latest/jax_array_migration.html#jax-array-migration.
-    jax.config.update("jax_array", True)
     # This allows replicated jax.Arrays to be used for computation on the host.
     jax.config.update("jax_spmd_mode", "allow_all")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "axlearn"
 version = "0.0.1"
 description = "AXLearn"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 # Production dependencies.
 # Every time we upgrade JAX, we should try to bring the rest to the newest versions.
@@ -15,13 +15,13 @@ dependencies = [
     "attrs>=21.3.0",
     "absl-py",
     "chex>=0.1.6",
-    "flax==0.7.1",  # only for checkpoints. Will require python 3.9 on 0.7.3.
+    "flax==0.7.4",  # only for checkpoints.
     "importlab==0.7",  # breaks pytype on 0.8
-    "jax==0.4.13",
-    "jaxlib==0.4.13",
+    "jax==0.4.18",
+    "jaxlib==0.4.18",
     "nltk==3.7",  # for text preprocessing
     "numpy<1.24",  # needed to pin to < 1.24; tf ragged_tensor depends on deprecated np.object.
-    "optax==0.1.3",  # optimizers (0.1.0 has known bugs).
+    "optax==0.1.7",  # optimizers (0.1.0 has known bugs).
     "portpicker",
     "protobuf==3.20.3",  # needed to pin to 3.20.x or lower for tensorflow 2.8.0.
     "tensorboard-plugin-profile==2.8.0",  # needed to pin to 2.8.0 for tensorflow 2.8.0.
@@ -42,11 +42,11 @@ apple-silicon = [
     "attrs>=21.3.0",
     "absl-py",
     "chex>=0.1.6",
-    "flax==0.7.1",  # only for checkpoints. Will require python 3.9 on 0.7.3.
-    "jax==0.4.13",
-    "jaxlib==0.4.13",
+    "flax==0.7.4",  # only for checkpoints.
+    "jax==0.4.18",
+    "jaxlib==0.4.18",
     "nltk==3.7",  # for text preprocessing
-    "optax>=0.1.1",  # optimizers (0.1.0 has known bugs).
+    "optax>=0.1.7",  # optimizers (0.1.0 has known bugs).
     "portpicker",
     "tensorboard-plugin-profile==2.8.0",  # needed to pin to 2.8.0 for tensorflow 2.8.0.
     "tensorflow-datasets==4.7.0",
@@ -75,7 +75,7 @@ dev = [
     "timm==0.6.12",  # DiT Dependency test-only
     "torch>=1.12.1",  # test-only
     "torchvision==0.14.1",  # test-only
-    "transformers==4.27.1",  # test-only
+    "transformers==4.34.0",  # test-only
     "wandb",  # test-only
     "wrapt",  # implied by tensorflow-datasets, but also used in config tests.
 ]
@@ -94,7 +94,7 @@ gcp = [
 # Note: Specify -f https://storage.googleapis.com/jax-releases/libtpu_releases.html during install.
 tpu = [
     "axlearn[gcp]",
-    "jax[tpu]==0.4.13",
+    "jax[tpu]==0.4.18",
 ]
 # Note: Currently tested on x86.
 t5x = [
@@ -104,9 +104,9 @@ t5x = [
 # Jax-triton. Can only be installed on a GPU machine.
 jax_triton = [
     "cmake",
-    # Compatible with jax 0.4.13.
-    "jax-triton@git+https://github.com/jax-ml/jax-triton.git@c3721db034b4311e0a8799d6a28ce8aea7be1da1",
-    "jaxlib==0.4.13+cuda12.cudnn89",
+    # Compatible with jax 0.4.18.
+    "jax-triton@git+https://github.com/jax-ml/jax-triton.git@06d35175fbb65771243f607b1f098ec4a75556c9",
+    "jaxlib==0.4.18+cuda12.cudnn89",
     "nvidia-cudnn-cu12==8.9.2.26",
     # To avoid conflicting with jax.
     "tensorflow-cpu==2.8.0",


### PR DESCRIPTION
* Minimum Python version will now be 3.9.
* Compatibility with Huggingface/transformers flax implementations will be limited until they upgrade their dependencies.