### PR TITLE
Makes `axlearn ... config list` print the current active project settings.

### DIFF
--- a/axlearn/cloud/common/config.py
+++ b/axlearn/cloud/common/config.py
@@ -140,12 +140,16 @@ def _default_config_file() -> Optional[str]:
     # Check if default config exists in repo root or CWD.
     repo_or_cwd_config = os.path.abspath(os.path.join(_repo_root_or_cwd(), default_config))
     if os.path.exists(repo_or_cwd_config):
+        logging.log_first_n(logging.INFO, "Found default config at %s", 1, repo_or_cwd_config)
         return repo_or_cwd_config
 
     # Check if running from package.
     try:
         package_default_config = os.path.join(utils.get_package_root(), default_config)
         if os.path.exists(package_default_config):
+            logging.log_first_n(
+                logging.INFO, "Found default config at %s", 1, package_default_config
+            )
             return package_default_config
     except ValueError:
         pass
@@ -172,6 +176,7 @@ def _locate_user_config_file() -> Optional[str]:
     config_file = None
     for path in search_paths:
         if os.path.exists(path):
+            logging.log_first_n(logging.INFO, "Found user config at %s", 1, path)
             config_file = path
             break
     return config_file
@@ -320,6 +325,12 @@ def main(argv: Sequence[str], *, namespace: str, fv: flags.FlagValues):
             if labels := project_config.get("labels", None):
                 project_str += f" [{labels if isinstance(labels, str) else ', '.join(labels)}]"
             print(project_str)
+
+        if active_project is not None:
+            print()
+            print(f"Settings of active project {active_project}:")
+            print()
+            print(toml.dumps(project_configs[active_project]))
         return
 
     elif action == "activate":

--- a/axlearn/cloud/common/config_test.py
+++ b/axlearn/cloud/common/config_test.py
@@ -409,6 +409,11 @@ class CLITest(TestWithTemporaryCWD):
             "[ ] project0 [a, b]\n"
             "[*] project1\n"
             "[ ] project2 [a]\n"
+            "\n"
+            "Settings of active project project1:\n"
+            "\n"
+            "test = 1\n"
+            "\n"
         ))
         # fmt: on
 
@@ -425,5 +430,11 @@ class CLITest(TestWithTemporaryCWD):
             "[*] project0 [a, b]\n"
             "[ ] project1\n"
             "[ ] project2 [a]\n"
+            "\n"
+            "Settings of active project project0:\n"
+            "\n"
+            "test = 0\n"
+            'labels = [ "a", "b",]\n'
+            "\n"
         ))
         # fmt: on


### PR DESCRIPTION
Makes cloud/common/config.py log which config files are used.