### PR TITLE
Adds axlearn/experiments/run_aot_compilation.py, a command-line tool to run AoT compilation on a given config.

### DIFF
--- a/axlearn/common/aot_compilation.py
+++ b/axlearn/common/aot_compilation.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict
 
 import jax
+jax.config.update("JAX_PLATFORMS", "cpu")
 import jax.random
 import numpy as np
 from jax.experimental.topologies import get_topology_desc

--- a/axlearn/common/aot_compilation.py
+++ b/axlearn/common/aot_compilation.py
@@ -1,0 +1,85 @@
+"""Utilities for ahead-of-time compilation.
+
+Reference:
+https://docs.google.com/document/d/1Y5IdmvAZA7UtMHAWkRh8k2PscVoG5FvMH9-E6hygsyY/
+"""
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["TPU_SKIP_MDS_QUERY"] = "1"
+
+import copy
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+import jax
+import jax.random
+import numpy as np
+from jax.experimental.topologies import get_topology_desc
+
+from axlearn.common.trainer import SpmdTrainer
+
+
+@dataclass
+class SystemCharacteristics:
+    platform: str
+    topology_name: str
+    chip_config_name: str  # 'megacore' or 'default'
+    chips_per_host_bounds: tuple
+    devices_per_slice: int
+
+
+USER_FACING_NAME_TO_SYSTEM_CHARACTERISTICS = {
+    "v5e-16": SystemCharacteristics("tpu", "v5e:4x4", "default", (2, 2, 1), 16),
+    "v5e-32": SystemCharacteristics("tpu", "v5e:4x8", "default", (2, 2, 1), 32),
+    "v5e-64": SystemCharacteristics("tpu", "v5e:8x8", "default", (2, 2, 1), 64),
+    "v5e-128": SystemCharacteristics("tpu", "v5e:8x16", "default", (2, 2, 1), 128),
+    "v5e-256": SystemCharacteristics("tpu", "v5e:16x16", "default", (2, 2, 1), 256),
+    "v4-8": SystemCharacteristics("tpu", "v4:2x2x1", "megacore", (2, 2, 1), 4),
+    "v4-16": SystemCharacteristics("tpu", "v4:2x2x2", "megacore", (2, 2, 1), 8),
+    "v4-32": SystemCharacteristics("tpu", "v4:2x2x4", "megacore", (2, 2, 1), 16),
+    "v4-64": SystemCharacteristics("tpu", "v4:2x4x4", "megacore", (2, 2, 1), 32),
+    "v4-128": SystemCharacteristics("tpu", "v4:4x4x4", "megacore", (2, 2, 1), 64),
+    "v4-256": SystemCharacteristics("tpu", "v4:4x4x8", "megacore", (2, 2, 1), 128),
+    "v4-512": SystemCharacteristics("tpu", "v4:4x8x8", "megacore", (2, 2, 1), 256),
+    "v4-1024": SystemCharacteristics("tpu", "v4:8x8x8", "megacore", (2, 2, 1), 512),
+    "v4-1536": SystemCharacteristics("tpu", "v4:8x8x12", "megacore", (2, 2, 1), 768),
+    "v4-2048": SystemCharacteristics("tpu", "v4:8x8x16", "megacore", (2, 2, 1), 1024),
+    "v4-4096": SystemCharacteristics("tpu", "v4:8x16x16", "megacore", (2, 2, 1), 2048),
+}
+
+
+def compile_trainer_programs(
+    trainer_config: SpmdTrainer.Config, *, topology: str, topology_num_slices: int = 1
+) -> Dict[str, Callable]:
+    """Returns compiled XLA programs for the given trainer.
+
+    Args:
+        trainer_config: the trainer config.
+        topology: a string representing the TPU topology, e.g., "v4-8". Must be a key in
+            USER_FACING_NAME_TO_SYSTEM_CHARACTERISTICS.
+        topology_num_slices: number of TPU slices.
+
+    Returns:
+        A dict containing the following programs:
+        * "train_step": a program to run a single training step.
+    """
+    if topology is not None:
+        target_hardware = USER_FACING_NAME_TO_SYSTEM_CHARACTERISTICS[topology]
+        topology_devices = get_topology_desc(
+            platform=target_hardware.platform,
+            topology_name=target_hardware.topology_name,
+            chip_config_name=target_hardware.chip_config_name,
+            chips_per_host_bounds=target_hardware.chips_per_host_bounds,
+            num_slices=topology_num_slices,
+        ).devices
+    else:
+        topology_devices = jax.devices()
+
+    cfg = copy.deepcopy(trainer_config)
+    cfg.dir = "NOT_USED"
+    cfg.mesh_shape = [len(topology_devices)] + [1] * (len(cfg.mesh_axis_names) - 1)
+    topology_devices = np.reshape(topology_devices, cfg.mesh_shape)
+    trainer: SpmdTrainer = cfg.instantiate(parent=None, devices=topology_devices)
+    compiled_train_step = trainer.compile_train_step()
+    return {"train_step": compiled_train_step}

--- a/axlearn/common/aot_compilation.py
+++ b/axlearn/common/aot_compilation.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict
 
 import jax
-jax.config.update("JAX_PLATFORMS", "cpu")
+jax.config.update("jax_platforms", "cpu")
 import jax.random
 import numpy as np
 from jax.experimental.topologies import get_topology_desc

--- a/axlearn/common/aot_compilation.py
+++ b/axlearn/common/aot_compilation.py
@@ -1,3 +1,5 @@
+# Copyright © 2023 Apple Inc.
+
 """Utilities for ahead-of-time compilation.
 
 Reference:
@@ -5,14 +7,14 @@ https://docs.google.com/document/d/1Y5IdmvAZA7UtMHAWkRh8k2PscVoG5FvMH9-E6hygsyY/
 """
 import os
 
-os.environ["JAX_PLATFORMS"] = "cpu"
 os.environ["TPU_SKIP_MDS_QUERY"] = "1"
 
-import copy
 from dataclasses import dataclass
 from typing import Callable, Dict
 
 import jax
+
+# To avoid error: Unable to initialize backend 'tpu'.
 jax.config.update("jax_platforms", "cpu")
 import jax.random
 import numpy as np
@@ -31,12 +33,15 @@ class SystemCharacteristics:
     devices_per_slice: int
 
 
+# Reference: https://github.com/google/maxtext/blob/main/MaxText/accelerator_to_spec_map.py
 USER_FACING_NAME_TO_SYSTEM_CHARACTERISTICS = {
+    # v5e
     "v5e-16": SystemCharacteristics("tpu", "v5e:4x4", "default", (2, 2, 1), 16),
     "v5e-32": SystemCharacteristics("tpu", "v5e:4x8", "default", (2, 2, 1), 32),
     "v5e-64": SystemCharacteristics("tpu", "v5e:8x8", "default", (2, 2, 1), 64),
     "v5e-128": SystemCharacteristics("tpu", "v5e:8x16", "default", (2, 2, 1), 128),
     "v5e-256": SystemCharacteristics("tpu", "v5e:16x16", "default", (2, 2, 1), 256),
+    # v4
     "v4-8": SystemCharacteristics("tpu", "v4:2x2x1", "megacore", (2, 2, 1), 4),
     "v4-16": SystemCharacteristics("tpu", "v4:2x2x2", "megacore", (2, 2, 1), 8),
     "v4-32": SystemCharacteristics("tpu", "v4:2x2x4", "megacore", (2, 2, 1), 16),
@@ -48,6 +53,103 @@ USER_FACING_NAME_TO_SYSTEM_CHARACTERISTICS = {
     "v4-1536": SystemCharacteristics("tpu", "v4:8x8x12", "megacore", (2, 2, 1), 768),
     "v4-2048": SystemCharacteristics("tpu", "v4:8x8x16", "megacore", (2, 2, 1), 1024),
     "v4-4096": SystemCharacteristics("tpu", "v4:8x16x16", "megacore", (2, 2, 1), 2048),
+    # v5p
+    "v5p-8": SystemCharacteristics("tpu", "v5:2x2x1", "megacore", (2, 2, 1), 4),
+    "v5p-16": SystemCharacteristics("tpu", "v5:2x2x2", "megacore", (2, 2, 1), 8),
+    "v5p-32": SystemCharacteristics("tpu", "v5:2x2x4", "megacore", (2, 2, 1), 16),
+    "v5p-64": SystemCharacteristics("tpu", "v5:2x4x4", "megacore", (2, 2, 1), 32),
+    "v5p-128": SystemCharacteristics("tpu", "v5:4x4x4", "megacore", (2, 2, 1), 64),
+    "v5p-256": SystemCharacteristics("tpu", "v5:4x4x8", "megacore", (2, 2, 1), 128),
+    "v5p-384": SystemCharacteristics("tpu", "v5:4x4x12", "megacore", (2, 2, 1), 192),
+    "v5p-512": SystemCharacteristics("tpu", "v5:4x8x8", "megacore", (2, 2, 1), 256),
+    "v5p-640": SystemCharacteristics("tpu", "v5:4x4x20", "megacore", (2, 2, 1), 320),
+    "v5p-768": SystemCharacteristics("tpu", "v5:4x8x12", "megacore", (2, 2, 1), 384),
+    "v5p-896": SystemCharacteristics("tpu", "v5:4x4x28", "megacore", (2, 2, 1), 448),
+    "v5p-1024": SystemCharacteristics("tpu", "v5:8x8x8", "megacore", (2, 2, 1), 512),
+    "v5p-1152": SystemCharacteristics("tpu", "v5:4x12x12", "megacore", (2, 2, 1), 576),
+    "v5p-1280": SystemCharacteristics("tpu", "v5:4x8x20", "megacore", (2, 2, 1), 640),
+    "v5p-1408": SystemCharacteristics("tpu", "v5:4x4x44", "megacore", (2, 2, 1), 704),
+    "v5p-1536": SystemCharacteristics("tpu", "v5:8x8x12", "megacore", (2, 2, 1), 768),
+    "v5p-1664": SystemCharacteristics("tpu", "v5:4x4x52", "megacore", (2, 2, 1), 832),
+    "v5p-1792": SystemCharacteristics("tpu", "v5:4x8x28", "megacore", (2, 2, 1), 896),
+    "v5p-1920": SystemCharacteristics("tpu", "v5:4x12x20", "megacore", (2, 2, 1), 960),
+    "v5p-2048": SystemCharacteristics("tpu", "v5:8x8x16", "megacore", (2, 2, 1), 1024),
+    "v5p-2176": SystemCharacteristics("tpu", "v5:4x4x68", "megacore", (2, 2, 1), 1088),
+    "v5p-2304": SystemCharacteristics("tpu", "v5:8x12x12", "megacore", (2, 2, 1), 1152),
+    "v5p-2432": SystemCharacteristics("tpu", "v5:4x4x76", "megacore", (2, 2, 1), 1216),
+    "v5p-2560": SystemCharacteristics("tpu", "v5:8x8x20", "megacore", (2, 2, 1), 1280),
+    "v5p-2688": SystemCharacteristics("tpu", "v5:4x12x28", "megacore", (2, 2, 1), 1344),
+    "v5p-2816": SystemCharacteristics("tpu", "v5:4x8x44", "megacore", (2, 2, 1), 1408),
+    "v5p-2944": SystemCharacteristics("tpu", "v5:4x4x92", "megacore", (2, 2, 1), 1472),
+    "v5p-3072": SystemCharacteristics("tpu", "v5:4x12x16", "megacore", (2, 2, 1), 1536),
+    "v5p-3200": SystemCharacteristics("tpu", "v5:4x20x20", "megacore", (2, 2, 1), 1600),
+    "v5p-3328": SystemCharacteristics("tpu", "v5:4x8x52", "megacore", (2, 2, 1), 1664),
+    "v5p-3456": SystemCharacteristics("tpu", "v5:12x12x12", "megacore", (2, 2, 1), 1728),
+    "v5p-3584": SystemCharacteristics("tpu", "v5:8x8x28", "megacore", (2, 2, 1), 1792),
+    "v5p-3712": SystemCharacteristics("tpu", "v5:4x4x116", "megacore", (2, 2, 1), 1856),
+    "v5p-3840": SystemCharacteristics("tpu", "v5:8x12x20", "megacore", (2, 2, 1), 1920),
+    "v5p-3968": SystemCharacteristics("tpu", "v5:4x4x124", "megacore", (2, 2, 1), 1984),
+    "v5p-4096": SystemCharacteristics("tpu", "v5:8x16x16", "megacore", (2, 2, 1), 2048),
+    "v5p-4224": SystemCharacteristics("tpu", "v5:4x12x44", "megacore", (2, 2, 1), 2112),
+    "v5p-4352": SystemCharacteristics("tpu", "v5:4x8x68", "megacore", (2, 2, 1), 2176),
+    "v5p-4480": SystemCharacteristics("tpu", "v5:4x20x28", "megacore", (2, 2, 1), 2240),
+    "v5p-4608": SystemCharacteristics("tpu", "v5:12x12x16", "megacore", (2, 2, 1), 2304),
+    "v5p-4736": SystemCharacteristics("tpu", "v5:4x4x148", "megacore", (2, 2, 1), 2368),
+    "v5p-4864": SystemCharacteristics("tpu", "v5:4x8x76", "megacore", (2, 2, 1), 2432),
+    "v5p-4992": SystemCharacteristics("tpu", "v5:4x12x52", "megacore", (2, 2, 1), 2496),
+    "v5p-5120": SystemCharacteristics("tpu", "v5:8x16x20", "megacore", (2, 2, 1), 2560),
+    "v5p-5248": SystemCharacteristics("tpu", "v5:4x4x164", "megacore", (2, 2, 1), 2624),
+    "v5p-5376": SystemCharacteristics("tpu", "v5:8x12x28", "megacore", (2, 2, 1), 2688),
+    "v5p-5504": SystemCharacteristics("tpu", "v5:4x4x172", "megacore", (2, 2, 1), 2752),
+    "v5p-5632": SystemCharacteristics("tpu", "v5:8x8x44", "megacore", (2, 2, 1), 2816),
+    "v5p-5760": SystemCharacteristics("tpu", "v5:12x12x20", "megacore", (2, 2, 1), 2880),
+    "v5p-5888": SystemCharacteristics("tpu", "v5:4x8x92", "megacore", (2, 2, 1), 2944),
+    "v5p-6016": SystemCharacteristics("tpu", "v5:4x4x188", "megacore", (2, 2, 1), 3008),
+    "v5p-6144": SystemCharacteristics("tpu", "v5:12x16x16", "megacore", (2, 2, 1), 3072),
+    "v5p-6272": SystemCharacteristics("tpu", "v5:4x28x28", "megacore", (2, 2, 1), 3136),
+    "v5p-6400": SystemCharacteristics("tpu", "v5:8x20x20", "megacore", (2, 2, 1), 3200),
+    "v5p-6528": SystemCharacteristics("tpu", "v5:4x12x68", "megacore", (2, 2, 1), 3264),
+    "v5p-6656": SystemCharacteristics("tpu", "v5:8x8x52", "megacore", (2, 2, 1), 3328),
+    "v5p-6784": SystemCharacteristics("tpu", "v5:4x4x212", "megacore", (2, 2, 1), 3392),
+    "v5p-6912": SystemCharacteristics("tpu", "v5:12x12x24", "megacore", (2, 2, 1), 3456),
+    "v5p-7040": SystemCharacteristics("tpu", "v5:4x20x44", "megacore", (2, 2, 1), 3520),
+    "v5p-7168": SystemCharacteristics("tpu", "v5:8x16x28", "megacore", (2, 2, 1), 3584),
+    "v5p-7296": SystemCharacteristics("tpu", "v5:4x12x76", "megacore", (2, 2, 1), 3648),
+    "v5p-7424": SystemCharacteristics("tpu", "v5:4x8x116", "megacore", (2, 2, 1), 3712),
+    "v5p-7552": SystemCharacteristics("tpu", "v5:4x4x236", "megacore", (2, 2, 1), 3776),
+    "v5p-7680": SystemCharacteristics("tpu", "v5:12x16x20", "megacore", (2, 2, 1), 3840),
+    "v5p-7808": SystemCharacteristics("tpu", "v5:4x4x244", "megacore", (2, 2, 1), 3904),
+    "v5p-7936": SystemCharacteristics("tpu", "v5:4x8x124", "megacore", (2, 2, 1), 3968),
+    "v5p-8064": SystemCharacteristics("tpu", "v5:12x12x28", "megacore", (2, 2, 1), 4032),
+    "v5p-8192": SystemCharacteristics("tpu", "v5:16x16x16", "megacore", (2, 2, 1), 4096),
+    "v5p-8320": SystemCharacteristics("tpu", "v5:4x20x52", "megacore", (2, 2, 1), 4160),
+    "v5p-8448": SystemCharacteristics("tpu", "v5:8x12x44", "megacore", (2, 2, 1), 4224),
+    "v5p-8704": SystemCharacteristics("tpu", "v5:8x8x68", "megacore", (2, 2, 1), 4352),
+    "v5p-8832": SystemCharacteristics("tpu", "v5:4x12x92", "megacore", (2, 2, 1), 4416),
+    "v5p-8960": SystemCharacteristics("tpu", "v5:8x20x28", "megacore", (2, 2, 1), 4480),
+    "v5p-9216": SystemCharacteristics("tpu", "v5:12x16x24", "megacore", (2, 2, 1), 4608),
+    "v5p-9472": SystemCharacteristics("tpu", "v5:4x8x148", "megacore", (2, 2, 1), 4736),
+    "v5p-9600": SystemCharacteristics("tpu", "v5:12x20x20", "megacore", (2, 2, 1), 4800),
+    "v5p-9728": SystemCharacteristics("tpu", "v5:8x8x76", "megacore", (2, 2, 1), 4864),
+    "v5p-9856": SystemCharacteristics("tpu", "v5:4x28x44", "megacore", (2, 2, 1), 4928),
+    "v5p-9984": SystemCharacteristics("tpu", "v5:8x12x52", "megacore", (2, 2, 1), 4992),
+    "v5p-10240": SystemCharacteristics("tpu", "v5:16x16x20", "megacore", (2, 2, 1), 5120),
+    "v5p-10368": SystemCharacteristics("tpu", "v5:12x12x36", "megacore", (2, 2, 1), 5184),
+    "v5p-10496": SystemCharacteristics("tpu", "v5:4x8x164", "megacore", (2, 2, 1), 5248),
+    "v5p-10752": SystemCharacteristics("tpu", "v5:12x16x28", "megacore", (2, 2, 1), 5376),
+    "v5p-10880": SystemCharacteristics("tpu", "v5:4x20x68", "megacore", (2, 2, 1), 5440),
+    "v5p-11008": SystemCharacteristics("tpu", "v5:4x8x172", "megacore", (2, 2, 1), 5504),
+    "v5p-11136": SystemCharacteristics("tpu", "v5:4x12x116", "megacore", (2, 2, 1), 5568),
+    "v5p-11264": SystemCharacteristics("tpu", "v5:8x16x44", "megacore", (2, 2, 1), 5632),
+    "v5p-11520": SystemCharacteristics("tpu", "v5:12x20x24", "megacore", (2, 2, 1), 5760),
+    "v5p-11648": SystemCharacteristics("tpu", "v5:4x28x52", "megacore", (2, 2, 1), 5824),
+    "v5p-11776": SystemCharacteristics("tpu", "v5:8x8x92", "megacore", (2, 2, 1), 5888),
+    "v5p-11904": SystemCharacteristics("tpu", "v5:4x12x124", "megacore", (2, 2, 1), 5952),
+    "v5p-12032": SystemCharacteristics("tpu", "v5:4x8x188", "megacore", (2, 2, 1), 6016),
+    "v5p-12160": SystemCharacteristics("tpu", "v5:4x20x76", "megacore", (2, 2, 1), 6080),
+    "v5p-12288": SystemCharacteristics("tpu", "v5:16x16x24", "megacore", (2, 2, 1), 6144),
+    "v5p-13824": SystemCharacteristics("tpu", "v5:12x24x24", "megacore", (2, 2, 1), 6912),
+    "v5p-17920": SystemCharacteristics("tpu", "v5:16x20x28", "megacore", (2, 2, 1), 8960),
 }
 
 
@@ -57,10 +159,10 @@ def compile_trainer_programs(
     """Returns compiled XLA programs for the given trainer.
 
     Args:
-        trainer_config: the trainer config.
-        topology: a string representing the TPU topology, e.g., "v4-8". Must be a key in
+        trainer_config: The trainer config.
+        topology: A string representing the TPU topology, e.g., "v4-8". Must be a key in
             USER_FACING_NAME_TO_SYSTEM_CHARACTERISTICS.
-        topology_num_slices: number of TPU slices.
+        topology_num_slices: The number of TPU slices.
 
     Returns:
         A dict containing the following programs:
@@ -78,8 +180,7 @@ def compile_trainer_programs(
     else:
         topology_devices = jax.devices()
 
-    cfg = copy.deepcopy(trainer_config)
-    cfg.dir = "NOT_USED"
+    cfg = trainer_config.clone(dir="NOT_USED")
     if cfg.mesh_shape is None:
         cfg.mesh_shape = [len(topology_devices)] + [1] * (len(cfg.mesh_axis_names) - 1)
     else:

--- a/axlearn/common/aot_compilation.py
+++ b/axlearn/common/aot_compilation.py
@@ -7,7 +7,7 @@ https://docs.google.com/document/d/1Y5IdmvAZA7UtMHAWkRh8k2PscVoG5FvMH9-E6hygsyY/
 """
 import os
 from dataclasses import dataclass
-from typing import Callable, Dict
+from typing import Dict
 
 import jax
 import jax.random
@@ -154,7 +154,7 @@ USER_FACING_NAME_TO_SYSTEM_CHARACTERISTICS = {
 
 def compile_trainer_programs(
     trainer_config: SpmdTrainer.Config, *, topology: str, topology_num_slices: int = 1
-) -> Dict[str, Callable]:
+) -> Dict[str, jax.stages.Compiled]:
     """Returns compiled XLA programs for the given trainer.
 
     Args:

--- a/axlearn/common/aot_compilation.py
+++ b/axlearn/common/aot_compilation.py
@@ -19,6 +19,7 @@ import numpy as np
 from jax.experimental.topologies import get_topology_desc
 
 from axlearn.common.trainer import SpmdTrainer
+from axlearn.common.utils import infer_mesh_shape
 
 
 @dataclass
@@ -79,7 +80,10 @@ def compile_trainer_programs(
 
     cfg = copy.deepcopy(trainer_config)
     cfg.dir = "NOT_USED"
-    cfg.mesh_shape = [len(topology_devices)] + [1] * (len(cfg.mesh_axis_names) - 1)
+    if cfg.mesh_shape is None:
+        cfg.mesh_shape = [len(topology_devices)] + [1] * (len(cfg.mesh_axis_names) - 1)
+    else:
+        cfg.mesh_shape = infer_mesh_shape(cfg.mesh_shape, num_devices=len(topology_devices))
     topology_devices = np.reshape(topology_devices, cfg.mesh_shape)
     trainer: SpmdTrainer = cfg.instantiate(parent=None, devices=topology_devices)
     compiled_train_step = trainer.compile_train_step()

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -130,8 +130,10 @@ class TestCase(parameterized.TestCase):
 
     def setUp(self):
         push_data_dir(self.data_dir)
-        # Setup without distributed initialization.
-        utils_spmd.setup(jax_backend="cpu")
+        utils_spmd.setup(jax_backend=self._jax_backend())
+
+    def _jax_backend(self) -> Optional[str]:
+        return None
 
     def tearDown(self) -> None:
         self.assertEqual(pop_data_dir(), self.data_dir)

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -132,8 +132,9 @@ class TestCase(parameterized.TestCase):
         push_data_dir(self.data_dir)
         utils_spmd.setup(jax_backend=self._jax_backend())
 
-    def _jax_backend(self) -> Optional[str]:
-        return None
+    def _jax_backend(self) -> str:
+        # Setup without distributed initialization by default.
+        return "cpu"
 
     def tearDown(self) -> None:
         self.assertEqual(pop_data_dir(), self.data_dir)

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -8,7 +8,7 @@ import sys
 import threading
 import time
 import traceback
-from typing import Any, Callable, Dict, List, Literal, NamedTuple, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence, Tuple, Union
 
 import jax
 import tensorflow as tf
@@ -731,7 +731,7 @@ class SpmdTrainer(Module):
             evaler_summaries[evaler_name] = summaries
         return evaler_summaries
 
-    def _pjit_train_step(self) -> Callable:
+    def _pjit_train_step(self) -> jax.stages.Wrapped:
         return pjit(
             self._train_step,
             in_shardings=(
@@ -749,7 +749,7 @@ class SpmdTrainer(Module):
             donate_argnums=(0,),  # donate the state
         )
 
-    def compile_train_step(self) -> Callable:
+    def compile_train_step(self) -> jax.stages.Compiled:
         with self.mesh():
             # Do not run init(), which require real devices.
             trainer_state_specs = jax.tree_util.tree_map(

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -163,7 +163,13 @@ class SpmdTrainer(Module):
         # increment within this interval.
         watchdog_timeout_seconds: Optional[float] = None
 
-    def __init__(self, cfg: Config, *, parent: Optional[Module], devices: Optional[Sequence[jax.Device]]=None):
+    def __init__(
+        self,
+        cfg: Config,
+        *,
+        parent: Optional[Module],
+        devices: Optional[Sequence[jax.Device]] = None,
+    ):
         super().__init__(cfg, parent=parent)
         cfg = self.config
 
@@ -758,7 +764,8 @@ class SpmdTrainer(Module):
             )
             input_batch_specs = jax.tree_util.tree_map(
                 lambda tf_spec: jax.ShapeDtypeStruct(
-                    shape=tf_spec.shape, dtype=tf_spec.dtype.as_numpy_dtype),
+                    shape=tf_spec.shape, dtype=tf_spec.dtype.as_numpy_dtype
+                ),
                 self.input.dataset().element_spec,
             )
             jit_train_step = self._pjit_train_step()

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -193,7 +193,9 @@ class SpmdTrainer(Module):
             [device.platform for device in jax.local_devices()],
         )
         self._step_log("Mesh shape: %s", cfg.mesh_shape)
-        devices = devices or utils.create_device_mesh(mesh_shape=cfg.mesh_shape)
+        devices = (
+            utils.create_device_mesh(mesh_shape=cfg.mesh_shape) if devices is None else devices
+        )
         mesh = jax.sharding.Mesh(devices, cfg.mesh_axis_names)
         self._step_log("Global mesh: %s", mesh)
         self._mesh = mesh

--- a/axlearn/common/utils_spmd.py
+++ b/axlearn/common/utils_spmd.py
@@ -13,7 +13,7 @@ _jax_distributed_initialized = False
 
 def setup(
     *,
-    jax_backend: str,
+    jax_backend: str = None,
     distributed_coordinator: Optional[str] = None,
     num_processes: Optional[int] = None,
     process_id: Optional[int] = None,
@@ -70,6 +70,14 @@ def setup(
                     f"Instead, got num_processes={num_processes}, process_id={process_id}."
                 )
 
+            num_processes = (
+                num_processes
+                if num_processes is not None
+                else jax.process_count(backend=jax_backend)
+            )
+            process_id = (
+                process_id if process_id is not None else jax.process_index(backend=jax_backend)
+            )
             if not distributed_coordinator:
                 if num_processes == 1:
                     distributed_coordinator = f"localhost:{portpicker.pick_unused_port()}"

--- a/axlearn/common/utils_spmd.py
+++ b/axlearn/common/utils_spmd.py
@@ -13,7 +13,7 @@ _jax_distributed_initialized = False
 
 def setup(
     *,
-    jax_backend: str = None,
+    jax_backend: str,
     distributed_coordinator: Optional[str] = None,
     num_processes: Optional[int] = None,
     process_id: Optional[int] = None,
@@ -70,14 +70,6 @@ def setup(
                     f"Instead, got num_processes={num_processes}, process_id={process_id}."
                 )
 
-            num_processes = (
-                num_processes
-                if num_processes is not None
-                else jax.process_count(backend=jax_backend)
-            )
-            process_id = (
-                process_id if process_id is not None else jax.process_index(backend=jax_backend)
-            )
             if not distributed_coordinator:
                 if num_processes == 1:
                     distributed_coordinator = f"localhost:{portpicker.pick_unused_port()}"

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -18,7 +18,6 @@ import numpy as np
 os.environ["JAX_PLATFORMS"] = "cpu"
 
 import copy
-import tempfile
 from typing import Optional
 
 import jax
@@ -28,15 +27,12 @@ from dataclasses import dataclass
 
 import jax.random
 from jax import numpy as jnp
-from absl import logging
 from absl.testing import absltest
 from jax.experimental.topologies import get_topology_desc
 from jax.experimental.serialize_executable import serialize
 import tensorflow as tf
 
 from axlearn.common import test_utils
-from axlearn.common.checkpointer import every_n_steps_policy
-from axlearn.common.evaler import every_n_steps_policy as eval_every_n_steps_policy
 from axlearn.common.trainer import SpmdTrainer
 from axlearn.common.utils import set_data_dir
 from axlearn.experiments.text.gpt import c4_trainer
@@ -75,21 +71,6 @@ def get_system_characteristics(user_facing_name):
     return UserFacingNameToSystemCharacteristics.get(user_facing_name)
 
 
-def to_jax_dtype(tf_dtype: tf.DType) -> jnp.dtype:
-    if tf_dtype == tf.int32:
-        return jnp.int32
-    elif tf_dtype == tf.float32:
-        return jnp.float32
-    elif tf_dtype == tf.bloat16:
-        return jnp.bloat16
-    else:
-        raise NotImplementedError(tf_dtype)
-
-
-def get_shape_dtype_struct(tf_spec) -> jax.ShapeDtypeStruct:
-    return jax.ShapeDtypeStruct(shape=tf_spec.shape, dtype=to_jax_dtype(tf_spec.dtype))
-
-
 class AoTCompilationTest(test_utils.TrainerConfigTestCase):
     """Tests ahead-of-time (AoT) compilation."""
 
@@ -100,58 +81,43 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
         self,
         trainer_config: SpmdTrainer.Config,
         *,
-        compile_topology: str,
+        compile_topology: Optional[str],
         compile_topology_num_slices: int = 1,
     ):
-        target_hardware = get_system_characteristics(compile_topology)
-        topology_devices = get_topology_desc(
-            platform=target_hardware.platform,
-            topology_name=target_hardware.topology_name,
-            chip_config_name=target_hardware.chip_config_name,
-            chips_per_host_bounds=target_hardware.chips_per_host_bounds,
-            num_slices=compile_topology_num_slices,
-        ).devices
+        if compile_topology is not None:
+            target_hardware = get_system_characteristics(compile_topology)
+            topology_devices = get_topology_desc(
+                platform=target_hardware.platform,
+                topology_name=target_hardware.topology_name,
+                chip_config_name=target_hardware.chip_config_name,
+                chips_per_host_bounds=target_hardware.chips_per_host_bounds,
+                num_slices=compile_topology_num_slices,
+            ).devices
+        else:
+            topology_devices = jax.devices(self._jax_backend())
 
         with jax.checking_leaks(), set_data_dir("FAKE"):
             cfg = copy.deepcopy(trainer_config)
-            cfg.dir = cfg.dir or tempfile.mkdtemp()
-            cfg.mesh_axis_names = cfg.mesh_axis_names or ("data", "model")
+            cfg.dir = "NOT_USED"
             cfg.mesh_shape = [len(topology_devices)] + [1] * (len(cfg.mesh_axis_names) - 1)
             topology_devices = np.reshape(topology_devices, cfg.mesh_shape)
-            cfg.max_step = 3
-            for evaler_cfg in cfg.evalers.values():
-                if getattr(evaler_cfg.eval_policy, "fn", None) is eval_every_n_steps_policy:
-                    evaler_cfg.eval_policy.n = 2
-                evaler_cfg.vlog = max(evaler_cfg.vlog or 0, 3)
-            if getattr(cfg.checkpointer.save_policy, "fn", None) is every_n_steps_policy:
-                cfg.checkpointer.save_policy.n = 2
-            logging.info("_test_with_trainer_config: %s", trainer_config)
             trainer: SpmdTrainer = cfg.instantiate(parent=None, devices=topology_devices)
-            with trainer.mesh():
-                # Do not run init(), which require real devices.
-                # trainer_state_specs = jax.eval_shape(trainer.init, jax.random.PRNGKey(1))
-                trainer_state_specs = jax.tree_util.tree_map(
-                    lambda spec: jax.ShapeDtypeStruct(shape=spec.shape, dtype=spec.dtype),
-                    trainer.trainer_state_specs,
-                )
-                input_batch_specs = jax.tree_util.tree_map(
-                    get_shape_dtype_struct,
-                    trainer.input.dataset().element_spec,
-                )
-                trainer._pjit_train_step()
-                compiled_train_step = trainer._jit_train_step.lower(
-                    trainer_state_specs, input_batch_specs
-                ).compile()
+            compiled_train_step = trainer.compile_train_step()
+            self.assertIsNotNone(compiled_train_step)
 
+            # Serialization does not work for CPU devices:
+            #     UNIMPLEMENTED: Not an XLA Runtime executable
+            if compile_topology is not None:
                 serialized_compiled, in_tree, out_tree = serialize(compiled_train_step)
                 with open("/tmp/aot_compiled", "wb") as f:
                     pickle.dump(serialized_compiled, f)
                 print(serialized_compiled)
 
-    def test_gpt_c4(self):
+    def test_fuji_test(self):
         self._test_aot(
             c4_trainer.named_trainer_configs()["fuji-test"](),
-            compile_topology="v4-8",
+            compile_topology=None,
+            # compile_topology="v4-8",
         )
 
 

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -10,11 +10,9 @@ python axlearn/experiments/aot_test.py
 Reference:
 https://docs.google.com/document/d/1Y5IdmvAZA7UtMHAWkRh8k2PscVoG5FvMH9-E6hygsyY/
 """
-import pickle
 from typing import Optional
 
 from absl.testing import absltest
-from jax.experimental.serialize_executable import serialize
 
 from axlearn.common import test_utils
 from axlearn.common.aot_compilation import compile_trainer_programs
@@ -24,9 +22,6 @@ from axlearn.experiments.text.gpt import c4_trainer
 
 class AoTCompilationTest(test_utils.TrainerConfigTestCase):
     """Tests ahead-of-time (AoT) compilation."""
-
-    def _jax_backend(self) -> str:
-        return "cpu"
 
     def _test_aot(
         self,
@@ -43,7 +38,7 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
         compiled_train_step = programs["train_step"]
         self.assertIsNotNone(compiled_train_step)
 
-    def test_fuji_7B(self):
+    def test_fuji_7b(self):
         self._test_aot(
             c4_trainer.named_trainer_configs()["fuji-7B"](),
             compile_topology=None,

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -103,6 +103,7 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
             logging.info("_test_with_trainer_config: %s", trainer_config)
             trainer: SpmdTrainer = cfg.instantiate(parent=None, devices=topology_devices)
             # trainer.init(jax.random.PRNGKey(1))
+            trainer._pjit_train_step()
             input_batch_spec = trainer.input.dataset().element_spec
             compiled_train_step = trainer._jit_train_step.lower(
                 trainer.trainer_state, input_batch_spec

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -63,7 +63,6 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
         self._test_aot(
             c4_trainer.named_trainer_configs()["fuji-7B"](),
             compile_topology=None,
-            # compile_topology="v4-8",
         )
 
 

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -10,65 +10,16 @@ python axlearn/experiments/aot_test.py
 Reference:
 https://docs.google.com/document/d/1Y5IdmvAZA7UtMHAWkRh8k2PscVoG5FvMH9-E6hygsyY/
 """
-import os
 import pickle
-
-import numpy as np
-
-os.environ["JAX_PLATFORMS"] = "cpu"
-
-import copy
 from typing import Optional
 
-import jax
-
-jax.config.update("jax_platforms", "cpu")
-from dataclasses import dataclass
-
-import jax.random
-from jax import numpy as jnp
 from absl.testing import absltest
-from jax.experimental.topologies import get_topology_desc
 from jax.experimental.serialize_executable import serialize
-import tensorflow as tf
 
 from axlearn.common import test_utils
+from axlearn.common.aot_compilation import compile_trainer_programs
 from axlearn.common.trainer import SpmdTrainer
-from axlearn.common.utils import set_data_dir
 from axlearn.experiments.text.gpt import c4_trainer
-
-
-@dataclass
-class SystemCharacteristics:
-    platform: str
-    topology_name: str
-    chip_config_name: str  # 'megacore' or 'default'
-    chips_per_host_bounds: tuple
-    devices_per_slice: int
-
-
-UserFacingNameToSystemCharacteristics = {
-    "v5e-16": SystemCharacteristics("tpu", "v5e:4x4", "default", (2, 2, 1), 16),
-    "v5e-32": SystemCharacteristics("tpu", "v5e:4x8", "default", (2, 2, 1), 32),
-    "v5e-64": SystemCharacteristics("tpu", "v5e:8x8", "default", (2, 2, 1), 64),
-    "v5e-128": SystemCharacteristics("tpu", "v5e:8x16", "default", (2, 2, 1), 128),
-    "v5e-256": SystemCharacteristics("tpu", "v5e:16x16", "default", (2, 2, 1), 256),
-    "v4-8": SystemCharacteristics("tpu", "v4:2x2x1", "megacore", (2, 2, 1), 4),
-    "v4-16": SystemCharacteristics("tpu", "v4:2x2x2", "megacore", (2, 2, 1), 8),
-    "v4-32": SystemCharacteristics("tpu", "v4:2x2x4", "megacore", (2, 2, 1), 16),
-    "v4-64": SystemCharacteristics("tpu", "v4:2x4x4", "megacore", (2, 2, 1), 32),
-    "v4-128": SystemCharacteristics("tpu", "v4:4x4x4", "megacore", (2, 2, 1), 64),
-    "v4-256": SystemCharacteristics("tpu", "v4:4x4x8", "megacore", (2, 2, 1), 128),
-    "v4-512": SystemCharacteristics("tpu", "v4:4x8x8", "megacore", (2, 2, 1), 256),
-    "v4-1024": SystemCharacteristics("tpu", "v4:8x8x8", "megacore", (2, 2, 1), 512),
-    "v4-1536": SystemCharacteristics("tpu", "v4:8x8x12", "megacore", (2, 2, 1), 768),
-    "v4-2048": SystemCharacteristics("tpu", "v4:8x8x16", "megacore", (2, 2, 1), 1024),
-    "v4-4096": SystemCharacteristics("tpu", "v4:8x16x16", "megacore", (2, 2, 1), 2048),
-}
-
-
-def get_system_characteristics(user_facing_name):
-    return UserFacingNameToSystemCharacteristics.get(user_facing_name)
 
 
 class AoTCompilationTest(test_utils.TrainerConfigTestCase):
@@ -84,38 +35,33 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
         compile_topology: Optional[str],
         compile_topology_num_slices: int = 1,
     ):
+        programs = compile_trainer_programs(
+            trainer_config,
+            topology=compile_topology,
+            topology_num_slices=compile_topology_num_slices,
+        )
+        compiled_train_step = programs["train_step"]
+        self.assertIsNotNone(compiled_train_step)
+        print("== Help ==")
+        print(help(compiled_train_step))
+        print("== Text ==")
+        print(compiled_train_step.as_text())
+        print("== Cost analysis ==")
+        print(compiled_train_step.cost_analysis())
+        print("== Memeory analysis ==")
+        print(compiled_train_step.memory_analysis())
+
+        # Serialization does not work for CPU devices:
+        #     UNIMPLEMENTED: Not an XLA Runtime executable
         if compile_topology is not None:
-            target_hardware = get_system_characteristics(compile_topology)
-            topology_devices = get_topology_desc(
-                platform=target_hardware.platform,
-                topology_name=target_hardware.topology_name,
-                chip_config_name=target_hardware.chip_config_name,
-                chips_per_host_bounds=target_hardware.chips_per_host_bounds,
-                num_slices=compile_topology_num_slices,
-            ).devices
-        else:
-            topology_devices = jax.devices(self._jax_backend())
+            serialized_compiled, in_tree, out_tree = serialize(compiled_train_step)
+            with open("/tmp/aot_compiled", "wb") as f:
+                pickle.dump(serialized_compiled, f)
+            print(serialized_compiled)
 
-        with jax.checking_leaks(), set_data_dir("FAKE"):
-            cfg = copy.deepcopy(trainer_config)
-            cfg.dir = "NOT_USED"
-            cfg.mesh_shape = [len(topology_devices)] + [1] * (len(cfg.mesh_axis_names) - 1)
-            topology_devices = np.reshape(topology_devices, cfg.mesh_shape)
-            trainer: SpmdTrainer = cfg.instantiate(parent=None, devices=topology_devices)
-            compiled_train_step = trainer.compile_train_step()
-            self.assertIsNotNone(compiled_train_step)
-
-            # Serialization does not work for CPU devices:
-            #     UNIMPLEMENTED: Not an XLA Runtime executable
-            if compile_topology is not None:
-                serialized_compiled, in_tree, out_tree = serialize(compiled_train_step)
-                with open("/tmp/aot_compiled", "wb") as f:
-                    pickle.dump(serialized_compiled, f)
-                print(serialized_compiled)
-
-    def test_fuji_test(self):
+    def test_fuji_7B(self):
         self._test_aot(
-            c4_trainer.named_trainer_configs()["fuji-test"](),
+            c4_trainer.named_trainer_configs()["fuji-7B"](),
             compile_topology=None,
             # compile_topology="v4-8",
         )

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -6,6 +6,7 @@ Reference:
 https://docs.google.com/document/d/1Y5IdmvAZA7UtMHAWkRh8k2PscVoG5FvMH9-E6hygsyY/
 """
 import os
+import pickle
 
 import numpy as np
 
@@ -135,7 +136,15 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
                 compiled_train_step = trainer._jit_train_step.lower(
                     trainer_state_specs, input_batch_specs
                 ).compile()
-                print(compiled_train_step)
+
+                (
+                    serialized_compiled,
+                    in_tree,
+                    out_tree,
+                ) = jax.experimental.serialize_executable.serialze(compiled_train_step)
+                with open("/tmp/aot_compiled", "wb") as f:
+                    pickle.dump(serialized_compiled, f)
+                print(serialized_compiled)
 
     def test_gpt_c4(self):
         self._test_aot(

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -103,7 +103,7 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
             logging.info("_test_with_trainer_config: %s", trainer_config)
             trainer: SpmdTrainer = cfg.instantiate(parent=None, devices=topology_devices)
             # trainer.init(jax.random.PRNGKey(1))
-            input_batch_spec = self.input.dataset().element_spec
+            input_batch_spec = trainer.input.dataset().element_spec
             compiled_train_step = trainer._jit_train_step.lower(
                 trainer.trainer_state, input_batch_spec
             ).compile()

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -6,6 +6,8 @@ E             RuntimeError: Unable to initialize backend 'tpu': INTERNAL: Failed
 """
 import os
 
+import numpy as np
+
 os.environ["JAX_PLATFORMS"] = "cpu"
 
 import copy
@@ -90,6 +92,7 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
             cfg.dir = cfg.dir or tempfile.mkdtemp()
             cfg.mesh_axis_names = cfg.mesh_axis_names or ("data", "model")
             cfg.mesh_shape = cfg.mesh_shape or (len(jax.devices()), 1)
+            topology_devices = np.reshape(topology_devices, cfg.mesh_shape)
             cfg.max_step = 3
             for evaler_cfg in cfg.evalers.values():
                 if getattr(evaler_cfg.eval_policy, "fn", None) is eval_every_n_steps_policy:

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -25,7 +25,7 @@ from axlearn.experiments.text.gpt import c4_trainer
 class AoTCompilationTest(test_utils.TrainerConfigTestCase):
     """Tests ahead-of-time (AoT) compilation."""
 
-    def _jax_backend(self) -> Optional[str]:
+    def _jax_backend(self) -> str:
         return "cpu"
 
     def _test_aot(
@@ -42,22 +42,6 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
         )
         compiled_train_step = programs["train_step"]
         self.assertIsNotNone(compiled_train_step)
-        print("== Help ==")
-        print(help(compiled_train_step))
-        print("== Text ==")
-        print(compiled_train_step.as_text())
-        print("== Cost analysis ==")
-        print(compiled_train_step.cost_analysis())
-        print("== Memeory analysis ==")
-        print(compiled_train_step.memory_analysis())
-
-        # Serialization does not work for CPU devices:
-        #     UNIMPLEMENTED: Not an XLA Runtime executable
-        if compile_topology is not None:
-            serialized_compiled, in_tree, out_tree = serialize(compiled_train_step)
-            with open("/tmp/aot_compiled", "wb") as f:
-                pickle.dump(serialized_compiled, f)
-            print(serialized_compiled)
 
     def test_fuji_7B(self):
         self._test_aot(

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -4,6 +4,7 @@
 
 pip install 'jax[tpu]==0.4.21' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 
+export TPU_SKIP_MDS_QUERY=1
 python axlearn/experiments/aot_test.py
 
 Reference:

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -1,0 +1,112 @@
+# Copyright © 2023 Apple Inc.
+
+"""AoT (ahead-of-time) compilation config tests.
+
+E             RuntimeError: Unable to initialize backend 'tpu': INTERNAL: Failed to open /Users/rpang/miniforge3/envs/axlearn/lib/python3.9/site-packages/libtpu/libtpu.so: dlopen(/Users/rpang/miniforge3/envs/axlearn/lib/python3.9/site-packages/libtpu/libtpu.so, 0x0001): tried: '/Users/rpang/miniforge3/envs/axlearn/lib/python3.9/site-packages/libtpu/libtpu.so' (not a mach-o file), '/System/Volumes/Preboot/Cryptexes/OS/Users/rpang/miniforge3/envs/axlearn/lib/python3.9/site-packages/libtpu/libtpu.so' (no such file), '/Users/rpang/miniforge3/envs/axlearn/lib/python3.9/site-packages/libtpu/libtpu.so' (not a mach-o file) (set JAX_PLATFORMS='' to automatically choose an available backend)
+"""
+import os
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+
+import copy
+import tempfile
+from typing import Optional
+
+import jax
+
+jax.config.update("jax_platforms", "cpu")
+from dataclasses import dataclass
+
+import jax.random
+from absl import logging
+from jax.experimental.topologies import get_topology_desc
+
+from axlearn.common import test_utils
+from axlearn.common.checkpointer import every_n_steps_policy
+from axlearn.common.evaler import every_n_steps_policy as eval_every_n_steps_policy
+from axlearn.common.trainer import SpmdTrainer
+from axlearn.common.utils import set_data_dir
+from axlearn.experiments.text.gpt import c4_trainer
+
+
+@dataclass
+class SystemCharacteristics:
+    platform: str
+    topology_name: str
+    chip_config_name: str  # 'megacore' or 'default'
+    chips_per_host_bounds: tuple
+    devices_per_slice: int
+
+
+UserFacingNameToSystemCharacteristics = {
+    "v5e-16": SystemCharacteristics("tpu", "v5e:4x4", "default", (2, 2, 1), 16),
+    "v5e-32": SystemCharacteristics("tpu", "v5e:4x8", "default", (2, 2, 1), 32),
+    "v5e-64": SystemCharacteristics("tpu", "v5e:8x8", "default", (2, 2, 1), 64),
+    "v5e-128": SystemCharacteristics("tpu", "v5e:8x16", "default", (2, 2, 1), 128),
+    "v5e-256": SystemCharacteristics("tpu", "v5e:16x16", "default", (2, 2, 1), 256),
+    "v4-8": SystemCharacteristics("tpu", "v4:2x2x1", "megacore", (2, 2, 1), 4),
+    "v4-16": SystemCharacteristics("tpu", "v4:2x2x2", "megacore", (2, 2, 1), 8),
+    "v4-32": SystemCharacteristics("tpu", "v4:2x2x4", "megacore", (2, 2, 1), 16),
+    "v4-64": SystemCharacteristics("tpu", "v4:2x4x4", "megacore", (2, 2, 1), 32),
+    "v4-128": SystemCharacteristics("tpu", "v4:4x4x4", "megacore", (2, 2, 1), 64),
+    "v4-256": SystemCharacteristics("tpu", "v4:4x4x8", "megacore", (2, 2, 1), 128),
+    "v4-512": SystemCharacteristics("tpu", "v4:4x8x8", "megacore", (2, 2, 1), 256),
+    "v4-1024": SystemCharacteristics("tpu", "v4:8x8x8", "megacore", (2, 2, 1), 512),
+    "v4-1536": SystemCharacteristics("tpu", "v4:8x8x12", "megacore", (2, 2, 1), 768),
+    "v4-2048": SystemCharacteristics("tpu", "v4:8x8x16", "megacore", (2, 2, 1), 1024),
+    "v4-4096": SystemCharacteristics("tpu", "v4:8x16x16", "megacore", (2, 2, 1), 2048),
+}
+
+
+def get_system_characteristics(user_facing_name):
+    return UserFacingNameToSystemCharacteristics.get(user_facing_name)
+
+
+class AoTCompilationTest(test_utils.TrainerConfigTestCase):
+    """Tests ahead-of-time (AoT) compilation."""
+
+    def _jax_backend(self) -> Optional[str]:
+        return "cpu"
+
+    def _test_aot(
+        self,
+        trainer_config: SpmdTrainer.Config,
+        *,
+        compile_topology: str,
+        compile_topology_num_slices: int = 1,
+    ):
+        target_hardware = get_system_characteristics(compile_topology)
+        topology_devices = get_topology_desc(
+            platform=target_hardware.platform,
+            topology_name=target_hardware.topology_name,
+            chip_config_name=target_hardware.chip_config_name,
+            chips_per_host_bounds=target_hardware.chips_per_host_bounds,
+            num_slices=compile_topology_num_slices,
+        ).devices
+
+        with jax.checking_leaks(), set_data_dir("FAKE"):
+            cfg = copy.deepcopy(trainer_config)
+            cfg.dir = cfg.dir or tempfile.mkdtemp()
+            cfg.mesh_axis_names = cfg.mesh_axis_names or ("data", "model")
+            cfg.mesh_shape = cfg.mesh_shape or (len(jax.devices()), 1)
+            cfg.max_step = 3
+            for evaler_cfg in cfg.evalers.values():
+                if getattr(evaler_cfg.eval_policy, "fn", None) is eval_every_n_steps_policy:
+                    evaler_cfg.eval_policy.n = 2
+                evaler_cfg.vlog = max(evaler_cfg.vlog or 0, 3)
+            if getattr(cfg.checkpointer.save_policy, "fn", None) is every_n_steps_policy:
+                cfg.checkpointer.save_policy.n = 2
+            logging.info("_test_with_trainer_config: %s", trainer_config)
+            trainer: SpmdTrainer = cfg.instantiate(parent=None, devices=topology_devices)
+            trainer.init(jax.random.PRNGKey(1))
+            input_batch_spec = self.input.dataset().element_spec
+            compiled_train_step = trainer._jit_train_step.lower(
+                trainer.trainer_state, input_batch_spec
+            ).compile()
+            print(compiled_train_step)
+
+    def test_gpt_c4(self):
+        self._test_aot(
+            c4_trainer.named_trainer_configs()["fuji-test"](),
+            compile_topology="v4-8",
+        )

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -30,6 +30,7 @@ from jax import numpy as jnp
 from absl import logging
 from absl.testing import absltest
 from jax.experimental.topologies import get_topology_desc
+from jax.experimental.serialize_executable import serialize
 import tensorflow as tf
 
 from axlearn.common import test_utils
@@ -141,11 +142,7 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
                     trainer_state_specs, input_batch_specs
                 ).compile()
 
-                (
-                    serialized_compiled,
-                    in_tree,
-                    out_tree,
-                ) = jax.experimental.serialize_executable.serialze(compiled_train_step)
+                serialized_compiled, in_tree, out_tree = serialize(compiled_train_step)
                 with open("/tmp/aot_compiled", "wb") as f:
                     pickle.dump(serialized_compiled, f)
                 print(serialized_compiled)

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -91,7 +91,7 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
             cfg = copy.deepcopy(trainer_config)
             cfg.dir = cfg.dir or tempfile.mkdtemp()
             cfg.mesh_axis_names = cfg.mesh_axis_names or ("data", "model")
-            cfg.mesh_shape = cfg.mesh_shape or (len(jax.devices()), 1)
+            cfg.mesh_shape = [len(topology_devices)] + [1] * (len(cfg.mesh_axis_names) - 1)
             topology_devices = np.reshape(topology_devices, cfg.mesh_shape)
             cfg.max_step = 3
             for evaler_cfg in cfg.evalers.values():

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -102,7 +102,7 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
                 cfg.checkpointer.save_policy.n = 2
             logging.info("_test_with_trainer_config: %s", trainer_config)
             trainer: SpmdTrainer = cfg.instantiate(parent=None, devices=topology_devices)
-            trainer.init(jax.random.PRNGKey(1))
+            # trainer.init(jax.random.PRNGKey(1))
             input_batch_spec = self.input.dataset().element_spec
             compiled_train_step = trainer._jit_train_step.lower(
                 trainer.trainer_state, input_batch_spec

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -2,6 +2,10 @@
 
 """AoT (ahead-of-time) compilation config tests.
 
+pip install 'jax[tpu]==0.4.21' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+
+python axlearn/experiments/aot_test.py
+
 Reference:
 https://docs.google.com/document/d/1Y5IdmvAZA7UtMHAWkRh8k2PscVoG5FvMH9-E6hygsyY/
 """

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 
 import jax.random
 from absl import logging
+from absl.testing import absltest
 from jax.experimental.topologies import get_topology_desc
 
 from axlearn.common import test_utils
@@ -110,3 +111,7 @@ class AoTCompilationTest(test_utils.TrainerConfigTestCase):
             c4_trainer.named_trainer_configs()["fuji-test"](),
             compile_topology="v4-8",
         )
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -8,7 +8,7 @@ XLA_FLAGS=--xla_dump_to=/tmp/aot_xla_dump \
 python axlearn/experiments/run_aot_compilation.py \
     --module=text.gpt.c4_trainer \
     --config=fuji-7B \
-    --topology=v4-1024 1>/tmp/aot_stdout 2| tee /tmp/aot_stderr
+    --topology=v4-1024 1> /tmp/aot_stdout
 
 Reference: https://jax.readthedocs.io/en/latest/aot.html
 """

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -3,6 +3,8 @@
 """A command-line tool to perform AoT (ahead-of-time) compilation.
 
 pip install 'jax[tpu]==0.4.21' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+
+XLA_FLAGS=--xla_dump_to=/tmp/aot_xla_dump \
 python axlearn/experiments/run_aot_compilation.py \
     --module=text.gpt.c4_trainer \
     --config=fuji-7B \

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -5,7 +5,7 @@ pip install 'jax[tpu]==0.4.21' -f https://storage.googleapis.com/jax-releases/li
 python axlearn/experiments/run_aot_compilation.py \
     --config_module=text.gpt.c4_trainer \
     --config=fuji-7B \
-    --topology=v4-8
+    --topology=v4-512
 
 Reference:
 https://docs.google.com/document/d/1Y5IdmvAZA7UtMHAWkRh8k2PscVoG5FvMH9-E6hygsyY/

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -1,0 +1,78 @@
+# Copyright © 2023 Apple Inc.
+"""A command-line tool to perform AoT (ahead-of-time) compilation.
+
+pip install 'jax[tpu]==0.4.21' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+python axlearn/experiments/run_aot_compilation.py \
+    --config_module=text.gpt.c4_trainer \
+    --config=fuji-7B \
+    --topology=v4-8
+
+Reference:
+https://docs.google.com/document/d/1Y5IdmvAZA7UtMHAWkRh8k2PscVoG5FvMH9-E6hygsyY/
+"""
+
+import pickle
+from typing import Optional
+
+from absl import flags, app
+from jax.experimental.serialize_executable import serialize
+
+from axlearn.common.aot_compilation import compile_trainer_programs
+from axlearn.common.trainer import SpmdTrainer
+from axlearn.common.utils import set_data_dir
+from axlearn.common.utils_spmd import setup
+from axlearn.experiments import TrainerConfigFn, get_named_trainer_config
+
+
+flags.DEFINE_string("config_module", None, "The TPU topology.")
+flags.DEFINE_string("config", None, "The TPU topology.")
+flags.DEFINE_string("topology", None, "The TPU topology.")
+flags.DEFINE_integer("topology_num_slices", 1, "The number of TPU slices.")
+
+FLAGS = flags.FLAGS
+
+
+def _compile_and_dump_programs(
+    trainer_config: SpmdTrainer.Config,
+    *,
+    compile_topology: Optional[str],
+    compile_topology_num_slices: int = 1,
+):
+    with set_data_dir("FAKE"):
+        programs = compile_trainer_programs(
+            trainer_config,
+            topology=compile_topology,
+            topology_num_slices=compile_topology_num_slices,
+        )
+    for program_name, program in programs.items():
+        print(f"== Text: {program_name} ==")
+        print(program.as_text())
+        print(f"== Cost analysis {program_name} ==")
+        print(program.cost_analysis())
+        print(f"== Memeory analysis {program_name} ==")
+        print(program.memory_analysis())
+
+        # Serialization does not work for CPU devices:
+        #     UNIMPLEMENTED: Not an XLA Runtime executable
+        if compile_topology is not None:
+            serialized_compiled, in_tree, out_tree = serialize(program)
+            with open("/tmp/aot_compiled", "wb") as f:
+                pickle.dump(serialized_compiled, f)
+                print(serialized_compiled)
+
+def main(argv):
+    setup(jax_backend="cpu")
+    trainer_config_fn: TrainerConfigFn = get_named_trainer_config(
+        FLAGS.config,
+        config_module=FLAGS.config_module,
+        root_module="axlearn",
+    )
+    _compile_and_dump_programs(
+        trainer_config_fn(),
+        compile_topology = FLAGS.topology,
+        compile_topology_num_slices = FLAGS.topology_num_slices,
+    )
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -10,8 +10,7 @@ python axlearn/experiments/run_aot_compilation.py \
     --config=fuji-7B \
     --topology=v4-1024 1> /tmp/aot_stdout 2| tee /tmp/aot_stderr
 
-Reference:
-https://docs.google.com/document/d/1Y5IdmvAZA7UtMHAWkRh8k2PscVoG5FvMH9-E6hygsyY/
+Reference: https://jax.readthedocs.io/en/latest/aot.html
 """
 
 import pickle

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -5,7 +5,7 @@ pip install 'jax[tpu]==0.4.21' -f https://storage.googleapis.com/jax-releases/li
 python axlearn/experiments/run_aot_compilation.py \
     --config_module=text.gpt.c4_trainer \
     --config=fuji-7B \
-    --topology=v4-512
+    --topology=v4-1024 1> /tmp/aot_stdout 2| tee /tmp/aot_stderr
 
 Reference:
 https://docs.google.com/document/d/1Y5IdmvAZA7UtMHAWkRh8k2PscVoG5FvMH9-E6hygsyY/

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -25,8 +25,8 @@ from axlearn.common.utils import set_data_dir
 from axlearn.common.utils_spmd import setup
 from axlearn.experiments import TrainerConfigFn, get_named_trainer_config
 
-flags.DEFINE_string("module", None, "The trainer config module.")
-flags.DEFINE_string("config", None, "The trainer config name.")
+flags.DEFINE_string("module", None, "The trainer config module.", required=True)
+flags.DEFINE_string("config", None, "The trainer config name.", required=True)
 flags.DEFINE_string("topology", None, "The TPU topology.")
 flags.DEFINE_integer("topology_num_slices", 1, "The number of TPU slices.")
 
@@ -51,18 +51,16 @@ def _compile_and_dump_programs(
         print(f"== Cost analysis {program_name} ==")
         print(program.cost_analysis())
         print(f"== Memeory analysis {program_name} ==")
-        print(help(program.memory_analysis()))
+        print(program.memory_analysis())
 
         # Serialization does not work for CPU devices:
         #     UNIMPLEMENTED: Not an XLA Runtime executable
         if compile_topology is not None:
             serialized_compiled, _, _ = serialize(program)
-            serialized_compiled_output_path = "/tmp/aot_compiled"
+            serialized_compiled_output_path = f"/tmp/aot_compiled_{program_name}"
             with open(serialized_compiled_output_path, "wb") as f:
                 pickle.dump(serialized_compiled, f)
-            logging.info(
-                "Written serialized %s to %s", program_name, serialized_compiled_output_path
-            )
+            logging.info("Wrote serialized %s to %s", program_name, serialized_compiled_output_path)
 
 
 def main(_):

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -57,13 +57,13 @@ def _compile_and_dump_programs(
         # Serialization does not work for CPU devices:
         #     UNIMPLEMENTED: Not an XLA Runtime executable
         if compile_topology is not None:
-            serialized_compiled, in_tree, out_tree = serialize(program)
+            serialized_compiled, _, _ = serialize(program)
             with open("/tmp/aot_compiled", "wb") as f:
                 pickle.dump(serialized_compiled, f)
                 print(serialized_compiled)
 
 
-def main(argv):
+def main(_):
     setup(jax_backend="cpu")
     trainer_config_fn: TrainerConfigFn = get_named_trainer_config(
         FLAGS.config,


### PR DESCRIPTION
This allows one to iterate on XLA compilation without creating a TPU slice.

Example usage (on an x86 machine, does not work on Apple silicon yet):

```
pip install 'jax[tpu]==0.4.21' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
python axlearn/experiments/run_aot_compilation.py \
    --config_module=text.gpt.c4_trainer \
    --config=fuji-7B \
    --topology=v4-1024 1> /tmp/aot_stdout 2| tee /tmp/aot_stderr
```

The same command with `--topology=v4-512` will report HBM OOM errors.