### PR TITLE
Replace jax.random.KeyArray with jax.Array to suppress deprecation warnings.

### DIFF
--- a/axlearn/common/adapter_flax.py
+++ b/axlearn/common/adapter_flax.py
@@ -63,7 +63,7 @@ class FlaxLayer(BaseLayer):
         return cfg.create_dummy_input_fn(**cfg.create_dummy_input_kwargs)
 
     def initialize_parameters_recursively(
-        self, prng_key: jax.random.KeyArray, *, prebuilt: Optional[NestedTensor] = None
+        self, prng_key: utils.Tensor, *, prebuilt: Optional[NestedTensor] = None
     ) -> NestedTensor:
         if self._use_prebuilt_params(prebuilt):
             return prebuilt

--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -875,7 +875,7 @@ class FusedQKVLinear(BaseQKVLinear):
         )
 
     def initialize_parameters_recursively(
-        self, prng_key: jax.random.KeyArray, *, prebuilt: Optional[NestedTensor] = None
+        self, prng_key: Tensor, *, prebuilt: Optional[NestedTensor] = None
     ) -> NestedTensor:
         if self._use_prebuilt_params(prebuilt):
             return prebuilt
@@ -2735,7 +2735,7 @@ class StackedTransformerLayer(BaseStackedTransformerLayer):
             self._layers.append(self._add_child(f"layer{i}", layer_cfg))
 
     def initialize_parameters_recursively(
-        self, prng_key: jax.random.KeyArray, *, prebuilt: Optional[NestedTensor] = None
+        self, prng_key: Tensor, *, prebuilt: Optional[NestedTensor] = None
     ) -> NestedTensor:
         cfg = self.config  # type: StackedTransformerLayer.Config
         prng_key = split_prng_key(prng_key, cfg.num_layers)
@@ -3057,7 +3057,7 @@ class RepeatedTransformerLayer(BaseStackedTransformerLayer):
         self._add_child("repeat", repeat_cfg)
 
     def initialize_parameters_recursively(
-        self, prng_key: jax.random.KeyArray, *, prebuilt: Optional[NestedTensor] = None
+        self, prng_key: Tensor, *, prebuilt: Optional[NestedTensor] = None
     ) -> NestedTensor:
         # We need to call self.repeat.initialize_parameters_recursively() with the same prng_key
         # to ensure initialization parity with StackedTransformerLayer.
@@ -3188,7 +3188,7 @@ class PipelinedTransformerLayer(BaseStackedTransformerLayer):
         self._add_child("pipeline", pipeline_cfg)
 
     def initialize_parameters_recursively(
-        self, prng_key: jax.random.KeyArray, *, prebuilt: Optional[NestedTensor] = None
+        self, prng_key: Tensor, *, prebuilt: Optional[NestedTensor] = None
     ) -> NestedTensor:
         cfg = self.config  # type: PipelinedTransformerLayer.Config
         # We pre-split all num_layers keys to ensure initialization parity with

--- a/axlearn/common/base_layer.py
+++ b/axlearn/common/base_layer.py
@@ -121,7 +121,7 @@ class RematSpec:
 class ParameterNoise(Configurable):
     """An interface for applying parameter noise."""
 
-    def apply(self, prng_key: jax.random.KeyArray, params: NestedTensor) -> NestedTensor:
+    def apply(self, prng_key: Tensor, params: NestedTensor) -> NestedTensor:
         """To be implemented by subclasses."""
         raise NotImplementedError(self)
 
@@ -275,7 +275,7 @@ class BaseLayer(Module):
         return specs
 
     def initialize_parameters_recursively(
-        self, prng_key: jax.random.KeyArray, *, prebuilt: Optional[NestedTensor] = None
+        self, prng_key: Tensor, *, prebuilt: Optional[NestedTensor] = None
     ) -> NestedTensor:
         params = {}
         param_specs = self._create_layer_parameter_specs()
@@ -318,7 +318,7 @@ class BaseLayer(Module):
         return True
 
     def _initialize_parameter(
-        self, name: str, *, prng_key: jax.random.KeyArray, parameter_spec: ParameterSpec
+        self, name: str, *, prng_key: Tensor, parameter_spec: ParameterSpec
     ) -> Tensor:
         """Adds a parameter with the given name and shape.
 
@@ -345,7 +345,7 @@ class BaseLayer(Module):
         return param
 
     def apply_parameter_noise_recursively(
-        self, prng_key: jax.random.KeyArray, params: NestedTensor
+        self, prng_key: Tensor, params: NestedTensor
     ) -> NestedTensor:
         """Applies parameter noise recursively on `params`.
 

--- a/axlearn/common/base_layer_test.py
+++ b/axlearn/common/base_layer_test.py
@@ -102,7 +102,7 @@ class ParameterScaler(ParameterNoise):
     class Config(ParameterNoise.Config):
         scale: float = 1.0
 
-    def apply(self, prng_key: jax.random.KeyArray, params: NestedTensor) -> NestedTensor:
+    def apply(self, prng_key: utils.Tensor, params: NestedTensor) -> NestedTensor:
         cfg = self.config
         return jax.tree_util.tree_map(lambda x: x * cfg.scale, params)
 

--- a/axlearn/common/conformer.py
+++ b/axlearn/common/conformer.py
@@ -19,7 +19,6 @@ https://github.com/tensorflow/lingvo/blob/d2f1e1b3cccdac8f73ae20f86afb03560b1c17
 
 from typing import Optional, Tuple, Union
 
-import jax
 from jax import numpy as jnp
 
 from axlearn.common.attention import (
@@ -328,7 +327,7 @@ class RepeatedConformerLayer(BaseLayer):
 
     def initialize_parameters_recursively(
         self,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         *,
         prebuilt: Optional[NestedTensor] = None,
     ) -> NestedTensor:

--- a/axlearn/common/decoding.py
+++ b/axlearn/common/decoding.py
@@ -729,7 +729,7 @@ class DecodingState(NamedTuple):
     # The current state of the autoregressive decoding caches.
     cache: NestedTensor
     # Random generator state.
-    prng_key: jax.random.KeyArray
+    prng_key: Tensor
 
 
 def _decode_init(
@@ -739,7 +739,7 @@ def _decode_init(
     num_decodes: int,
     max_decode_len: int,
     cache: NestedTensor,
-    prng_key: jax.random.KeyArray,
+    prng_key: Tensor,
     pad_id: int,
     token_scores: Optional[Tensor] = None,
 ) -> DecodingState:
@@ -902,7 +902,7 @@ def sample_decode(
     tokens_to_scores: Callable[[Tensor, NestedTensor], Tuple[Tensor, NestedTensor]],
     stop_decoding_condition: StopDecodingCondition,
     num_decodes: int,
-    prng_key: jax.random.KeyArray,
+    prng_key: Tensor,
     max_decode_len: Optional[int] = None,
     loop: Literal["lax", "python"] = "lax",
     pad_id: int = 0,

--- a/axlearn/common/evaler_test.py
+++ b/axlearn/common/evaler_test.py
@@ -152,7 +152,7 @@ class DummyMetricCalculator(ModelSummaryAccumulator):
         self,
         *,
         method: str,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         model_params: NestedTensor,
         input_batch: NestedTensor,
         **kwargs,

--- a/axlearn/common/inference.py
+++ b/axlearn/common/inference.py
@@ -45,6 +45,7 @@ from axlearn.common.utils import (
     NestedPartitionSpec,
     NestedTensor,
     PartitionSpec,
+    Tensor,
     TensorSpec,
 )
 
@@ -56,12 +57,12 @@ class MethodRunner:
     def __init__(
         self,
         *,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         mesh: jax.sharding.Mesh,
         input_batch_partition_spec: DataPartitionType,
         jit_run_on_batch: Callable[
-            [jax.random.KeyArray, NestedTensor],
-            Tuple[jax.random.KeyArray, NestedTensor, NestedTensor],
+            [Tensor, NestedTensor],
+            Tuple[Tensor, NestedTensor, NestedTensor],
         ],
     ):
         """Initializes MethodRunner object.
@@ -141,7 +142,7 @@ class MethodRunner:
 class _InferenceRunnerState(NamedTuple):
     """Contains inference runner {state | state-partition-specs}."""
 
-    prng_key: Union[jax.random.KeyArray, NestedPartitionSpec]
+    prng_key: Union[Tensor, NestedPartitionSpec]
     model: Union[NestedTensor, NestedPartitionSpec]
     learner: Optional[Union[NestedTensor, NestedPartitionSpec]] = None
 
@@ -255,7 +256,7 @@ class InferenceRunner(Module):
         input_batches: Iterable[NestedTensor],
         *,
         method: str,
-        prng_key: Optional[jax.random.KeyArray] = None,
+        prng_key: Optional[Tensor] = None,
         **kwargs,
     ) -> Generator[NestedTensor, None, None]:
         """Runs inference on the provided input batches.
@@ -296,7 +297,7 @@ class InferenceRunner(Module):
         self,
         *,
         method: str,
-        prng_key: Optional[jax.random.KeyArray] = None,
+        prng_key: Optional[Tensor] = None,
         **kwargs,
     ) -> MethodRunner:
         """Creates MethodRunner for the specified method and arguments.
@@ -361,13 +362,13 @@ class InferenceRunner(Module):
 
     def _inference_iter(
         self,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         model_params: NestedTensor,
         input_batch: Dict[str, Any],
         *,
         method,
         **kwargs,
-    ) -> Tuple[jax.random.KeyArray, NestedTensor, NestedTensor]:
+    ) -> Tuple[Tensor, NestedTensor, NestedTensor]:
         """Implements inference for a single input batch."""
         cfg = self.config
         new_prng_key, iter_key = jax.random.split(prng_key)

--- a/axlearn/common/inference_test.py
+++ b/axlearn/common/inference_test.py
@@ -106,7 +106,7 @@ class RangeWeightInitializer(Initializer, Configurable):
         self,
         name: str,
         *,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         shape: Shape,
         dtype: jnp.dtype,
         axes: Optional[FanAxes] = None,
@@ -238,7 +238,7 @@ class InferenceTest(test_utils.TestCase):
         root_dir: str,
         mesh_shape: Tuple[int, int],
         mesh_axis_names: Tuple[str, str],
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         use_ema: bool = False,
     ) -> Tuple[NestedTensor, str]:
         devices = mesh_utils.create_device_mesh(mesh_shape)

--- a/axlearn/common/layers.py
+++ b/axlearn/common/layers.py
@@ -1777,7 +1777,7 @@ class VariationalNoise(ParameterNoise):
 
         vn_std: Required[float] = REQUIRED
 
-    def apply(self, prng_key: jax.random.KeyArray, params: NestedTensor) -> NestedTensor:
+    def apply(self, prng_key: Tensor, params: NestedTensor) -> NestedTensor:
         cfg = self.config
         if cfg.vn_std <= 0:
             return params

--- a/axlearn/common/metrics_glue.py
+++ b/axlearn/common/metrics_glue.py
@@ -77,7 +77,7 @@ class GLUEMetricCalculator(ModelSummaryAccumulator):
     def _forward_in_pjit(
         self,
         model_params: NestedTensor,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         input_batch: NestedTensor,
     ) -> Dict[str, NestedTensor]:
         """Calls `self._model` and returns summaries."""

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -149,7 +149,7 @@ class InvocationContext:  # pylint: disable=too-many-instance-attributes
     # The state of the module.
     state: NestedTensor
     is_training: bool
-    prng_key: Optional[jax.random.KeyArray]
+    prng_key: Optional[Tensor]
     output_collection: OutputCollection
 
     def path(self):
@@ -670,7 +670,7 @@ class Module(Configurable):
         return self.get_invocation_context().is_training
 
     @property
-    def prng_key(self) -> jax.random.KeyArray:
+    def prng_key(self) -> Tensor:
         return self.get_invocation_context().prng_key
 
     @property
@@ -724,7 +724,7 @@ class Module(Configurable):
 
 def functional(
     module: Module,
-    prng_key: Optional[jax.random.KeyArray],
+    prng_key: Optional[Tensor],
     state: NestedTensor,
     inputs: Union[Sequence[Any], Dict[str, Any]],
     *,

--- a/axlearn/common/param_init.py
+++ b/axlearn/common/param_init.py
@@ -10,6 +10,7 @@ from absl import logging
 from jax import numpy as jnp
 
 from axlearn.common.config import REQUIRED, Configurable, InstantiableConfig, Required, config_class
+from axlearn.common.utils import Tensor
 
 Shape = Sequence[int]
 
@@ -156,7 +157,7 @@ class Initializer(Configurable):
         self,
         name: str,
         *,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         shape: Shape,
         dtype: jnp.dtype,
         axes: Optional[FanAxes] = None,
@@ -183,7 +184,7 @@ class ConstantInitializer(Initializer):
         self,
         name: str,
         *,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         shape: Shape,
         dtype: jnp.dtype,
         axes: Optional[FanAxes] = None,
@@ -214,7 +215,7 @@ class GaussianInitializer(Initializer):
         self,
         name: str,
         *,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         shape: Shape,
         dtype: jnp.dtype,
         axes: Optional[FanAxes] = None,
@@ -294,7 +295,7 @@ class WeightInitializer(Initializer):
         self,
         name,
         *,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         shape: Shape,
         dtype: jnp.dtype,
         axes: Optional[FanAxes] = None,
@@ -393,7 +394,7 @@ class DefaultInitializer(Initializer):
         self,
         name: str,
         *,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         shape: Shape,
         dtype: jnp.dtype,
         axes: Optional[FanAxes] = None,
@@ -463,7 +464,7 @@ class PerGroupInitializer(Initializer):
         self,
         name: str,
         *,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         shape: Shape,
         dtype: jnp.dtype,
         axes: Optional[FanAxes] = None,
@@ -478,7 +479,7 @@ class PerGroupInitializer(Initializer):
             raise ValueError(f"{shape[-1]=} must be divisible by {cfg.num_groups=}.")
         shape_per_group = list(shape[:-1]) + [shape[-1] // cfg.num_groups]
 
-        def init(prng_key_i: jax.random.KeyArray) -> jnp.ndarray:
+        def init(prng_key_i: Tensor) -> jnp.ndarray:
             return self.initializer.initialize(
                 name, prng_key=prng_key_i, shape=shape_per_group, dtype=dtype, axes=axes
             )

--- a/axlearn/common/pipeline.py
+++ b/axlearn/common/pipeline.py
@@ -157,7 +157,7 @@ class Pipeline(BaseLayer):
 
     def initialize_parameters_recursively(
         self,
-        prng_key: Union[jax.random.KeyArray, VDict],
+        prng_key: Union[Tensor, VDict],
         *,
         prebuilt: Optional[NestedTensor] = None,
     ) -> NestedTensor:

--- a/axlearn/common/quantizer.py
+++ b/axlearn/common/quantizer.py
@@ -325,7 +325,7 @@ class RandomVectorQuantizer(BaseQuantizer):
         )
 
     def initialize_parameters_recursively(
-        self, prng_key: jax.random.KeyArray, *, prebuilt: Optional[NestedTensor] = None
+        self, prng_key: Tensor, *, prebuilt: Optional[NestedTensor] = None
     ) -> NestedTensor:
         params = super().initialize_parameters_recursively(prng_key=prng_key, prebuilt=prebuilt)
         # In RandomVectorQuantizer, we freeze codebook throughout training. So we can

--- a/axlearn/common/quantizer_test.py
+++ b/axlearn/common/quantizer_test.py
@@ -32,7 +32,7 @@ from axlearn.common.quantizer import (
     quantize_by_nearest_neighbor,
 )
 from axlearn.common.test_utils import TestCase, assert_allclose, prng_impl
-from axlearn.common.utils import shapes
+from axlearn.common.utils import Tensor, shapes
 
 _CODE_BOOK = jnp.array(
     [
@@ -44,7 +44,7 @@ _CODE_BOOK = jnp.array(
 )
 
 
-def _create_prngkeyarray(key_data: List[int]) -> jax.random.KeyArray:
+def _create_prngkeyarray(key_data: List[int]) -> Tensor:
     # pylint: disable-next=protected-access
     return jax._src.prng.PRNGKeyArrayImpl(  # pytype: disable=module-attr
         impl=jax.random.default_prng_impl(), key_data=jnp.array(key_data, dtype=jnp.uint32)

--- a/axlearn/common/repeat.py
+++ b/axlearn/common/repeat.py
@@ -67,14 +67,15 @@ from axlearn.common.config import (
     config_class,
     config_for_function,
 )
-from axlearn.common.module import (
-    Module,
+from axlearn.common.module import Module, child_context, new_output_collection, scan_in_context
+from axlearn.common.utils import (
     NestedTensor,
-    child_context,
-    new_output_collection,
-    scan_in_context,
+    Tensor,
+    VDict,
+    get_or_none,
+    match_regex_rules,
+    split_prng_key,
 )
-from axlearn.common.utils import VDict, get_or_none, match_regex_rules, split_prng_key
 
 
 def _drop_by_regex(rules: Sequence[str]) -> Callable[[str], bool]:
@@ -135,7 +136,7 @@ class Repeat(BaseLayer):
         )
 
     def initialize_parameters_recursively(
-        self, prng_key: jax.random.KeyArray, *, prebuilt: Optional[NestedTensor] = None
+        self, prng_key: Tensor, *, prebuilt: Optional[NestedTensor] = None
     ) -> NestedTensor:
         def init(prng_key_i, prebuilt_i):
             return VDict(

--- a/axlearn/common/rnn.py
+++ b/axlearn/common/rnn.py
@@ -270,7 +270,7 @@ class StackedRNNLayer(BaseRNNCell):
 
     def initialize_parameters_recursively(
         self,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         *,
         prebuilt: Optional[NestedTensor] = None,
     ) -> NestedTensor:
@@ -410,7 +410,7 @@ class RepeatedRNNLayer(BaseRNNCell):
 
     def initialize_parameters_recursively(
         self,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         *,
         prebuilt: Optional[NestedTensor] = None,
     ) -> NestedTensor:

--- a/axlearn/common/state_builder_test.py
+++ b/axlearn/common/state_builder_test.py
@@ -744,7 +744,7 @@ class BaseConverterFromPretrainedModelTest(TestCase):
 class DiffusersPretrainedBuilderTest(TestCase):
     """Tests FlaxPretrainedBuilder for a diffusers model."""
 
-    def _init_state(self, model, prng_key: jax.random.KeyArray):
+    def _init_state(self, model, prng_key: Tensor):
         prng_key, init_key = jax.random.split(prng_key)
         model_params = model.initialize_parameters_recursively(init_key)
         return _TrainerState(
@@ -855,7 +855,7 @@ class HuggingFacePreTrainedBuilderTest(TestCase):
     """Tests HuggingFacePreTrainedBuilder."""
 
     # TODO(bwzhang@) add a HF builder test by setting a temporary path for downloading the models.
-    def _init_state(self, model, prng_key: jax.random.KeyArray):
+    def _init_state(self, model, prng_key: Tensor):
         prng_key, init_key = jax.random.split(prng_key)
         model_params = model.initialize_parameters_recursively(init_key)
         return _TrainerState(

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -71,7 +71,7 @@ def _prune_empty(in_tree: NestedTensor) -> NestedTensor:
 
 
 class _TrainerState(NamedTuple):
-    prng_key: Union[jax.random.KeyArray, NestedPartitionSpec]
+    prng_key: Union[Tensor, NestedPartitionSpec]
     model: Union[NestedTensor, NestedPartitionSpec]
     learner: Union[NestedTensor, NestedPartitionSpec]
 
@@ -332,7 +332,7 @@ class SpmdTrainer(Module):
         logging.info("Watchdog loop done")
 
     # pylint: disable-next=too-many-statements,too-many-branches
-    def run(self, prng_key: jax.random.KeyArray) -> Optional[NestedTensor]:
+    def run(self, prng_key: Tensor) -> Optional[NestedTensor]:
         with self._watchdog(), self.mesh(), jax.log_compiles(self.vlog_is_on(1)):
             cfg = self.config
             # Attempt to restore the latest checkpoint, which may contain a saved `_input_iter`.
@@ -451,7 +451,7 @@ class SpmdTrainer(Module):
             specs,
         )
 
-    def init(self, prng_key: jax.random.KeyArray):
+    def init(self, prng_key: Tensor):
         """Initializes self._step and self._trainer_state.
 
         Args:
@@ -475,7 +475,7 @@ class SpmdTrainer(Module):
 
     def _init_with_prebuilt_state(
         self,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         *,
         prebuilt_state: Optional[TrainerStateBuilder.State],
     ):
@@ -531,7 +531,7 @@ class SpmdTrainer(Module):
             prebuilt_state.trainer_state.model,
         )
 
-        def _init_state(prng_key: jax.random.KeyArray, prebuilt_model_state: NestedTensor):
+        def _init_state(prng_key: Tensor, prebuilt_model_state: NestedTensor):
             prng_key, init_key = jax.random.split(prng_key)
             logging.info("prebuilt_model_state: %s", utils.shapes(prebuilt_model_state))
             model_params = self.model.initialize_parameters_recursively(

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -161,7 +161,7 @@ class DummyModel(BaseModel):
         return dict(sorted(specs.items()))  # type: ignore
 
     def initialize_parameters_recursively(
-        self, prng_key: jax.random.KeyArray, *, prebuilt: Optional[NestedTensor]
+        self, prng_key: Tensor, *, prebuilt: Optional[NestedTensor]
     ) -> NestedTensor:
         params = super().initialize_parameters_recursively(prng_key, prebuilt=prebuilt)
         if self.config.init_dummy_state:

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -251,11 +251,11 @@ def vectorized_tree_map(fn, tree, *rest):
 
 
 class StackedKeyArray(NamedTuple):
-    keys: Union[jax.random.KeyArray, "StackedKeyArray"]
+    keys: Union[Tensor, "StackedKeyArray"]
 
 
 def split_prng_key(
-    prng_key: Union[StackedKeyArray, jax.random.KeyArray], num_keys: Union[int, Sequence[int]]
+    prng_key: Union[StackedKeyArray, Tensor], num_keys: Union[int, Sequence[int]]
 ) -> StackedKeyArray:
     """Splits prng_key to keys iteratively and return the stacked keys.
 

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -42,6 +42,7 @@ from axlearn.common.trainer import SpmdTrainer
 from axlearn.common.utils import (
     NestedTensor,
     StackedKeyArray,
+    Tensor,
     VDict,
     as_numpy_array,
     as_tensor,
@@ -399,7 +400,7 @@ class TreeUtilsTest(TestCase):
     def test_split_prng_key(self):
         original_key = jax.random.PRNGKey(1234)
 
-        def fn(key: jax.random.KeyArray):
+        def fn(key: Tensor):
             return jax.random.normal(key, [3, 2])
 
         base_results = []
@@ -684,7 +685,7 @@ class ReadParamInitSpecsRecursivelyTest(TestCase):
     def test_delegates(self):
         class TestLayer(Linear):
             def initialize_parameters_recursively(
-                self, prng_key: jax.random.KeyArray, *, prebuilt: Optional[NestedTensor] = None
+                self, prng_key: Tensor, *, prebuilt: Optional[NestedTensor] = None
             ) -> NestedTensor:
                 params = super().initialize_parameters_recursively(prng_key, prebuilt=prebuilt)
                 params["dummy"] = {"test": 1}

--- a/axlearn/huggingface/hf_module.py
+++ b/axlearn/huggingface/hf_module.py
@@ -154,7 +154,7 @@ class HfModuleWrapper(BaseModel, ABC):
         )
 
     def initialize_parameters_recursively(
-        self, prng_key: jax.random.KeyArray, *, prebuilt: Optional[NestedTensor] = None
+        self, prng_key: Tensor, *, prebuilt: Optional[NestedTensor] = None
     ) -> NestedTensor:
         if self._use_prebuilt_params(prebuilt):
             return prebuilt

--- a/axlearn/vision/eval_detection.py
+++ b/axlearn/vision/eval_detection.py
@@ -56,9 +56,7 @@ class COCOMetricCalculator(BaseMetricCalculator):
             need_rescale_bboxes=cfg.need_rescale_bboxes,
         )
 
-    def init_state(
-        self, *, prng_key: jax.random.KeyArray, model_params: NestedTensor
-    ) -> NestedTensor:
+    def init_state(self, *, prng_key: Tensor, model_params: NestedTensor) -> NestedTensor:
         self._coco_metric.reset_states()
         return dict(prng_key=prng_key)
 
@@ -106,7 +104,7 @@ class COCOMetricCalculator(BaseMetricCalculator):
     def _predict_in_pjit(
         self,
         model_params: NestedTensor,
-        prng_key: jax.random.KeyArray,
+        prng_key: Tensor,
         input_batch: NestedTensor,
     ) -> Dict[str, NestedTensor]:
         predict_key, next_key = jax.random.split(prng_key)

--- a/axlearn/vision/samplers.py
+++ b/axlearn/vision/samplers.py
@@ -10,7 +10,7 @@ import numpy as np
 from axlearn.common.module import Tensor
 
 
-def sample(*, is_candidate: Tensor, size: Tensor, prng_key: jax.random.KeyArray) -> Tensor:
+def sample(*, is_candidate: Tensor, size: Tensor, prng_key: Tensor) -> Tensor:
     """Samples candidate elements.
 
     Samples `size` elements along the last axis and returns a boolean tensor indicating their
@@ -74,9 +74,7 @@ class LabelSampler:
         self.background_label = background_label
         self.ignore_label = ignore_label
 
-    def __call__(
-        self, *, labels: Tensor, paddings: Tensor, prng_key: jax.random.KeyArray
-    ) -> LabelSamples:
+    def __call__(self, *, labels: Tensor, paddings: Tensor, prng_key: Tensor) -> LabelSamples:
         """Samples foreground and background labels at the specified rate.
 
         Avoids sampling `ignore` labels and padding.


### PR DESCRIPTION
Since jax.random.KeyArray is deprecated, it emits lots of noisy warnings.