### PR TITLE
Implement rank_by_value with support for tied ranks.

### DIFF
--- a/axlearn/common/input_ranking.py
+++ b/axlearn/common/input_ranking.py
@@ -1,0 +1,68 @@
+# Copyright © 2023 Apple Inc.
+
+"""Input processing utilities on tf.data for ranking-related tasks."""
+from typing import Dict
+
+import seqio
+import tensorflow as tf
+
+from axlearn.common import input_tf_data
+
+
+def rank_by_value(
+    *, input_field: str, output_field: str, ascending: bool = True, allow_ties: bool = False
+) -> input_tf_data.DatasetToDatasetFn:
+    """Returns a DatasetToDatasetFn that stores the ranks of input_field in output_field.
+
+    Note the rank starts at 1.
+
+    Args:
+        input_field: The field whose value will be ranked.
+        output_field: The field to store the ranks into.
+        ascending: True to rank in ascending order or False to rank in descending order.
+        allow_ties: If true, multiple elements could have the same rank. Ranks could have gaps
+            in between to account for duplicate ranks. For example, the ranks of [2, 2, 4]
+            would be [1, 1, 3] when allow_ties is True, and [1, 2, 3] otherwise.
+
+    Returns:
+        A DatasetToDatasetFn where each input example is ranked according to the value
+        of input_field, and the ranks are stored in output_field.
+    """
+
+    def example_fn(example: Dict[str, tf.Tensor]) -> Dict[str, tf.Tensor]:
+        if len(example[input_field].shape) != 1:
+            raise NotImplementedError(
+                f"Only implemented for rank-1 tensors. Got rank-{len(example[input_field].shape)}."
+            )
+
+        if allow_ties:
+            values = example[input_field] * -1 if not ascending else example[input_field]
+            sorted_idx = tf.argsort(values, stable=True)
+            sorted_values = tf.gather(params=values, indices=sorted_idx)
+
+            _, idx, counts = tf.unique_with_counts(sorted_values)
+            cumsum = tf.zeros_like(counts)
+            # Index i stores total number of values that come before position i, exclusive.
+            # pylint: disable-next=unexpected-keyword-arg,no-value-for-parameter
+            cumsum = tf.concat([cumsum[:1], tf.cumsum(counts[:-1])], axis=0)
+            ranks = tf.gather(params=cumsum, indices=idx) + 1
+            ranks = tf.scatter_nd(
+                indices=tf.expand_dims(sorted_idx, 1),
+                updates=ranks,
+                shape=tf.convert_to_tensor([len(values)]),
+            )
+        else:
+            ranks = (
+                tf.argsort(
+                    tf.argsort(
+                        example[input_field],
+                        direction="ASCENDING" if ascending else "DESCENDING",
+                        stable=True,
+                    )
+                )
+                + 1
+            )
+        example[output_field] = ranks
+        return example
+
+    return seqio.map_over_dataset(example_fn)

--- a/axlearn/common/input_ranking.py
+++ b/axlearn/common/input_ranking.py
@@ -10,7 +10,7 @@ from axlearn.common import input_tf_data
 
 
 def rank_by_value(
-    *, input_key: str, output_key: str, ascending: bool = True, allow_ties: bool = False
+    *, input_key: str, output_key: str, ascending: bool, allow_ties: bool
 ) -> input_tf_data.DatasetToDatasetFn:
     """Returns a DatasetToDatasetFn that stores the ranks of input_field in output_field.
 
@@ -19,10 +19,12 @@ def rank_by_value(
     Args:
         input_key: The field whose value will be ranked.
         output_key: The field to store the ranks into.
-        ascending: True to rank in ascending order or False to rank in descending order.
+        ascending: True to rank in ascending order or false to rank in descending order.
         allow_ties: If true, multiple elements could have the same rank. Ranks could have gaps
-            in between to account for duplicate ranks. For example, the ranks of [2, 2, 4]
-            would be [1, 1, 3] when allow_ties is True, and [1, 2, 3] otherwise.
+            in between to account for duplicate ranks. If false, ranks will never have ties,
+            even when values are equivalent - stable sorting by values is used.
+            For example, the ranks of [2, 2, 4] would be [1, 1, 3] when allow_ties is true,
+            and [1, 2, 3] otherwise.
 
     Returns:
         A DatasetToDatasetFn where each input example is ranked according to the value
@@ -38,7 +40,7 @@ def rank_by_value(
         inputs = example[input_key]
         if not ascending:
             inputs *= -1
-        idx = tf.argsort(inputs)
+        idx = tf.argsort(inputs, stable=True)
         ranks = tf.math.invert_permutation(idx)
         if allow_ties:
             # Construct an arange where index repeats for repeated inputs.

--- a/axlearn/common/input_ranking_test.py
+++ b/axlearn/common/input_ranking_test.py
@@ -79,7 +79,7 @@ class RankByValueTest(TestCase):
         )
 
         ds = rank_by_value(
-            input_field="label", output_field="rank", ascending=ascending, allow_ties=allow_ties
+            input_key="label", output_key="rank", ascending=ascending, allow_ties=allow_ties
         )(ds)
         for ex in ds.as_numpy_iterator():
             self.assertListEqual(expected_ranks, ex["rank"].tolist())
@@ -98,6 +98,4 @@ class RankByValueTest(TestCase):
         with self.assertRaisesRegex(
             NotImplementedError, "Only implemented for rank-1 tensors. Got rank-2."
         ):
-            rank_by_value(
-                input_field="label", output_field="rank", ascending=True, allow_ties=True
-            )(ds)
+            rank_by_value(input_key="label", output_key="rank", ascending=True, allow_ties=True)(ds)

--- a/axlearn/common/input_ranking_test.py
+++ b/axlearn/common/input_ranking_test.py
@@ -1,0 +1,103 @@
+# Copyright © 2023 Apple Inc.
+
+"""Tests for input ranking."""
+from typing import Sequence
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from axlearn.common.input_ranking import rank_by_value
+from axlearn.common.test_utils import TestCase
+
+
+class RankByValueTest(TestCase):
+    @parameterized.parameters(
+        {
+            "input_sequence": [0.2, 0.9, 0.5, 0.8, 0.7],
+            "expected_ranks": [1, 5, 2, 4, 3],
+            "ascending": True,
+            "allow_ties": False,
+        },
+        {
+            "input_sequence": [0.3, 0.4, 0.2, 0.7],
+            "expected_ranks": [3, 2, 4, 1],
+            "ascending": False,
+            "allow_ties": False,
+        },
+        {
+            "input_sequence": [0.5, 0.6, 0.3, 0.1, 0.1],
+            "expected_ranks": [4, 5, 3, 1, 2],
+            "ascending": True,
+            "allow_ties": False,
+        },
+        {
+            "input_sequence": [0.5, 0.6, 0.3, 0.1, 0.1],
+            "expected_ranks": [4, 5, 3, 1, 1],
+            "ascending": True,
+            "allow_ties": True,
+        },
+        {
+            "input_sequence": [3, 1, 2, 3, 5, 4],
+            "expected_ranks": [3, 6, 5, 3, 1, 2],
+            "ascending": False,
+            "allow_ties": True,
+        },
+        {
+            "input_sequence": [0.2, 0.9, 0.5, 0.8, 0.7],
+            "expected_ranks": [1, 5, 2, 4, 3],
+            "ascending": True,
+            "allow_ties": True,
+        },
+        {
+            "input_sequence": [],
+            "expected_ranks": [],
+            "ascending": True,
+            "allow_ties": True,
+        },
+        {
+            "input_sequence": [],
+            "expected_ranks": [],
+            "ascending": True,
+            "allow_ties": False,
+        },
+    )
+    def test_rank_by_value(
+        self,
+        input_sequence: Sequence[float],
+        expected_ranks: Sequence[int],
+        ascending: bool,
+        allow_ties: bool,
+    ):
+        def gen():
+            yield {"label": input_sequence}
+
+        ds = tf.data.Dataset.from_generator(
+            gen,
+            output_signature={
+                "label": tf.TensorSpec(shape=(len(input_sequence),), dtype=tf.float32),
+            },
+        )
+
+        ds = rank_by_value(
+            input_field="label", output_field="rank", ascending=ascending, allow_ties=allow_ties
+        )(ds)
+        for ex in ds.as_numpy_iterator():
+            self.assertListEqual(expected_ranks, ex["rank"].tolist())
+
+    def test_rank_by_value_unsupported_shape(self):
+        def gen():
+            yield {"label": [[1, 2, 3, 4], [5, 6, 6, 9]]}
+
+        ds = tf.data.Dataset.from_generator(
+            gen,
+            output_signature={
+                "label": tf.TensorSpec(shape=(2, 4), dtype=tf.float32),
+            },
+        )
+
+        with self.assertRaisesRegex(
+            NotImplementedError, "Only implemented for rank-1 tensors. Got rank-2."
+        ):
+            rank_by_value(
+                input_field="label", output_field="rank", ascending=True, allow_ties=True
+            )(ds)


### PR DESCRIPTION
Implement rank_by_value with support for tied ranks.

This is useful to produce ranks for `ranking_pairwise_loss`, https://github.com/apple/axlearn/blob/4a77cd89ea25a8f0e92029272b6824338fcf8c83/axlearn/common/loss.py#L1203 where the ranks are obtained by sorting another field.