### PR TITLE
Adds logical-to-physical batching, to decouple the real batch size from the number of devices. 

### DIFF
--- a/axlearn/common/evaler.py
+++ b/axlearn/common/evaler.py
@@ -230,8 +230,10 @@ class BaseMetricCalculator(Module):
             (outputs, output_collection), where `outputs` are the return value of
             self._model.method(...).
         """
+        # Shard and (possibly) dispatch the input batch.
+        input_batch = utils.dispatch_input_batch(input_batch)
         model_inputs = dict(
-            input_batch=self._eval_cast(utils.shard_input_batch(input_batch)),
+            input_batch=self._eval_cast(input_batch),
             **kwargs,
         )
         # Run model forward pass to compute outputs.

--- a/axlearn/common/inference.py
+++ b/axlearn/common/inference.py
@@ -378,12 +378,13 @@ class InferenceRunner(Module):
                 return utils.cast_floats(in_tree, to_dtype=cfg.inference_dtype)
             return in_tree
 
-        input_batch = utils.shard_input_batch(inference_cast(input_batch))
+        # Shard and (possibly) dispatch the input batch.
+        input_batch = utils.dispatch_input_batch(input_batch)
         output_batch, output_collection = F(
             self.model,
             prng_key=iter_key,
             state=inference_cast(model_params),
-            inputs={"input_batch": input_batch, **kwargs},
+            inputs={"input_batch": inference_cast(input_batch), **kwargs},
             is_training=False,
             method=method,
         )

--- a/axlearn/common/input_lm_test.py
+++ b/axlearn/common/input_lm_test.py
@@ -262,28 +262,27 @@ class LmTrainingInputTest(BaseLmInputTest):
         not os.path.exists(t5_sentence_piece_vocab_file), reason="Missing testdata."
     )
     def test_fake_text_lm_training_data_eval(self):
+        # N.B. we do not typically expect users to run the training data pipeline in eval mode.
+        # Instead we expect them to prefer `text_to_lm_eval_input`.
         expected_first_and_last_batch = [
             {
                 "input_ids": [
-                    [1712, 2, 29, 3155, 0, 0],
-                    [29, 3155, 1, 21820, 1712, 2],
-                    [29, 3155, 1, 21820, 1782, 2],
+                    [1, 21820, 296, 2, 29, 3155],
+                    [1, 21820, 8114, 2, 29, 3155],
+                    [1, 21820, 3, 17, 4424, 2],
                 ],
                 "target_labels": [
-                    [2, 29, 3155, 1, 0, 0],
-                    [3155, 1, 21820, 1712, 2, 29],
-                    [3155, 1, 21820, 1782, 2, 29],
+                    [21820, 296, 2, 29, 3155, 1],
+                    [21820, 8114, 2, 29, 3155, 1],
+                    [21820, 3, 17, 4424, 2, 29],
                 ],
-                "target_num_bytes": [8, 18, 18],
+                "target_num_bytes": [19, 18, 17],
             },
+            # Last batch should have some fully-padded examples.
             {
-                "input_ids": [[29, 3155, 1, 21820, 3, 17], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]],
-                "target_labels": [
-                    [3155, 1, 21820, 3, 17, 4424],
-                    [0, 0, 0, 0, 0, 0],
-                    [0, 0, 0, 0, 0, 0],
-                ],
-                "target_num_bytes": [14, 0, 0],
+                "input_ids": [[1712, 2, 29, 3155, 0, 0], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]],
+                "target_labels": [[2, 29, 3155, 1, 0, 0], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]],
+                "target_num_bytes": [8, 0, 0],
             },
         ]
 
@@ -307,7 +306,7 @@ class LmTrainingInputTest(BaseLmInputTest):
                 replace_newlines_with=self.newlines_replaced_with,
                 window_size=10,
                 max_padding_fraction=0.5,
-                shuffle_buffer_size=1024,
+                shuffle_buffer_size=0,
             ),
             batcher=config_for_function(input_tf_data.batch).set(
                 global_batch_size=batch_size,

--- a/axlearn/common/t5_test.py
+++ b/axlearn/common/t5_test.py
@@ -366,7 +366,7 @@ class T5EncoderDecoderModelTest(TestCase):
             layer: T5EncoderDecoderModel = cfg.instantiate(parent=None)
 
             def train_step(state, input_batch):
-                input_batch = utils.shard_input_batch(input_batch)
+                input_batch = utils.dispatch_input_batch(input_batch)
                 new_prng_key, prng_key = jax.random.split(state["prng_key"])
 
                 def _forward(model_parameters, forward_input_batch):

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -746,9 +746,11 @@ class SpmdTrainer(Module):
         state: _TrainerState,
         input_batch: Dict[str, Any],
     ) -> Tuple[_TrainerState, NestedTensor]:
-        input_batch = utils.shard_input_batch(
+        # Shard and (possibly) dispatch the input batch.
+        input_batch = utils.dispatch_input_batch(
             input_batch, batch_axis_names=self.config.batch_axis_names
         )
+
         new_prng_key, param_noise_key, forward_key, learner_key = jax.random.split(
             state.prng_key, 4
         )


### PR DESCRIPTION
Default input_tf_data.py:batch function now accepts optional arguments to indicate the global logical batch size, and the logical feed process indices.

The trainer.py:SpmdTrainer will dispatch the global physical batch post-sharding to a logical batch. The minimum global logical batch size is 1.

This allows one to configure an Input where only a subset of the processes read the input dataset, and the remainder are replaced with padding which is discarded by SpmdTrainer when dispatching the physical batch to logical batch axes.