### PR TITLE
Fix RoPE positional encoding shape

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -1059,9 +1059,10 @@ class RoFormerQKVLinear(BaseQKVLinear):
     ) -> BaseQKVLinear.Output:
         cfg = self.config
         query, key, value = self.i_proj(query, key=key, value=value)
-        # Query should has shape of [batch_size, num_len, num_heads, dim]
-        positions = jnp.arange(cfg.max_seq_length)
-        # sinusoidal_pos_emb shape should be [1, num_len, 1, dim]
+        # Query should have shape of [batch_size, seq_len, num_heads, per_head_dim].
+        # So `positions` will be in range [0, seq_len - 1).
+        positions = jnp.arange(query.shape[1])
+        # sinusoidal_pos_emb shape should be [1, seq_len, 1, dim]
         sinusoidal_pos_emb = jnp.expand_dims(self.rope_pos_emb_layer.forward(positions), [0, 2])
         sinusoidal_pos_emb = sinusoidal_pos_emb.astype(query.dtype)
         query, key, value = apply_rotary_position_embeddings(

--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -784,7 +784,6 @@ class RoFormerSinusoidalPositionalEmbeddingTest(TestCase):
             )
             assert_allclose(layer_outputs.data, as_tensor(ref_outputs))
 
-    #: TODO: (Chen Chen) Add a test to reproduce LLaMA1 attention with rotary_value=False.
     @parameterized.parameters([True, False])
     def test_rope_self_attention(self, rotary_value: bool):
         model_dim = 32
@@ -981,8 +980,11 @@ class RoFormerSinusoidalPositionalEmbeddingAgainstLLaMATest(TestCase):
         assert_allclose(llama_real, as_tensor(axlearn_real))
         assert_allclose(llama_imag, as_tensor(axlearn_imag))
 
-    @parameterized.parameters([jnp.float32, jnp.bfloat16])
-    def test_roformer_qkv_linear(self, dtype: jnp.dtype):
+    @parameterized.product(
+        dtype=(jnp.float32, jnp.bfloat16),
+        max_seq_len=(100, 6),
+    )
+    def test_roformer_qkv_linear(self, dtype: jnp.dtype, max_seq_len: int):
         seq_len = 6
         batch_size = 2
         model_dim = 16
@@ -992,7 +994,7 @@ class RoFormerSinusoidalPositionalEmbeddingAgainstLLaMATest(TestCase):
             RoFormerQKVLinear.default_config()
             .set(
                 name="roformer_qkv_linear",
-                max_seq_length=seq_len,
+                max_seq_length=max_seq_len,
                 query_dim=model_dim,
                 key_dim=model_dim,
                 value_dim=model_dim,


### PR DESCRIPTION
Without this fix, https://github.com/apple/axlearn/blob/4a77cd89ea25a8f0e92029272b6824338fcf8c83/axlearn/common/attention.py#L1009
can lead to shape mismatch problem during extrapolation, where `cos.shape[1] == cfg.max_seq_length` and `query.shape[1] == seq_len`， though these can be different for extrapolation.

In theory, we would like to have `cfg.max_seq_length` to be the max length of positional encoding budget, while the rotation matrix shape could vary according to the requested sequence length.