### PR TITLE
Infers mesh shape when using state builder.

### DIFF
--- a/axlearn/common/launch_trainer.py
+++ b/axlearn/common/launch_trainer.py
@@ -8,7 +8,8 @@ import jax
 import tensorflow as tf
 from absl import flags, logging
 
-from axlearn.common.trainer import SpmdTrainer, infer_mesh_shape, select_mesh_config
+from axlearn.common.trainer import SpmdTrainer, select_mesh_config
+from axlearn.common.utils import infer_mesh_shape
 from axlearn.experiments import TrainerConfigFn, get_named_trainer_config
 
 # Trainer-specific flags.

--- a/axlearn/common/state_builder.py
+++ b/axlearn/common/state_builder.py
@@ -45,6 +45,7 @@ from axlearn.common.utils import (
     check_param_shape_alignment,
     flatten_items,
     get_data_dir,
+    infer_mesh_shape,
     set_data_dir,
 )
 from axlearn.experiments.trainer_config_utils import TrainerConfigFn
@@ -417,7 +418,7 @@ class BaseConverterFromPretrainedModel(Converter):
     @config_class
     class Config(Converter.Config):
         # A config that instantiates to a TrainerConfigFn that defines the source pretrained model.
-        source_trainer_config: Required[InstantiableConfig] = REQUIRED
+        source_trainer_config: Required[InstantiableConfig[TrainerConfigFn]] = REQUIRED
         source_data_dir: Optional[str] = None
         mesh_axis_names: Optional[Sequence[str]] = None
         mesh_shape: Optional[Sequence[int]] = None
@@ -434,7 +435,7 @@ class BaseConverterFromPretrainedModel(Converter):
             trainer_cfg.mesh_axis_names = (
                 cfg.mesh_axis_names or trainer_cfg.mesh_axis_names or ("data", "model")
             )
-            trainer_cfg.mesh_shape = (
+            trainer_cfg.mesh_shape = infer_mesh_shape(
                 cfg.mesh_shape or trainer_cfg.mesh_shape or (len(jax.devices()), 1)
             )
             trainer = trainer_cfg.instantiate(parent=None)

--- a/axlearn/common/state_builder_test.py
+++ b/axlearn/common/state_builder_test.py
@@ -35,6 +35,7 @@ from axlearn.common.repeat import Repeat
 from axlearn.common.state_builder import (
     _BUILDERS,
     BaseConv2DStateBuilder,
+    BaseConverterFromPretrainedModel,
     Builder,
     ChainBuilder,
     ChainConverter,
@@ -724,6 +725,20 @@ class TestConv2DStateBuilders(TestCase):
             input_size=input_size,
         )
         return mock_trainer_config(input_config=input_cfg, model_config=model_cfg)
+
+
+class BaseConverterFromPretrainedModelTest(TestCase):
+    """Sanity checks for BaseConverterFromPretrainedModel."""
+
+    def test_mesh_shape(self):
+        mock_trainer_cfg, mock_state = _create_dummy_state(jax.random.PRNGKey(1))
+        cfg = BaseConverterFromPretrainedModel.default_config().set(
+            source_trainer_config=mock_trainer_cfg,
+            mesh_shape=(-1, 1),
+        )
+        # Ensure that we're able to instantiate mock_trainer_cfg with -1 in the mesh.
+        converter = cfg.set(name="test_converter").instantiate(parent=None)
+        converter.target_to_source(mock_state)
 
 
 class DiffusersPretrainedBuilderTest(TestCase):

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -31,13 +31,7 @@ from axlearn.common.evaler import every_n_steps_policy as eval_every_n_steps_pol
 from axlearn.common.learner import UpdateType, should_update_with_optimizers
 from axlearn.common.module import Module
 from axlearn.common.state_builder import Builder as TrainerStateBuilder
-from axlearn.common.trainer import (
-    SpmdTrainer,
-    _prune_empty,
-    _TrainerState,
-    infer_mesh_shape,
-    select_mesh_config,
-)
+from axlearn.common.trainer import SpmdTrainer, _prune_empty, _TrainerState, select_mesh_config
 from axlearn.common.utils import NestedTensor, Tensor, as_tensor, flatten_items, match_regex_rules
 
 FLAGS = flags.FLAGS
@@ -849,28 +843,6 @@ class SelectMeshConfigTest(test_utils.TestCase):
         self.assertEqual(cfg.mesh_shape, (4, 1, 8, 1))
         select_mesh_config(cfg, mesh_selector="gpu-p4d.24xlarge-128")
         self.assertIsNone(cfg.mesh_shape)
-
-
-class InferMeshShapeTest(test_utils.TestCase):
-    def test_infer_mesh_shape_config(self):
-        # When mesh shape has no -1
-        mesh_shape = infer_mesh_shape((4, 1, 8, 1))
-        self.assertEqual(mesh_shape, (4, 1, 8, 1))
-
-        # When there is mutiple -1
-        with self.assertRaises(ValueError):
-            infer_mesh_shape((-1, 1, -1, 8))
-
-        # When num_devices is not a mutiple of products of mesh_shape
-        with self.assertRaises(ValueError):
-            infer_mesh_shape((-1, 1, 8, 1), num_devices=4)
-
-        # When one -1 for a valid mesh shape
-        mesh_shape = infer_mesh_shape((-1, 1, 8, 1), num_devices=32)
-        self.assertEqual(mesh_shape, (4, 1, 8, 1))
-
-        mesh_shape = infer_mesh_shape((4, 1, 8, -1), num_devices=32)
-        self.assertEqual(mesh_shape, (4, 1, 8, 1))
 
 
 if __name__ == "__main__":

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -54,6 +54,7 @@ from axlearn.common.utils import (
     flatten_items,
     get_data_dir,
     get_recursively,
+    infer_mesh_shape,
     input_partition_spec,
     match_regex_rules,
     prune_tree,
@@ -1105,6 +1106,30 @@ class DeviceMeshTest(TestCase):
         # Check that the constructed mesh has the expected shape.
         device_mesh = create_device_mesh(mesh_shape=logical_mesh, devices=devices)
         self.assertEqual(device_mesh.shape, logical_mesh)
+
+
+class InferMeshShapeTest(TestCase):
+    """Tests infer_mesh_shape."""
+
+    def test_infer_mesh_shape_config(self):
+        # When mesh sinfer_mesh_shape
+        mesh_shape = infer_mesh_shape((4, 1, 8, 1))
+        self.assertEqual(mesh_shape, (4, 1, 8, 1))
+
+        # When there is mutiple -1
+        with self.assertRaises(ValueError):
+            infer_mesh_shape((-1, 1, -1, 8))
+
+        # When num_devices is not a mutiple of products of mesh_shape
+        with self.assertRaises(ValueError):
+            infer_mesh_shape((-1, 1, 8, 1), num_devices=4)
+
+        # When one -1 for a valid mesh shape
+        mesh_shape = infer_mesh_shape((-1, 1, 8, 1), num_devices=32)
+        self.assertEqual(mesh_shape, (4, 1, 8, 1))
+
+        mesh_shape = infer_mesh_shape((4, 1, 8, -1), num_devices=32)
+        self.assertEqual(mesh_shape, (4, 1, 8, 1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since it's possible to restore from a trainer config with -1 in the mesh. Also moves `infer_mesh_shape` to utils to avoid a circular import.