### PR TITLE
Add platform to DockerBundler with linux/amd64 as default.

### DIFF
--- a/axlearn/cloud/common/bundler.py
+++ b/axlearn/cloud/common/bundler.py
@@ -47,7 +47,7 @@ from axlearn.common.config import REQUIRED, Configurable, Required, config_class
 
 BUNDLE_EXCLUDE = ["venv", ".git", ".idea", ".cache", ".pytest_cache", ".pytype", "__pycache__"]
 FLAGS = flags.FLAGS
-DEFAULT_DOCKER_PLATFORM = "linux/amd64"
+_DEFAULT_DOCKER_PLATFORM = "linux/amd64"
 
 
 class Bundler(Configurable):
@@ -201,7 +201,7 @@ class BaseDockerBundler(Bundler):
         # Build target platform.
         # Usually the image is to be run on the cloud on x86 machines, so
         # "linux/amd64" is the default even on arm64 machines like Apple Silicon.
-        platform: str = DEFAULT_DOCKER_PLATFORM
+        platform: str = _DEFAULT_DOCKER_PLATFORM
 
     def __init__(self, cfg: Config):
         super().__init__(cfg)

--- a/axlearn/cloud/common/bundler_test.py
+++ b/axlearn/cloud/common/bundler_test.py
@@ -14,7 +14,7 @@ from absl.testing import parameterized
 
 from axlearn.cloud.common import bundler
 from axlearn.cloud.common.bundler import (
-    DEFAULT_DOCKER_PLATFORM,
+    _DEFAULT_DOCKER_PLATFORM,
     BaseTarBundler,
     Bundler,
     DockerBundler,
@@ -176,7 +176,7 @@ class DockerBundlerTest(TestWithTemporaryCWD):
 
         def build_and_push(*, args, **kwargs):
             self.assertTrue(all(isinstance(x, str) for x in args.values()))
-            self.assertEqual(kwargs["platform"], DEFAULT_DOCKER_PLATFORM)
+            self.assertEqual(kwargs["platform"], _DEFAULT_DOCKER_PLATFORM)
 
         with _fake_dockerfile() as dockerfile:
             b = (

--- a/axlearn/cloud/common/bundler_test.py
+++ b/axlearn/cloud/common/bundler_test.py
@@ -13,7 +13,13 @@ import toml
 from absl.testing import parameterized
 
 from axlearn.cloud.common import bundler
-from axlearn.cloud.common.bundler import BaseTarBundler, Bundler, DockerBundler, get_bundler_config
+from axlearn.cloud.common.bundler import (
+    DEFAULT_DOCKER_PLATFORM,
+    BaseTarBundler,
+    Bundler,
+    DockerBundler,
+    get_bundler_config,
+)
 from axlearn.cloud.common.config import CONFIG_DIR, CONFIG_FILE, DEFAULT_CONFIG_FILE
 from axlearn.cloud.common.config_test import create_default_config
 from axlearn.common.test_utils import TestCase, TestWithTemporaryCWD
@@ -169,8 +175,8 @@ class DockerBundlerTest(TestWithTemporaryCWD):
         build_args = dict(a="a,b", b=("a", "b"), c=["a", "b"])
 
         def build_and_push(*, args, **kwargs):
-            del kwargs
             self.assertTrue(all(isinstance(x, str) for x in args.values()))
+            self.assertEqual(kwargs["platform"], DEFAULT_DOCKER_PLATFORM)
 
         with _fake_dockerfile() as dockerfile:
             b = (

--- a/axlearn/cloud/common/docker.py
+++ b/axlearn/cloud/common/docker.py
@@ -21,6 +21,7 @@ def build(
     args: Optional[Dict[str, str]] = None,
     target: Optional[str] = None,
     labels: Optional[Dict[str, str]] = None,
+    platform: Optional[str] = None,
 ) -> str:
     """Builds a Dockerfile.
 
@@ -32,6 +33,8 @@ def build(
         target: Optional build target.
             https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target
         labels: Optional image labels. Can be viewed with `docker inspect`.
+        platform: Optional target platform for the build output.
+            https://docs.docker.com/build/building/multi-platform/
 
     Returns:
         The image name.
@@ -47,6 +50,8 @@ def build(
         cli_args.extend(["--label", f"{k.strip()}={v.strip()}"])
     if target:
         cli_args.extend(["--target", target])
+    if platform:
+        cli_args.extend(["--platform", platform])
     cli_args.append(context)
 
     # Execute command.


### PR DESCRIPTION
Update default platform to `linux/amd64` for docker builds regardless of host OS / architecture.