### PR TITLE
FlashAttention now inherits from GQA, and has improved sharding-spec flexibility.

### DIFF
--- a/axlearn/common/flash_attention/tpu_attention_benchmark.py
+++ b/axlearn/common/flash_attention/tpu_attention_benchmark.py
@@ -73,7 +73,7 @@ _BENCHMARK_CONFIGS = {
 
 
 def _time_call(fn: Callable, *, num_iters: int = 5) -> float:
-    """Times average execution time for fn call after warmup over num_iters."""
+    """Times average execution time for fn call over num_iters after warmup."""
     fn().block_until_ready()
     tic = time.perf_counter()
     for _ in range(num_iters):


### PR DESCRIPTION
We:
* Modify FlashAttention so as to inherit from GroupedQueryAttention instead of MultiheadAttention,
* equip FlashAttention's config with a more flexible way to specify partition specs for both the attention shard_map impl, and the outputs.