### PR TITLE
Fixes large memory usage by pipeline

### DIFF
--- a/axlearn/common/pipeline.py
+++ b/axlearn/common/pipeline.py
@@ -240,9 +240,9 @@ class Pipeline(BaseLayer):
             """Pads input [M, microbatch_size, ...] to [M + N - 1, 1, microbatch_size, ...]."""
             # Pad to shape [M + N - 1, ...].
             v_carry = jnp.pad(v_carry, [(0, n - 1)] + [(0, 0)] * (v_carry.ndim - 1))
-            v_carry = with_sharding_constraint(v_carry, PartitionSpec(
-                PartitionSpec.UNCONSTRAINED, *partition_spec[1:]
-            ))
+            v_carry = with_sharding_constraint(
+                v_carry, PartitionSpec(PartitionSpec.UNCONSTRAINED, *partition_spec[1:])
+            )
             # Expand to shape [M + N - 1, 1, ...].
             v_carry = jnp.expand_dims(v_carry, 1)
             return v_carry


### PR DESCRIPTION
Pipeline takes carry inputs of shape [M=num_microbatches, microbatch_size, ...].

Currently the code pads carry tensors to shape [M + N - 1, N=num_layers, microbatch_size, ...] to fully materialize the inputs to every layer on each iteration. This blows up memory usage when carry is large, e.g., one of the tensors can be [batch, num_heads, seq_len, seq_len], representing ALiBi attention logit biases.

Full materialization before the loop is actually unnecessary. Instead, we can pad carry to [M + N - 1, 1, microbatch_size, ...]. Within each iteration, we can generate inputs of shape [N, microbatch_size, ...] by concatenating the inputs to layer 0 with
the outputs of layer [0..N-2].
