### PR TITLE
Add TPU flash-attention implementation.

### DIFF
--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -1,0 +1,70 @@
+# Copyright © 2023 Apple Inc.
+
+"""Wrappers for FlashAttention on TPU in JAX with logit bias support."""
+import functools
+from typing import Optional
+
+import jax
+import jax.numpy as jnp
+from jax.experimental.pallas.ops.tpu.flash_attention import BlockSizes
+from jax.experimental.pallas.ops.tpu.flash_attention import flash_attention as tpu_flash_attention
+
+from axlearn.common.utils import Tensor
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "causal",
+        "softmax_scale",
+        "block_sizes",
+    ],
+)
+def flash_attention(
+    query: Tensor,  # [batch_size, q_seq_len, num_heads, d_model]
+    key: Tensor,  # [batch_size, kv_seq_len, num_heads, d_model]
+    value: Tensor,  # [batch_size, kv_seq_len, num_heads, d_model]
+    bias: Tensor = None,  # [batch_size, num_heads, q_seq_len, kv_seq_len]
+    *,
+    causal: bool = False,
+    softmax_scale: float = 1.0,
+    block_sizes: Optional[BlockSizes] = None,
+):
+    """Wraps JAX's TPU flash-attention, with reshapes and softmax-scaling outside kernel.
+
+    N.B. we apply the softmax scale factor outside of the kernel because:
+        1. within-kernel ordering of attention-bias addition and softmax scaling differ to axlearn,
+        2. it's more efficient to scale outside the kernel vs. fix order of ops in kernel.
+
+    Args:
+        query: The query tensor, of shape [batch_size, target_seq_len, num_heads, head_dim].
+        key: The key tensor, of shape [batch_size, source_seq_len, num_heads, head_dim].
+        value: The value tensor, of shape [batch_size, source_seq_len, num_heads, head_dim].
+        bias: The attention biases, of shape [batch_size, num_heads, q_seq_len, source_seq_len].
+        causal: Whether the attention is causal (allows for additional optimizations).
+        softmax_scale: A scaling factor applied to the query.
+
+    Returns:
+        The context tensor, of shape [batch_size, q_seq_len, num_heads, head_dim].
+
+    """
+    # Apply the softmax scale outside the kernel (see docstring for why).
+    if softmax_scale != 1.0:
+        query *= softmax_scale
+    # Switch num_heads and seq_len axes.
+    query = jnp.einsum("btnh->bnth", query)
+    key = jnp.einsum("bsnh->bnsh", key)
+    value = jnp.einsum("bsnh->bnsh", value)
+    context = tpu_flash_attention(
+        q=query,
+        k=key,
+        v=value,
+        ab=bias,
+        causal=causal,
+        # If sm_scale==1.0, the kernel skips applying it.
+        sm_scale=1.0,
+        block_sizes=block_sizes,
+        debug=False,
+    )
+    # Restore num_heads and seq_len axes.
+    return jnp.einsum("bnth->btnh", context)

--- a/axlearn/common/flash_attention/tpu_attention_benchmark.py
+++ b/axlearn/common/flash_attention/tpu_attention_benchmark.py
@@ -1,0 +1,142 @@
+# Copyright © 2023 Apple Inc.
+
+"""Benchmark TPU FlashAttention kernels.
+
+Sample outputs:
+
+Benchmarking attention representative of 1.2b model layer on TPU v4.
+ref_fwd:0.0030s, flash_fwd:0.0012s
+ref_bwd:0.0075s, flash_bwd:0.0054s
+
+Benchmarking attention representative of 12.6b model layer on TPU v4.
+ref_fwd:0.0043s, flash_fwd:0.0016s
+ref_bwd:0.0098s, flash_bwd:0.0071s
+
+Benchmarking attention representative of 29.6b model layer on TPU v4.
+ref_fwd:0.0060s, flash_fwd:0.0022s
+ref_bwd:0.0135s, flash_bwd:0.0101s
+
+Benchmarking attention representative of 65.2b model layer on TPU v4.
+ref_fwd:0.0077s, flash_fwd:0.0028s
+ref_bwd:0.0176s, flash_bwd:0.0130s
+
+Benchmarking attention representative of 134b model layer on TPU v4.
+ref_fwd:0.0094s, flash_fwd:0.0035s
+ref_bwd:0.0216s, flash_bwd:0.0158s
+
+Benchmarking attention representative of 261.7b model layer on TPU v4.
+ref_fwd:0.0105s, flash_fwd:0.0035s
+ref_bwd:0.0254s, flash_bwd:0.0182s
+
+Benchmarking attention representative of 539.5b model layer on TPU v4.
+ref_fwd:0.0134s, flash_fwd:0.0047s
+ref_bwd:0.0324s, flash_bwd:0.0237s
+"""
+import time
+from typing import Callable
+
+import jax
+import jax.numpy as jnp
+
+from axlearn.common.flash_attention.utils import flash_attention_implementation, mha_reference
+
+_BENCHMARK_CONFIGS = {
+    "1.2b": dict(
+        num_heads=32,
+        per_head_dim=64,
+    ),
+    "12.6b": dict(
+        num_heads=40,
+        per_head_dim=128,
+    ),
+    "29.6b": dict(
+        num_heads=56,
+        per_head_dim=128,
+    ),
+    "65.2b": dict(
+        num_heads=72,
+        per_head_dim=128,
+    ),
+    "134b": dict(
+        num_heads=88,
+        per_head_dim=128,
+    ),
+    "261.7b": dict(
+        num_heads=110,
+        per_head_dim=128,
+    ),
+    "539.5b": dict(
+        num_heads=140,
+        per_head_dim=128,
+    ),
+}
+
+
+def _time_call(fn: Callable, *, num_iters: int = 5) -> float:
+    """Times average execution time for fn call after warmup over num_iters."""
+    fn().block_until_ready()
+    tic = time.perf_counter()
+    for _ in range(num_iters):
+        fn().block_until_ready()
+    toc = time.perf_counter()
+    return (toc - tic) / num_iters
+
+
+def _benchmark(
+    *,
+    batch_size: int,
+    seq_len: int,
+    block_size: int,
+    num_heads: int,
+    per_head_dim: int,
+    causal: bool = True,
+):
+    """Benchmarks TPU FlashAttention vs reference impl."""
+    k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(0), 4)
+    q = jax.random.normal(k1, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16)
+    k = jax.random.normal(k2, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16)
+    v = jax.random.normal(k3, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16)
+    bias = jax.random.normal(k4, (batch_size, num_heads, seq_len, seq_len), dtype=jnp.bfloat16)
+
+    softmax_scale = per_head_dim**-0.5
+    ref_fwd_time = _time_call(
+        lambda: mha_reference(q, k, v, bias, causal=causal, softmax_scale=softmax_scale)
+    )
+
+    grad_fn = jax.jit(
+        jax.grad(
+            lambda q, k, v, b: mha_reference(
+                q, k, v, b, causal=causal, softmax_scale=softmax_scale
+            ).mean(),
+            argnums=(0, 1, 2),
+        )
+    )
+    ref_bwd_time = _time_call(lambda: grad_fn(q, k, v, bias)[0])
+
+    # Get fwd & bwd timing information when softmax scaling applied before calling the kernel.
+    mha_impl = flash_attention_implementation(
+        "tpu", causal=causal, softmax_scale=softmax_scale, block_size=block_size
+    )
+
+    flash_fwd_time = _time_call(lambda: mha_impl(q, k, v, bias))
+
+    flash_grad_fn = jax.jit(
+        jax.grad(lambda q, k, v, b: mha_impl(q, k, v, b).mean(), argnums=(0, 1, 2))
+    )
+    flash_bwd_time = _time_call(lambda: flash_grad_fn(q, k, v, bias)[0])
+
+    print(f"ref_fwd:{ref_fwd_time:.4f}s, flash_fwd:{flash_fwd_time:.4f}s")
+    print(f"ref_bwd:{ref_bwd_time:.4f}s, flash_bwd:{flash_bwd_time:.4f}s\n")
+
+
+if __name__ == "__main__":
+    assert jax.default_backend() == "tpu", "Benchmarking requires a TPU backend."
+    device_kind = jax.devices()[0].device_kind
+    for name, cfg in _BENCHMARK_CONFIGS.items():
+        print(f"Benchmarking attention representative of {name} model layer on {device_kind}.")
+        _benchmark(
+            batch_size=2,
+            seq_len=2048,
+            block_size=4 * 128,
+            **cfg,
+        )

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -1,0 +1,87 @@
+# Copyright © 2023 Apple Inc.
+
+"""Tests TPU FlashAttention kernels."""
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+from absl.testing import parameterized
+
+from axlearn.common.flash_attention.tpu_attention import flash_attention
+from axlearn.common.flash_attention.utils import mha_reference
+from axlearn.common.test_utils import TestCase
+
+if jax.default_backend() != "tpu":
+    pytest.skip(reason="Incompatible hardware", allow_module_level=True)
+
+
+class TestFlashAttention(TestCase):
+    """Tests FlashAttention layer."""
+
+    _TEST_CONFIGS = [
+        dict(
+            batch_size=2,
+            seq_len=384,
+            num_heads=4,
+            per_head_dim=32,
+        ),
+        dict(
+            batch_size=2,
+            seq_len=2048,
+            num_heads=4,
+            per_head_dim=64,
+        ),
+        dict(
+            batch_size=8,
+            seq_len=2048,
+            num_heads=4,
+            per_head_dim=64,
+        ),
+    ]
+
+    @parameterized.product(
+        _TEST_CONFIGS,
+        causal=[False, True],
+        with_attention_bias=[False, True],
+    )
+    def test_forward_and_backward(
+        self, batch_size, seq_len, num_heads, per_head_dim, causal, with_attention_bias
+    ):
+        k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(0), 4)
+        q = jax.random.normal(
+            k1, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16
+        )
+        k = jax.random.normal(
+            k2, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16
+        )
+        v = jax.random.normal(
+            k3, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16
+        )
+        attention_bias = None
+        if with_attention_bias:
+            attention_bias = jax.random.normal(
+                k4, (batch_size, num_heads, seq_len, seq_len), dtype=jnp.bfloat16
+            )
+
+        softmax_scale = q.shape[-1] ** -0.5
+
+        def ref_fn(q, k, v, bias):
+            return mha_reference(q, k, v, bias, causal=causal, softmax_scale=softmax_scale)
+
+        def fn(q, k, v, bias):
+            return flash_attention(q, k, v, bias, causal=causal, softmax_scale=softmax_scale)
+
+        # Compare outputs.
+        out = fn(q, k, v, attention_bias)
+        ref_out = ref_fn(q, k, v, attention_bias)
+        self.assertNestedAllClose(out, ref_out, atol=0.05)
+
+        # Compare grads.
+        grad_out = jax.grad(lambda q, k, v, b: fn(q, k, v, b).mean(), argnums=(0, 1, 2))(
+            q, k, v, attention_bias
+        )
+        ref_grad_out = jax.grad(lambda q, k, v, b: ref_fn(q, k, v, b).mean(), argnums=(0, 1, 2))(
+            q, k, v, attention_bias
+        )
+        self.assertNestedAllClose(grad_out, ref_grad_out, atol=0.05)

--- a/axlearn/common/flash_attention/utils.py
+++ b/axlearn/common/flash_attention/utils.py
@@ -1,0 +1,137 @@
+# Copyright © 2023 Apple Inc.
+
+"""FlashAttention utilities shared amongst CPU/GPU/TPU backends."""
+import functools
+from typing import Callable, Literal, Optional
+
+import jax
+import jax.numpy as jnp
+from absl import logging
+from jax.experimental.pallas.ops.tpu.flash_attention import BlockSizes
+
+from axlearn.common.attention import NEG_INF
+from axlearn.common.flash_attention.tpu_attention import flash_attention as tpu_flash_attention
+from axlearn.common.utils import Tensor
+
+
+@functools.partial(jax.jit, static_argnames=["causal", "softmax_scale"])
+@jax.default_matmul_precision("bfloat16")
+def mha_reference(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    bias: Optional[Tensor] = None,
+    *,
+    causal: bool = False,
+    softmax_scale: float = 1.0,
+) -> Tensor:
+    """Reference multi-headed attention implementation."""
+    # We apply the scale factor before the attention biases.
+    q *= softmax_scale
+    logits = jnp.einsum("btnh,bsnh->bnts", q, k)
+
+    if bias is not None:
+        logits += bias.astype(logits.dtype)
+
+    if causal:
+        mask_shape = (q.shape[1], k.shape[1])
+        row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+        col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+        causal_mask = (row_ids < col_ids)[None, None, :, :]
+        logits = jnp.where(causal_mask, NEG_INF, logits)
+
+    logits_dtype = logits.dtype
+    logits = logits.astype(jnp.float32)
+    probs = jax.nn.softmax(logits, axis=-1).astype(logits_dtype)
+    return jnp.einsum("bnts,bsnh->btnh", probs, v)
+
+
+# Accepts [query, key, value, attention_bias] tensors and returns the context Tensor.
+MultiHeadAttentionImpl = Callable[[Tensor, Tensor, Tensor, Tensor], Tensor]
+
+
+def flash_attention_implementation(
+    backend: Literal["cpu", "tpu", "gpu"],
+    *,
+    causal: bool,
+    softmax_scale: float,
+    block_size: int = 128,
+) -> MultiHeadAttentionImpl:
+    """Returns a jitted "flash" multihead-attention implementation for the given backend.
+
+    Args:
+        backend: A valid XLA backend name. 'cpu' intended for testing only.
+        causal: Whether the attention is causal (allows for additional efficiency optimizations).
+        softmax_scale: A scalar value applied to the logits before softmax.
+        block_size: The size of the computation-block unit, only applies to the 'tpu' backend.
+            A multiple of 128, and should be less than the target sequence length.
+            Smaller values are more memory efficient but less compute efficient.
+
+    Returns:
+        A jitted function implementing multi-head attention for the given backend.
+
+    Raises:
+        NotImplementedError: If implementation for the backend is not available.
+    """
+    if backend == "gpu":
+        # Lazy import GPU flash-attention to avoid file-level dependency on jax-triton.
+        # pylint: disable-next=import-outside-toplevel
+        from axlearn.common.flash_attention.gpu_attention import (
+            flash_attention as gpu_flash_attention,
+        )
+
+        # shard_map-decorated function needs to be jitted.
+        @jax.jit
+        def jit_attn(query, key, value, bias):
+            return gpu_flash_attention(
+                query, key, value, bias=bias, causal=causal, softmax_scale=softmax_scale
+            )
+
+        return jit_attn
+
+    elif backend == "tpu":
+        # TODO(tom_gunter): See if we can do better block-size tuning.
+        block_sizes = BlockSizes(
+            block_q=block_size,
+            block_k_major=block_size,
+            block_k=block_size,
+            block_b=1,
+            block_q_major_dkv=block_size,
+            block_k_major_dkv=block_size,
+            block_k_dkv=block_size,
+            block_q_dkv=block_size,
+            block_k_major_dq=block_size,
+            block_k_dq=block_size,
+            block_q_dq=block_size,
+        )
+
+        # shard_map-decorated function needs to be jitted.
+        @jax.jit
+        def jit_attn(query, key, value, bias):
+            context = tpu_flash_attention(
+                query,
+                key,
+                value,
+                bias=bias,
+                causal=causal,
+                softmax_scale=softmax_scale,
+                block_sizes=block_sizes,
+            )
+            return context
+
+        return jit_attn
+
+    elif backend == "cpu":
+        logging.warning("Flash attention CPU backend is for testing only.")
+
+        # shard_map-decorated function needs to be jitted.
+        @jax.jit
+        def jit_attn(query, key, value, bias):
+            return mha_reference(
+                query, key, value, bias=bias, causal=causal, softmax_scale=softmax_scale
+            )
+
+        return jit_attn
+
+    else:
+        raise NotImplementedError(f"Backend ({backend}) does not have an implementation.")

--- a/axlearn/common/transducer_test.py
+++ b/axlearn/common/transducer_test.py
@@ -15,6 +15,7 @@ from jax.experimental import checkify
 
 from axlearn.common.config import config_for_function
 from axlearn.common.module import functional as F
+from axlearn.common.test_utils import TestWithTemporaryCWD
 from axlearn.common.transducer import (
     _NEG_INF,
     Transducer,
@@ -103,7 +104,7 @@ def assert_all_close(x, y, atol=1e-5, rtol=1e-5, err_msg=None):
 
 
 # pylint: disable=no-self-use
-class AlignmentTest(parameterized.TestCase, tf.test.TestCase):
+class AlignmentTest(TestWithTemporaryCWD, tf.test.TestCase):
     def test_single_route(self):
         U = T = 4
         self._test_prefix_probs(


### PR DESCRIPTION
`axlearn.common.flash_attention.layer.FlashAttention` now has a (tested) TPU impl, and can be used as a drop-in replacement for `axlearn.common.attention.MultiheadAttention` in most cases.