### PR TITLE
Add jnp.uint32 to the dtype list in tensor spec parser.

### DIFF
--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -249,6 +249,7 @@ def _parse_tensor_spec(spec_dict: Dict[str, str]) -> TensorSpec:
             jnp.int16,
             jnp.int32,
             jnp.int64,
+            jnp.uint32,
         )
     }
     if dtype_str not in dtype_dict:

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -532,7 +532,7 @@ class CheckpointerTest(test_utils.TestCase):
             state0 = dict(
                 **{
                     f"v_{str(dtype.dtype)}": jnp.zeros([], dtype=dtype)
-                    for dtype in (jnp.int32, jnp.int64)
+                    for dtype in (jnp.uint32, jnp.int32, jnp.int64)
                 },
                 **{
                     f"v_{str(dtype.dtype)}": jnp.zeros([4], dtype=dtype)


### PR DESCRIPTION
FYI, the unit32 dtype is used by the prng_key field in a checkpoint.