### PR TITLE
Cleanup temp chdir handling.

### DIFF
--- a/axlearn/cloud/gcp/config_test.py
+++ b/axlearn/cloud/gcp/config_test.py
@@ -3,17 +3,15 @@
 """Tests config utils."""
 
 import os
-import tempfile
 from unittest import mock
-
-from absl.testing import absltest
 
 from axlearn.cloud.common import config
 from axlearn.cloud.common.config_test import _setup_fake_repo, create_default_config
 from axlearn.cloud.gcp import config as gcp_config
+from axlearn.common.test_utils import TestWithTemporaryCWD
 
 
-class ConfigTest(absltest.TestCase):
+class ConfigTest(TestWithTemporaryCWD):
     """Tests config utils."""
 
     @mock.patch(
@@ -22,45 +20,43 @@ class ConfigTest(absltest.TestCase):
     def test_gcp_settings(self, flag_values):
         del flag_values
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            temp_dir = os.path.realpath(temp_dir)
-            _setup_fake_repo(temp_dir)
-            os.chdir(temp_dir)
+        temp_dir = os.path.realpath(self._temp_root.name)
+        _setup_fake_repo(temp_dir)
 
-            # By default, should fail because no config file exists.
-            with self.assertRaises(SystemExit):
-                gcp_config.gcp_settings("project")
+        # By default, should fail because no config file exists.
+        with self.assertRaises(SystemExit):
+            gcp_config.gcp_settings("project")
 
-            # Should not fail if not required.
-            self.assertIsNone(gcp_config.gcp_settings("project", required=False))
+        # Should not fail if not required.
+        self.assertIsNone(gcp_config.gcp_settings("project", required=False))
 
-            # Should not fail if a default exists.
-            self.assertEqual(
-                "default", gcp_config.gcp_settings("project", required=True, default="default")
-            )
+        # Should not fail if a default exists.
+        self.assertEqual(
+            "default", gcp_config.gcp_settings("project", required=True, default="default")
+        )
 
-            # Create a default config, which should get picked up.
-            default_config = create_default_config(temp_dir)
+        # Create a default config, which should get picked up.
+        default_config = create_default_config(temp_dir)
 
-            # Should fail because no config for --project and --zone.
-            with self.assertRaises(SystemExit):
-                gcp_config.gcp_settings("project")
+        # Should fail because no config for --project and --zone.
+        with self.assertRaises(SystemExit):
+            gcp_config.gcp_settings("project")
 
-            # Should not fail if not required.
-            self.assertIsNone(gcp_config.gcp_settings("project", required=False))
+        # Should not fail if not required.
+        self.assertIsNone(gcp_config.gcp_settings("project", required=False))
 
-            # Write some values to the config.
-            config.write_configs_with_header(
-                str(default_config),
-                {gcp_config.CONFIG_NAMESPACE: {"test:test": {"project": "test", "zone": "test"}}},
-            )
+        # Write some values to the config.
+        config.write_configs_with_header(
+            str(default_config),
+            {gcp_config.CONFIG_NAMESPACE: {"test:test": {"project": "test", "zone": "test"}}},
+        )
 
-            # Should fail because key cannot be found.
-            with self.assertRaises(SystemExit):
-                gcp_config.gcp_settings("unknown_key")
+        # Should fail because key cannot be found.
+        with self.assertRaises(SystemExit):
+            gcp_config.gcp_settings("unknown_key")
 
-            # Should not fail if not required.
-            self.assertIsNone(gcp_config.gcp_settings("unknown_key", required=False))
+        # Should not fail if not required.
+        self.assertIsNone(gcp_config.gcp_settings("unknown_key", required=False))
 
-            # Should succeed.
-            self.assertEqual(gcp_config.gcp_settings("project"), "test")
+        # Should succeed.
+        self.assertEqual(gcp_config.gcp_settings("project"), "test")


### PR DESCRIPTION
So that we don't chdir into a tempdir without changing back. This is to avoid missing CWD issues.

The usage is simply os.chdir -> with temp_chdir.