### PR TITLE
Makes summary_writer.py log trainer_config individual lines as separate text summary entries for easier filtering.

### DIFF
--- a/axlearn/common/summary_writer.py
+++ b/axlearn/common/summary_writer.py
@@ -144,7 +144,11 @@ class SummaryWriter(BaseWriter):
 
     def log_config(self, config: ConfigBase, step: int = 0):
         with self.as_default():
-            tf_summary.text("trainer_config", config.debug_string().split("\n"), step=step)
+            config_lines = config.debug_string().split("\n")
+            tf_summary.text("trainer_config", config_lines, step=step)
+            for line in config_lines:
+                k, v = line.split(": ", 2)
+                tf_summary.text(f"trainer_config/{k}", v, step=step)
 
     def __call__(self, step: int, values: Dict[str, Any]):
         cfg = self.config

--- a/axlearn/common/summary_writer.py
+++ b/axlearn/common/summary_writer.py
@@ -147,7 +147,7 @@ class SummaryWriter(BaseWriter):
             config_lines = config.debug_string().split("\n")
             tf_summary.text("trainer_config", config_lines, step=step)
             for line in config_lines:
-                k, v = line.split(": ", 2)
+                k, v = line.split(": ", 1)
                 tf_summary.text(f"trainer_config/{k}", v, step=step)
 
     def __call__(self, step: int, values: Dict[str, Any]):


### PR DESCRIPTION
It allows comparisons such as

<img width="1585" alt="image" src="https://github.com/apple/axlearn/assets/29696544/35d35beb-c753-4524-b55c-91c827164236">
