### PR TITLE
Implement Tie-Aware NDCG.

### DIFF
--- a/axlearn/common/metrics_retrieval.py
+++ b/axlearn/common/metrics_retrieval.py
@@ -285,17 +285,15 @@ def average_precision_at_k(
 def _tie_averaged_dcg(*, y_true: Tensor, y_score: Tensor, discount_factor: Tensor) -> Tensor:
     """Computes tie-aware DCG by averaging over possible permutations of ties.
 
-    DCG@k(gains) = sum_{i=1}^{m} [
-        (sum_{j=t_i + 1}^{t_{i+1}} gain(v_j) / n_i) * sum_{j=t_i + 1}^{min(t_{i+1}, k)} discount(j)
-    ]
+    DCG@K(gains) = sum_{i=1}^{max_k} gain(i) * discount_factor(i)
 
     where:
-        * V = <v_1, ..., v_n> are scores sorted in non-increasing order
-        * There are m equivalence classes (unique scores)
-        * t_i is an element of a tie-vector T = <t_1, ..., t_{m+1}> whose first element t_1=0
-            and the rest are ending indices of the m equivalence classes,
-            so V_i = <v_{t_i + 1}, ..., v_{t_{i+1}}> all have the same score
-        * n_i is the total number of elements in V_i
+        * y_score is divided into different equivalence classes,
+            with each equivalence class having a unique score,
+        * gain(i) is average gain for all items within the same equivalence class as item i,
+            so gain(i) = sum_{j ∈ I_c} gain(j) / n_c where item i belongs to group c and
+            I_c is the indices of all items that belongs to group c, with n_c items in the class.
+            gain(i) and gain(j) mean y_true_i or y_true_j.
 
     Ref (Sect. 2.6):
     https://www.microsoft.com/en-us/research/publication/computing-information-retrieval-performance-measures-efficiently-in-the-presence-of-tied-scores

--- a/axlearn/common/metrics_retrieval.py
+++ b/axlearn/common/metrics_retrieval.py
@@ -1,4 +1,10 @@
 # Copyright © 2023 Apple Inc.
+#
+# Some of the code in this file is adapted from:
+#
+# scikit-learn/scikit-learn:
+# Copyright (c) 2007-2023 The scikit-learn developers. All rights reserved.
+# Licensed under BSD 3 clause.
 
 """Retrieval metrics."""
 from typing import Dict, List, Optional, Tuple
@@ -388,13 +394,10 @@ def ndcg_at_k(
             jnp.expand_dims(jnp.arange(num_queries), 1), indices_of_sorted_relevance_labels
         ]
 
-        def compute_dcg(gains: Tensor) -> Tensor:
-            # Shape: [num_queries, max_k].
-            dcg = jnp.cumsum(gains * discount_factors, axis=-1)
-            return dcg
-
-        dcg = compute_dcg(relevance_labels_sorted_by_scores)
-        idcg = compute_dcg(sorted_relevance_labels)
+        # Shape: [num_queries, max_k].
+        dcg = jnp.cumsum(relevance_labels_sorted_by_scores * discount_factors, axis=-1)
+        # Shape: [num_queries, max_k].
+        idcg = jnp.cumsum(sorted_relevance_labels * discount_factors, axis=-1)
     else:
         auto_batch_tie_averaged_dcg = jax.vmap(_tie_averaged_dcg)
         discount_factors = jnp.tile(discount_factors, reps=(num_queries, 1))

--- a/axlearn/common/metrics_retrieval.py
+++ b/axlearn/common/metrics_retrieval.py
@@ -289,11 +289,12 @@ def _tie_averaged_dcg(*, y_true: Tensor, y_score: Tensor, discount_factor: Tenso
 
     where:
         * y_score is divided into different equivalence classes,
-            with each equivalence class having a unique score,
+            with each equivalence class having a unique score.
         * gain(i) is the average gain for all items within the same equivalence class as item i,
             so gain(i) = sum_{j ∈ I_c} gain(j) / n_c where item i belongs to group c and
             I_c is the indices of all items that belongs to group c, with n_c items in the class.
             gain(i) and gain(j) mean y_true_i or y_true_j.
+            Note in this context indices are 1-indexed.
 
     Ref (Sect. 2.6):
     https://www.microsoft.com/en-us/research/publication/computing-information-retrieval-performance-measures-efficiently-in-the-presence-of-tied-scores
@@ -322,7 +323,7 @@ def _tie_averaged_dcg(*, y_true: Tensor, y_score: Tensor, discount_factor: Tenso
     _, inv, counts = jnp.unique(-y_score, return_inverse=True, return_counts=True, size=max_k)
     # Get average gain for each equivalence class.
     # Average gain is calculated from all items that belongs to the same class
-    # even if when k < num_items.
+    # even if when max_k < num_items.
     # Shape: [max_k].
     group_gains = jnp.zeros(max_k)
     group_gains = group_gains.at[inv].add(y_true)

--- a/axlearn/common/metrics_retrieval.py
+++ b/axlearn/common/metrics_retrieval.py
@@ -290,7 +290,7 @@ def _tie_averaged_dcg(*, y_true: Tensor, y_score: Tensor, discount_factor: Tenso
     where:
         * y_score is divided into different equivalence classes,
             with each equivalence class having a unique score,
-        * gain(i) is average gain for all items within the same equivalence class as item i,
+        * gain(i) is the average gain for all items within the same equivalence class as item i,
             so gain(i) = sum_{j ∈ I_c} gain(j) / n_c where item i belongs to group c and
             I_c is the indices of all items that belongs to group c, with n_c items in the class.
             gain(i) and gain(j) mean y_true_i or y_true_j.
@@ -318,7 +318,7 @@ def _tie_averaged_dcg(*, y_true: Tensor, y_score: Tensor, discount_factor: Tenso
     # inv shape: [num_items].
     # counts shape: [max_k].
     # We care about the counts of up to and including the first max_k equivalence classes.
-    # If there are fewer than max_k classes, the counts of the extra ones are 0s.
+    # If there are fewer than max_k classes, the counts of the extra classes are 0s.
     _, inv, counts = jnp.unique(-y_score, return_inverse=True, return_counts=True, size=max_k)
     # Get average gain for each equivalence class.
     # Average gain is calculated from all items that belongs to the same class

--- a/axlearn/common/metrics_retrieval_test.py
+++ b/axlearn/common/metrics_retrieval_test.py
@@ -1,7 +1,6 @@
 # Copyright © 2023 Apple Inc.
 
 """Tests retrieval metrics."""
-import itertools
 from typing import List
 
 import jax
@@ -183,7 +182,7 @@ class NDCGTest(TestCase):
         y_score = jnp.array(y_score)
         jit_f = jax.jit(tie_averaged_dcg)
         checked_jit_f = checkify.checkify(jit_f, errors=checkify.user_checks)
-        _, out = checked_jit_f(y_true=y_true, y_score=y_score, discount=discount)
+        _, out = checked_jit_f(y_true=y_true, y_score=y_score, discount_factor=discount)
         ref = _tie_averaged_dcg(y_true=y_true, y_score=y_score, discount_cumsum=discount_cumsum)
         self.assertAlmostEqual(out[-1].item(), ref, places=6)
 

--- a/axlearn/common/metrics_retrieval_test.py
+++ b/axlearn/common/metrics_retrieval_test.py
@@ -244,20 +244,29 @@ class NDCGTest(TestCase):
         {
             "scores": [[1, 1, 1, 1, 1, 1, 1]],
             "relevance_labels": [[0, 0, 0, 0, 2, 2, 3]],
+            "top_ks_for_ndcg": list(range(1, 8)),
         },
         {
             "scores": [[1, 2, 1, 4, 1, 2, 3, 0, 1.5, 1.5]],
             "relevance_labels": [[4, 0, 2, 0, 5, 2, 1, 2, 2, 5]],
+            "top_ks_for_ndcg": list(range(1, 11)),
         },
         {
             "scores": [[1, 2, 3, 3, 3, 0, 4], [1, 1, 2, 2, 1, 1, 1]],
             "relevance_labels": [[1, 2, 2, 3, 7, 1, 1], [1, 1, 3, 5, 1, 1, 1]],
+            "top_ks_for_ndcg": list(range(1, 8)),
+        },
+        {
+            "scores": [[1, 2, 3, 3, 3, 0, 4], [1, 1, 2, 2, 1, 1, 1]],
+            "relevance_labels": [[1, 2, 2, 3, 7, 1, 1], [1, 1, 3, 5, 2, 3, 5]],
+            "top_ks_for_ndcg": list(range(1, 4)),
         },
     )
-    def test_ndcg_at_k_with_ties(self, scores: List[float], relevance_labels: List[float]):
+    def test_ndcg_at_k_with_ties(
+        self, scores: List[float], relevance_labels: List[float], top_ks_for_ndcg: List[int]
+    ):
         scores = jnp.array(scores)
         relevance_labels = jnp.array(relevance_labels)
-        top_ks_for_ndcg = list(range(1, len(scores) + 1))
         ndcgs = ndcg_at_k(
             scores=scores,
             relevance_labels=relevance_labels,

--- a/axlearn/common/metrics_retrieval_test.py
+++ b/axlearn/common/metrics_retrieval_test.py
@@ -10,17 +10,17 @@ import pytest
 from absl.testing import parameterized
 from jax.experimental import checkify
 from sklearn.metrics import ndcg_score
-from sklearn.metrics._ranking import _tie_averaged_dcg
+from sklearn.metrics._ranking import _tie_averaged_dcg as sklearn_tie_averaged_dcg
 
 from axlearn.common.loss import contrastive_logits
 from axlearn.common.metrics_retrieval import (
+    _tie_averaged_dcg,
     average_precision_at_k,
     average_rank,
     calculate_accuracy_metrics,
     calculate_mean_average_precision_metrics,
     mean_reciprocal_rank,
     ndcg_at_k,
-    tie_averaged_dcg,
     top_k_accuracy,
 )
 from axlearn.common.test_utils import TestCase
@@ -180,10 +180,12 @@ class NDCGTest(TestCase):
         discount_cumsum = jnp.cumsum(discount)
         y_true = jnp.array(y_true)
         y_score = jnp.array(y_score)
-        jit_f = jax.jit(tie_averaged_dcg)
+        jit_f = jax.jit(_tie_averaged_dcg)
         checked_jit_f = checkify.checkify(jit_f, errors=checkify.user_checks)
         _, out = checked_jit_f(y_true=y_true, y_score=y_score, discount_factor=discount)
-        ref = _tie_averaged_dcg(y_true=y_true, y_score=y_score, discount_cumsum=discount_cumsum)
+        ref = sklearn_tie_averaged_dcg(
+            y_true=y_true, y_score=y_score, discount_cumsum=discount_cumsum
+        )
         self.assertAlmostEqual(out[-1].item(), ref, places=6)
 
     @parameterized.product(

--- a/axlearn/common/metrics_retrieval_test.py
+++ b/axlearn/common/metrics_retrieval_test.py
@@ -185,7 +185,7 @@ class NDCGTest(TestCase):
         checked_jit_f = checkify.checkify(jit_f, errors=checkify.user_checks)
         _, out = checked_jit_f(y_true=y_true, y_score=y_score, discount=discount)
         ref = _tie_averaged_dcg(y_true=y_true, y_score=y_score, discount_cumsum=discount_cumsum)
-        self.assertAlmostEqual(out.item(), ref, places=6)
+        self.assertAlmostEqual(out[-1].item(), ref, places=6)
 
     @parameterized.product(
         [


### PR DESCRIPTION
This PR implements [Tie-Aware NDCG](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/ecir2008.pdf) to compute DCG by averaging over different possible permutations of ties.