### PR TITLE
Constrain causal LM input batch across batch & sequence-parallel axes.

### DIFF
--- a/axlearn/common/causal_lm.py
+++ b/axlearn/common/causal_lm.py
@@ -320,8 +320,9 @@ class Model(BaseModel):
                 assert v.ndim == 1
                 input_batch[k] = with_sharding_constraint(v, PartitionSpec(cfg.batch_axis_names))
             else:
+                # We warn as not-constraining may be an oversight.
                 logging.log_first_n(
-                    logging.INFO, "Not constraining input_batch[%s].", len(input_batch), k
+                    logging.WARNING, "Not constraining input_batch[%s].", len(input_batch), k
                 )
 
 

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B.txt
@@ -122,6 +122,8 @@ mesh_shape[0]: 1
 mesh_shape[1]: 1
 mesh_shape[2]: -1
 mesh_shape[3]: 1
+model.batch_axis_names[0]: 'data'
+model.batch_axis_names[1]: 'fsdp'
 model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
 model.decoder.dim: 4096
 model.decoder.dropout_rate: 0.0

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-test.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-test.txt
@@ -112,6 +112,8 @@ mesh_shape[0]: 1
 mesh_shape[1]: 1
 mesh_shape[2]: 1
 mesh_shape[3]: 1
+model.batch_axis_names[0]: 'data'
+model.batch_axis_names[1]: 'fsdp'
 model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
 model.decoder.dim: 8
 model.decoder.dropout_rate: 0.0

--- a/axlearn/experiments/text/gpt/common.py
+++ b/axlearn/experiments/text/gpt/common.py
@@ -233,12 +233,14 @@ def model_config(
             )
         }
     )
+    batch_axis_names = ("data", "fsdp")
     cfg = causal_lm.Model.default_config().set(
         decoder=decoder_cfg,
         param_init=model_param_init,
+        batch_axis_names=batch_axis_names,
+        seq_axis_names=None,
     )
     cfg.dtype = jnp.float32
-    batch_axis_names = ("data", "fsdp")
     # Shard some FFN and attention weights over both FSDP and model axes.
     set_double_shard_weights_config(
         cfg.decoder.transformer.layer,


### PR DESCRIPTION
We can now specify batch & sequence mesh axis names for causal LM, and tensors in the input batch will be constrained accordingly.