### PR TITLE
Moves the `utils.host_to_global_device_array` call from `SpmdTrainer._run_step` to `SpmdTrainer.run`.

### DIFF
--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -417,7 +417,7 @@ class SpmdTrainer(Module):
                         stop_trace_step = self.step + 3
                     self._step = self._step + 1
                     self.vlog(3, "Start step %s", self.step)
-                    output = self._run_step(input_batch)
+                    output = self._run_step(utils.host_to_global_device_array(input_batch))
                     self.vlog(3, "Done step %s", self.step)
                     num_steps += 1
                     if num_steps % 100 == 0:
@@ -688,13 +688,11 @@ class SpmdTrainer(Module):
         """Runs a single training step.
 
         Args:
-            input_batch: a NestedTensor.
+            input_batch: a NestedTensor containing global arrays.
 
         Returns:
             A dict containing 'loss' and 'aux' outputs.
         """
-        input_batch = utils.host_to_global_device_array(input_batch)
-
         with jax.profiler.StepTraceAnnotation("train", step_num=self.step):
             # Note(Jan 2022):
             # pjit currently requires all parameters to be specified as positional args.

--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -19,7 +19,7 @@ When using AXLearn's support for TFDS inputs, the typical way input batch shardi
   `read_config` that sets per-process splits.
 https://github.com/apple/axlearn/blob/c00c632b99e6a2d87ee7ba94f295b39e0871a577/axlearn/common/input_tf_data.py#L87-L98
 2. In each step, each process reads in the data specified by its split, but it is only a local array
-   initially. 
+   initially.
 3. `SpmdTrainer` combines these local arrays into a globally sharded array using
    `utils.host_to_global_device_array()` before passing the global input batch to `_run_step()`.
 https://github.com/apple/axlearn/blob/c00c632b99e6a2d87ee7ba94f295b39e0871a577/axlearn/common/trainer.py#L420

--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -11,11 +11,16 @@ For more complex use cases, it can be helpful to have a general idea of the what
 
 When using AXLearn's support for TFDS inputs, the typical way input batch sharding works is:
 
-1. You specify the split for the Tensorflow dataset you want each process to have either explicitly using the `read_config` option of `input_data.tfds_dataset()` or let it default to splitting evenly per process.
-https://github.com/apple/axlearn/blob/30e19f261638dc74f14a44461a8da538aa824fd6/axlearn/common/input_tf_data.py#L205
-See `input_tf_data.tfds_read_config()` for an example of how to construct a suitable value for `read_config` that sets per-process splits.
-https://github.com/apple/axlearn/blob/30e19f261638dc74f14a44461a8da538aa824fd6/axlearn/common/input_tf_data.py#L87-L98
-2. In each step, each process reads in the data specified by its split, but it is only a local array initially.
-3. In `SpmdTrainer`, the `_run_step()` function combines these local arrays into a globally sharded array using `utils.host_to_global_device_array()`.
-https://github.com/apple/axlearn/blob/30e19f261638dc74f14a44461a8da538aa824fd6/axlearn/common/trainer.py#L687
-https://github.com/apple/axlearn/blob/30e19f261638dc74f14a44461a8da538aa824fd6/axlearn/common/utils.py#L496
+1. You specify the split for the Tensorflow dataset you want each process to have either
+   explicitly using the `read_config` option of `input_data.tfds_dataset()` or
+   let it default to splitting evenly per process.
+  https://github.com/apple/axlearn/blob/c00c632b99e6a2d87ee7ba94f295b39e0871a577/axlearn/common/input_tf_data.py#L205
+  See `input_tf_data.tfds_read_config()` for an example of how to construct a suitable value for
+  `read_config` that sets per-process splits.
+https://github.com/apple/axlearn/blob/c00c632b99e6a2d87ee7ba94f295b39e0871a577/axlearn/common/input_tf_data.py#L87-L98
+2. In each step, each process reads in the data specified by its split, but it is only a local array
+   initially. 
+3. `SpmdTrainer` combines these local arrays into a globally sharded array using
+   `utils.host_to_global_device_array()` before passing the global input batch to `_run_step()`.
+https://github.com/apple/axlearn/blob/c00c632b99e6a2d87ee7ba94f295b39e0871a577/axlearn/common/trainer.py#L420
+https://github.com/apple/axlearn/blob/c00c632b99e6a2d87ee7ba94f295b39e0871a577/axlearn/common/utils.py#L496


### PR DESCRIPTION
This makes it easier for subclasses of SpmdTrainer to override `_run_step`.