### PR TITLE
CTC loss is only valid when input_length >= output_length + num_of_consecutive duplications in label sequence

### DIFF
--- a/axlearn/audio/asr_decoder.py
+++ b/axlearn/audio/asr_decoder.py
@@ -40,21 +40,21 @@ def _is_valid_ctc_seq(
     considered as an invalid sequence and the loss should be ignored.
 
     A validity check is passed if for an example when:
-      input.length >= labels.length + num(consecutive dup label tokens)
+        input.length >= labels.length + num(consecutive dup label tokens)
 
     Args:
-      paddings: A 0/1 tensor of shape [batch_size, num_frames], indicating whether
-        an input frame is a padding.
-      target_labels: A int32 tensor of shape [batch_size, num_frames].
-      target_paddings: A 0/1 tensor of shape [batch_size, num_frames], indicating
-        whether a label is a padding. Note that at the moment, `target_paddings`
-        must be left-justified, i.e., it must starts with 0 and followed by 1, and
-        not transition back to 0.
-        TODO(yqw): support generic target_paddings.
+        paddings: A 0/1 tensor of shape [batch_size, num_frames], indicating whether
+            an input frame is a padding.
+        target_labels: A int32 tensor of shape [batch_size, num_frames].
+        target_paddings: A 0/1 tensor of shape [batch_size, num_frames], indicating
+            whether a label is a padding. Note that at the moment, `target_paddings`
+            must be left-justified, i.e., it must starts with 0 and followed by 1, and
+            not transition back to 0.
+            TODO(yqw): support generic target_paddings.
 
     Returns:
-      A float tensor of [batch_size, ] indicating if each (input, label) pair is valid,
-      with a value of 1.0 indicating valid and 0.0 otherwise.
+        A float tensor of [batch_size, ] indicating if each (input, label) pair is valid,
+        with a value of 1.0 indicating valid and 0.0 otherwise.
     """
     # [batch_size, ]
     label_lengths = jnp.sum(1.0 - target_paddings, axis=-1)

--- a/axlearn/audio/asr_decoder.py
+++ b/axlearn/audio/asr_decoder.py
@@ -47,7 +47,10 @@ def _is_valid_ctc_seq(
         an input frame is a padding.
       target_labels: A int32 tensor of shape [batch_size, num_frames].
       target_paddings: A 0/1 tensor of shape [batch_size, num_frames], indicating
-        whether a label is a padding.
+        whether a label is a padding. Note that at the moment, `target_paddings`
+        must be left-justified, i.e., it must starts with 0 and followed by 1, and
+        not transition back to 0.
+        TODO(yqw): support generic target_paddings.
 
     Returns:
       A float tensor of [batch_size, ] indicating if each (input, label) pair is valid,

--- a/axlearn/audio/asr_decoder.py
+++ b/axlearn/audio/asr_decoder.py
@@ -29,37 +29,36 @@ from axlearn.common.utils import Nested, Tensor
 
 
 def is_valid_ctc_seq(logitpaddings, labels, labelpaddings):
-  """Returns for per example sequence if it passes validity check.
+    """Returns for per example sequence if it passes validity check.
 
-  Note that the above `ctc_loss_with_alignments` returns logeps
-  (usually a very large number) if the input length is smaller than
-  the label length plus number of consectutive duplications.
-  However, in that case, we should ignore the loss.
+    Note that the above `ctc_loss_with_alignments` returns logeps
+    (usually a very large number) if the input length is smaller than
+    the label length plus number of consectutive duplications.
+    However, in that case, we should ignore the loss.
 
-  A validity check is passed if for an example when :
-    input.length >= labels.length + num(consecutive dup label tokens)
+    A validity check is passed if for an example when :
+      input.length >= labels.length + num(consecutive dup label tokens)
 
-  Args:
-    logitpaddings:  [b, t], 0/1 JTensor.
-    labels:         [b, t], int32 JTensor.
-    labelpaddings:  [b, t], 0/1 JTensor.
-  Returns:
-    A shape [b] float tensor indicating if each (input, label) pair is valid,
-      with a value of 1.0 indicating valid and 0.0 otherwise.
-  """
-  # [b]
-  label_lengths = jnp.sum(1.0 - labelpaddings, axis=-1)
-  # [b]
-  input_lengths = jnp.sum(1.0 - logitpaddings, axis=-1)
-  # [b, t-1]
-  dups = (1.0 - labelpaddings[:, 1:]) * (labels[:, :-1] == labels[:, 1:])
-  # [b]
-  num_consecutive_dups = jnp.sum(dups, axis=-1)
-  # [b]
-  is_valid = (label_lengths + num_consecutive_dups) <= input_lengths
-  is_valid = is_valid.astype(jnp.float32)
-  return is_valid
-
+    Args:
+      logitpaddings:  [b, t], 0/1 JTensor.
+      labels:         [b, t], int32 JTensor.
+      labelpaddings:  [b, t], 0/1 JTensor.
+    Returns:
+      A shape [b] float tensor indicating if each (input, label) pair is valid,
+        with a value of 1.0 indicating valid and 0.0 otherwise.
+    """
+    # [b]
+    label_lengths = jnp.sum(1.0 - labelpaddings, axis=-1)
+    # [b]
+    input_lengths = jnp.sum(1.0 - logitpaddings, axis=-1)
+    # [b, t-1]
+    dups = (1.0 - labelpaddings[:, 1:]) * (labels[:, :-1] == labels[:, 1:])
+    # [b]
+    num_consecutive_dups = jnp.sum(dups, axis=-1)
+    # [b]
+    is_valid = (label_lengths + num_consecutive_dups) <= input_lengths
+    is_valid = is_valid.astype(jnp.float32)
+    return is_valid
 
 
 class CTCPrefixMerger(PrefixMerger):

--- a/axlearn/audio/asr_decoder.py
+++ b/axlearn/audio/asr_decoder.py
@@ -31,7 +31,7 @@ from axlearn.common.utils import Nested, Tensor
 def _is_valid_ctc_seq(
     *, paddings: Tensor, target_labels: Tensor, target_paddings: Tensor
 ) -> Tensor:
-    """Returns for per example sequence if it passes validity check.
+    """Returns whether each input sequence passes validity check.
 
     Note that `optax.ctc_loss` returns -logeps (default to 1e5) if the
     input length is smaller than the label length plus number of

--- a/axlearn/audio/asr_decoder.py
+++ b/axlearn/audio/asr_decoder.py
@@ -28,15 +28,12 @@ from axlearn.common.module import Module
 from axlearn.common.utils import Nested, Tensor
 
 
-def _is_valid_ctc_seq(
-        paddings: Tensor,
-        target_labels: Tensor,
-        target_paddings: Tensor) -> Tensor:
+def _is_valid_ctc_seq(paddings: Tensor, target_labels: Tensor, target_paddings: Tensor) -> Tensor:
     """Returns for per example sequence if it passes validity check.
 
-    Note that `optax.ctc_loss` returns logeps (default to 1e5) if the
-    input length is smaller than the label length plus number of 
-    consectutive duplications. However, in that case, we should 
+    Note that `optax.ctc_loss` returns -logeps (default to 1e5) if the
+    input length is smaller than the label length plus number of
+    consectutive duplications. However, in that case, we should
     ignore the loss.
 
     A validity check is passed if for an example when :
@@ -61,7 +58,6 @@ def _is_valid_ctc_seq(
     num_consecutive_dups = jnp.sum(dups, axis=-1)
     # [b]
     is_valid = (label_lengths + num_consecutive_dups) <= input_lengths
-    is_valid = is_valid.astype(jnp.float32)
     return is_valid
 
 

--- a/axlearn/audio/asr_decoder.py
+++ b/axlearn/audio/asr_decoder.py
@@ -28,6 +28,40 @@ from axlearn.common.module import Module
 from axlearn.common.utils import Nested, Tensor
 
 
+def is_valid_ctc_seq(logitpaddings, labels, labelpaddings):
+  """Returns for per example sequence if it passes validity check.
+
+  Note that the above `ctc_loss_with_alignments` returns logeps
+  (usually a very large number) if the input length is smaller than
+  the label length plus number of consectutive duplications.
+  However, in that case, we should ignore the loss.
+
+  A validity check is passed if for an example when :
+    input.length >= labels.length + num(consecutive dup label tokens)
+
+  Args:
+    logitpaddings:  [b, t], 0/1 JTensor.
+    labels:         [b, t], int32 JTensor.
+    labelpaddings:  [b, t], 0/1 JTensor.
+  Returns:
+    A shape [b] float tensor indicating if each (input, label) pair is valid,
+      with a value of 1.0 indicating valid and 0.0 otherwise.
+  """
+  # [b]
+  label_lengths = jnp.sum(1.0 - labelpaddings, axis=-1)
+  # [b]
+  input_lengths = jnp.sum(1.0 - logitpaddings, axis=-1)
+  # [b, t-1]
+  dups = (1.0 - labelpaddings[:, 1:]) * (labels[:, :-1] == labels[:, 1:])
+  # [b]
+  num_consecutive_dups = jnp.sum(dups, axis=-1)
+  # [b]
+  is_valid = (label_lengths + num_consecutive_dups) <= input_lengths
+  is_valid = is_valid.astype(jnp.float32)
+  return is_valid
+
+
+
 class CTCPrefixMerger(PrefixMerger):
     """Merges equivalent lower-ranked beams into higher-ranked ones.
 
@@ -185,9 +219,8 @@ class CTCDecoderModel(BaseModel):
         )
 
         # Drop examples with targets longer than inputs.
-        target_length = (1 - target_paddings).sum(axis=-1)
-        input_length = (1 - paddings).sum(axis=-1)
-        per_example_weight = (target_length <= input_length).astype(per_example_loss.dtype)
+        per_example_weight = is_valid_ctc_seq(paddings, target_labels, target_paddings)
+        per_example_weight = per_example_weight.astype(per_example_loss.dtype)
 
         # Compute weighted loss.
         loss = jnp.sum(per_example_loss * per_example_weight) / jnp.maximum(

--- a/axlearn/audio/asr_decoder_test.py
+++ b/axlearn/audio/asr_decoder_test.py
@@ -125,7 +125,7 @@ class ValidCtcSeqTest(TestCase):
         per_seq_validality = _is_valid_ctc_seq(paddings, target_labels, target_paddings).astype(
             jnp.float32
         )
-        self.assertAllClose(per_seq_validality, [0.0] * batchsize)
+        self.assertTensorAllClose(per_seq_validality, [0.0] * batchsize)
 
     def test_label_shorter_than_input(self):
         batchsize = 4
@@ -146,7 +146,7 @@ class ValidCtcSeqTest(TestCase):
         per_seq_validality = _is_valid_ctc_seq(paddings, labels, target_paddings).astype(
             jnp.float32
         )
-        self.assertAllClose(per_seq_validality, [1.0] * batchsize)
+        self.assertTensorAllClose(per_seq_validality, [1.0] * batchsize)
 
     def test_label_with_duplicates(self):
         batchsize = 4
@@ -179,7 +179,8 @@ class ValidCtcSeqTest(TestCase):
         per_seq_validality = _is_valid_ctc_seq(paddings, target_labels, target_paddings).astype(
             jnp.float32
         )
-        self.assertAllClose(per_seq_validality, [1.0, 1.0, 0.0, 1.0])
+        import pdb; pdb.set_trace()
+        self.assertTensorAllClose(per_seq_validality, [1.0, 1.0, 0.0, 1.0])
 
 
 class CTCPrefixMergerTest(TestCase):

--- a/axlearn/audio/asr_decoder_test.py
+++ b/axlearn/audio/asr_decoder_test.py
@@ -148,11 +148,7 @@ class ValidCtcSeqTest(TestCase):
         per_seq_validality = _is_valid_ctc_seq(
             paddings=paddings, target_labels=labels, target_paddings=target_paddings
         ).astype(jnp.float32)
-        # self.assertTensorAllClose(per_seq_validality, [1.0] * batch_size)
-        import pdb
-
-        pdb.set_trace()
-        self.assertNestedAllClose(per_seq_validality, jnp.array([1.0] * batch_size))
+        self.assertTensorAllClose(per_seq_validality, [1.0] * batch_size)
 
     def test_label_with_duplicates(self):
         batch_size = 5

--- a/axlearn/audio/asr_decoder_test.py
+++ b/axlearn/audio/asr_decoder_test.py
@@ -127,7 +127,9 @@ class ValidCtcSeqTest(TestCase):
         per_seq_validality = _is_valid_ctc_seq(
             paddings=paddings, target_labels=target_labels, target_paddings=target_paddings
         ).astype(jnp.float32)
-        self.assertTensorAllClose(per_seq_validality, [0.0] * batch_size)
+        self.assertNestedAllClose(
+            per_seq_validality,
+            jnp.array([0.0] * batch_size, dtype=per_seq_validality.type))
 
     def test_label_shorter_than_input(self):
         batch_size = 4
@@ -148,7 +150,9 @@ class ValidCtcSeqTest(TestCase):
         per_seq_validality = _is_valid_ctc_seq(
             paddings=paddings, target_labels=labels, target_paddings=target_paddings
         ).astype(jnp.float32)
-        self.assertTensorAllClose(per_seq_validality, [1.0] * batch_size)
+        self.assertNestedAllClose(
+            per_seq_validality,
+            jnp.array([1.0] * batch_size), dtype=per_seq_validality.type)
 
     def test_label_with_duplicates(self):
         batch_size = 5
@@ -183,7 +187,9 @@ class ValidCtcSeqTest(TestCase):
         per_seq_validality = _is_valid_ctc_seq(
             paddings=paddings, target_labels=target_labels, target_paddings=target_paddings
         ).astype(jnp.float32)
-        self.assertTensorAllClose(per_seq_validality, [1.0, 1.0, 0.0, 1.0, 1.0])
+        self.assertNestedAllClose(
+            per_seq_validality, 
+            jnp.array([1.0, 1.0, 0.0, 1.0, 1.0], dtype=per_seq_validality.type))
 
 
 class CTCPrefixMergerTest(TestCase):

--- a/axlearn/audio/asr_decoder_test.py
+++ b/axlearn/audio/asr_decoder_test.py
@@ -96,7 +96,9 @@ class ValidCtcSeqTest(TestCase):
         self, batch_size: int, input_lengths: int, target_lengths: int, vocab_size: int
     ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         prng_key = jax.random.PRNGKey(1234)
-        logits = jax.random.normal(prng_key, (batch_size, input_lengths, vocab_size), dtype=jnp.float32)
+        logits = jax.random.normal(
+            prng_key, (batch_size, input_lengths, vocab_size), dtype=jnp.float32
+        )
         paddings = jnp.zeros((batch_size, input_lengths), dtype=np.int32)
         target_labels = jax.random.randint(
             prng_key,

--- a/axlearn/audio/asr_decoder_test.py
+++ b/axlearn/audio/asr_decoder_test.py
@@ -17,7 +17,7 @@ from axlearn.audio.asr_decoder import (
     CTCPrefixMerger,
     DecodeOutputs,
     _map_label_sequences,
-    is_valid_ctc_seq,
+    _is_valid_ctc_seq,
 )
 from axlearn.common.config import config_for_function
 from axlearn.common.decoder import _scores_from_logits
@@ -92,12 +92,25 @@ class UtilsTest(TestCase):
 
 
 class ValidCtcSeqTest(TestCase):
-    def get_logits_and_labels(self, batchsize, timesteps, labelsteps, nclasses):
-        logits = np.random.randn(batchsize, timesteps, nclasses)
-        logitpaddings = np.zeros((batchsize, timesteps), dtype=np.int32)
-        labels = np.random.randint(1, nclasses, size=(batchsize, labelsteps)).astype(np.int32)
-        labelpaddings = np.zeros((batchsize, labelsteps), dtype=np.int32)
-        return logits, logitpaddings, labels, labelpaddings
+    def get_logits_and_labels(
+            self,
+            batch_size:int,
+            time_steps:int,
+            target_steps:int,
+            nclasses:int) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        prng_key = jax.random.PRNGKey(1234)
+        logits = jax.random.normal(prng_key, (batch_size, time_steps, nclasses), dtype=jnp.float32)
+        paddings = jnp.zeros((batch_size, time_steps), dtype=np.int32)
+        target_labels = jax.random.randint(
+            prng_key,
+            shape=(batch_size, target_steps),
+            minval=1, maxval=nclasses - 1,
+            dtype=jnp.int32)
+        target_paddings = jnp.zeros(
+            shape=(batch_size, target_steps),
+            dtype=jnp.int32
+        )
+        return logits, paddings, target_labels, target_paddings
 
     def test_label_longer_than_input(self):
         batchsize = 4
@@ -105,13 +118,13 @@ class ValidCtcSeqTest(TestCase):
         labelsteps = 11
         nclasses = 400
         # generate logits and labels, which has logits shorter than labels
-        logits, logitpaddings, labels, labelpaddings = self.get_logits_and_labels(
+        logits, paddings, target_labels, target_paddings = self.get_logits_and_labels(
             batchsize, timesteps, labelsteps, nclasses
         )
-        per_seq_loss = optax.ctc_loss(logits, logitpaddings, labels, labelpaddings, blank_id=0)
+        per_seq_loss = optax.ctc_loss(logits, paddings, target_labels, target_paddings, blank_id=0)
         print(per_seq_loss)
         # they are very close to `logepsilon` (default in optax is -1e5)
-        per_seq_validality = is_valid_ctc_seq(logitpaddings, labels, labelpaddings)
+        per_seq_validality = _is_valid_ctc_seq(paddings, target_labels, target_paddings)
         self.assertAllClose(per_seq_validality, [0.0] * batchsize)
 
     def test_label_shorter_than_input(self):
@@ -119,16 +132,16 @@ class ValidCtcSeqTest(TestCase):
         timesteps = 15
         labelsteps = 10
         nclasses = 400
-        logits, logitpaddings, _, labelpaddings = self.get_logits_and_labels(
+        logits, paddings, _, target_paddings = self.get_logits_and_labels(
             batchsize, timesteps, labelsteps, nclasses
         )
         # to make sure there is no duplicate in the labels
-        labels = np.tile(np.arange(labelsteps)[np.newaxis, :], [batchsize, 1])
+        labels = jnp.tile(jnp.arange(labelsteps)[jnp.newaxis, :], [batchsize, 1])
 
-        per_seq_loss = optax.ctc_loss(logits, logitpaddings, labels, labelpaddings)
+        per_seq_loss = optax.ctc_loss(logits, paddings, labels, target_paddings)
         # per_seq_loss in this case looks normal, it should be around log(400)*15
         print(per_seq_loss)
-        per_seq_validality = is_valid_ctc_seq(logitpaddings, labels, labelpaddings)
+        per_seq_validality = _is_valid_ctc_seq(paddings, labels, target_paddings)
         self.assertAllClose(per_seq_validality, [1.0] * batchsize)
 
     def test_label_with_duplicates(self):
@@ -136,12 +149,12 @@ class ValidCtcSeqTest(TestCase):
         timesteps = 12
         labelsteps = 10
         nclasses = 400
-        logits, logitpaddings, _, labelpaddings = self.get_logits_and_labels(
+        logits, paddings, _, target_paddings = self.get_logits_and_labels(
             batchsize, timesteps, labelsteps, nclasses
         )
         # there are 12 timesteps, and 10 labels. If the consecutive duplicates in
         # one sequence is larger than 2, then the pair become non-valid
-        labels = np.array(
+        target_labels = np.array(
             [
                 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],  # no duplicates
                 [0, 0, 1, 1, 2, 3, 4, 5, 6, 7],  # 2 duplicates
@@ -151,12 +164,12 @@ class ValidCtcSeqTest(TestCase):
             ],
             dtype=np.int32,
         )
-        labelpaddings[3, 9:] = 1
-        per_seq_loss = optax.ctc_loss(logits, logitpaddings, labels, labelpaddings)
+        target_paddings = target_paddings.at[3, 9].set(1)
+        per_seq_loss = optax.ctc_loss(logits, paddings, target_labels, target_paddings)
         # per_seq_loss[0:1] and per_seq_loss[3] should near log(400) * 15, while
         # per_seq_loss[2] should be around logepsilon
         print(per_seq_loss)
-        per_seq_validality = is_valid_ctc_seq(logitpaddings, labels, labelpaddings)
+        per_seq_validality = _is_valid_ctc_seq(paddings, target_labels, target_paddings)
         self.assertAllClose(per_seq_validality, [1.0, 1.0, 0.0, 1.0])
 
 

--- a/axlearn/audio/asr_decoder_test.py
+++ b/axlearn/audio/asr_decoder_test.py
@@ -128,8 +128,8 @@ class ValidCtcSeqTest(TestCase):
             paddings=paddings, target_labels=target_labels, target_paddings=target_paddings
         ).astype(jnp.float32)
         self.assertNestedAllClose(
-            per_seq_validality,
-            jnp.array([0.0] * batch_size, dtype=per_seq_validality.type))
+            per_seq_validality, jnp.array([0.0] * batch_size, dtype=per_seq_validality.dtype)
+        )
 
     def test_label_shorter_than_input(self):
         batch_size = 4
@@ -151,8 +151,8 @@ class ValidCtcSeqTest(TestCase):
             paddings=paddings, target_labels=labels, target_paddings=target_paddings
         ).astype(jnp.float32)
         self.assertNestedAllClose(
-            per_seq_validality,
-            jnp.array([1.0] * batch_size), dtype=per_seq_validality.type)
+            per_seq_validality, jnp.array([1.0] * batch_size, dtype=per_seq_validality.dtype)
+        )
 
     def test_label_with_duplicates(self):
         batch_size = 5
@@ -188,8 +188,8 @@ class ValidCtcSeqTest(TestCase):
             paddings=paddings, target_labels=target_labels, target_paddings=target_paddings
         ).astype(jnp.float32)
         self.assertNestedAllClose(
-            per_seq_validality, 
-            jnp.array([1.0, 1.0, 0.0, 1.0, 1.0], dtype=per_seq_validality.type))
+            per_seq_validality, jnp.array([1.0, 1.0, 0.0, 1.0, 1.0], dtype=per_seq_validality.dtype)
+        )
 
 
 class CTCPrefixMergerTest(TestCase):

--- a/axlearn/audio/asr_decoder_test.py
+++ b/axlearn/audio/asr_decoder_test.py
@@ -7,18 +7,17 @@ import functools
 
 import jax.random
 import numpy as np
+import optax
 import torch
 from absl.testing import parameterized
 from jax import numpy as jnp
-import optax
-
 
 from axlearn.audio.asr_decoder import (
     CTCDecoderModel,
     CTCPrefixMerger,
     DecodeOutputs,
     _map_label_sequences,
-    is_valid_ctc_seq
+    is_valid_ctc_seq,
 )
 from axlearn.common.config import config_for_function
 from axlearn.common.decoder import _scores_from_logits
@@ -91,79 +90,74 @@ class UtilsTest(TestCase):
             jit_fn(inputs, blank_id=blank_id, pad_id=pad_id),
         )
 
+
 class ValidCtcSeqTest(TestCase):
+    def get_logits_and_labels(self, batchsize, timesteps, labelsteps, nclasses):
+        logits = np.random.randn(batchsize, timesteps, nclasses)
+        logitpaddings = np.zeros((batchsize, timesteps), dtype=np.int32)
+        labels = np.random.randint(1, nclasses, size=(batchsize, labelsteps)).astype(np.int32)
+        labelpaddings = np.zeros((batchsize, labelsteps), dtype=np.int32)
+        return logits, logitpaddings, labels, labelpaddings
 
-  def get_logits_and_labels(self, batchsize, timesteps, labelsteps, nclasses):
-    logits = np.random.randn(batchsize, timesteps, nclasses)
-    logitpaddings = np.zeros((batchsize, timesteps), dtype=np.int32)
-    labels = np.random.randint(
-        1, nclasses, size=(batchsize, labelsteps)
-    ).astype(np.int32)
-    labelpaddings = np.zeros((batchsize, labelsteps), dtype=np.int32)
-    return logits, logitpaddings, labels, labelpaddings
+    def test_label_longer_than_input(self):
+        batchsize = 4
+        timesteps = 10
+        labelsteps = 11
+        nclasses = 400
+        # generate logits and labels, which has logits shorter than labels
+        logits, logitpaddings, labels, labelpaddings = self.get_logits_and_labels(
+            batchsize, timesteps, labelsteps, nclasses
+        )
+        per_seq_loss = optax.ctc_loss(logits, logitpaddings, labels, labelpaddings, blank_id=0)
+        print(per_seq_loss)
+        # they are very close to `logepsilon` (default in optax is -1e5)
+        per_seq_validality = is_valid_ctc_seq(logitpaddings, labels, labelpaddings)
+        self.assertAllClose(per_seq_validality, [0.0] * batchsize)
 
-  def test_label_longer_than_input(self):
-    batchsize = 4
-    timesteps = 10
-    labelsteps = 11
-    nclasses = 400
-    # generate logits and labels, which has logits shorter than labels
-    logits, logitpaddings, labels, labelpaddings = self.get_logits_and_labels(
-        batchsize, timesteps, labelsteps, nclasses
-    )
-    per_seq_loss = optax.ctc_loss(
-        logits, logitpaddings, labels, labelpaddings, blank_id=0)
-    print(per_seq_loss)
-    # they are very close to `logepsilon` (default in optax is -1e5)
-    per_seq_validality = is_valid_ctc_seq(logitpaddings, labels, labelpaddings)
-    self.assertAllClose(per_seq_validality, [0.0] * batchsize)
+    def test_label_shorter_than_input(self):
+        batchsize = 4
+        timesteps = 15
+        labelsteps = 10
+        nclasses = 400
+        logits, logitpaddings, _, labelpaddings = self.get_logits_and_labels(
+            batchsize, timesteps, labelsteps, nclasses
+        )
+        # to make sure there is no duplicate in the labels
+        labels = np.tile(np.arange(labelsteps)[np.newaxis, :], [batchsize, 1])
 
-  def test_label_shorter_than_input(self):
-    batchsize = 4
-    timesteps = 15
-    labelsteps = 10
-    nclasses = 400
-    logits, logitpaddings, _, labelpaddings = self.get_logits_and_labels(
-        batchsize, timesteps, labelsteps, nclasses
-    )
-    # to make sure there is no duplicate in the labels
-    labels = np.tile(np.arange(labelsteps)[np.newaxis, :], [batchsize, 1])
+        per_seq_loss = optax.ctc_loss(logits, logitpaddings, labels, labelpaddings)
+        # per_seq_loss in this case looks normal, it should be around log(400)*15
+        print(per_seq_loss)
+        per_seq_validality = is_valid_ctc_seq(logitpaddings, labels, labelpaddings)
+        self.assertAllClose(per_seq_validality, [1.0] * batchsize)
 
-    per_seq_loss = optax.ctc_loss(
-        logits, logitpaddings, labels, labelpaddings)
-    # per_seq_loss in this case looks normal, it should be around log(400)*15
-    print(per_seq_loss)
-    per_seq_validality = is_valid_ctc_seq(logitpaddings, labels, labelpaddings)
-    self.assertAllClose(per_seq_validality, [1.0] * batchsize)
-
-  def test_label_with_duplicates(self):
-    batchsize = 4
-    timesteps = 12
-    labelsteps = 10
-    nclasses = 400
-    logits, logitpaddings, _, labelpaddings = self.get_logits_and_labels(
-        batchsize, timesteps, labelsteps, nclasses
-    )
-    # there are 12 timesteps, and 10 labels. If the consecutive duplicates in
-    # one sequence is larger than 2, then the pair become non-valid
-    labels = np.array(
-        [
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],  # no duplicates
-            [0, 0, 1, 1, 2, 3, 4, 5, 6, 7],  # 2 duplicates
-            [0, 0, 0, 1, 1, 2, 3, 4, 5, 6],  # 3 duplicates -> invalid seq
-            [0, 0, 1, 1, 2, 3, 4, 5, 6, 6],
-            # 2 duplicates, since the last 6 is a padding
-        ],
-        dtype=np.int32,
-    )
-    labelpaddings[3, 9:] = 1
-    per_seq_loss = optax.ctc_loss(
-        logits, logitpaddings, labels, labelpaddings)
-    # per_seq_loss[0:1] and per_seq_loss[3] should near log(400) * 15, while
-    # per_seq_loss[2] should be around logepsilon
-    print(per_seq_loss)
-    per_seq_validality = is_valid_ctc_seq(logitpaddings, labels, labelpaddings)
-    self.assertAllClose(per_seq_validality, [1.0, 1.0, 0.0, 1.0])
+    def test_label_with_duplicates(self):
+        batchsize = 4
+        timesteps = 12
+        labelsteps = 10
+        nclasses = 400
+        logits, logitpaddings, _, labelpaddings = self.get_logits_and_labels(
+            batchsize, timesteps, labelsteps, nclasses
+        )
+        # there are 12 timesteps, and 10 labels. If the consecutive duplicates in
+        # one sequence is larger than 2, then the pair become non-valid
+        labels = np.array(
+            [
+                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],  # no duplicates
+                [0, 0, 1, 1, 2, 3, 4, 5, 6, 7],  # 2 duplicates
+                [0, 0, 0, 1, 1, 2, 3, 4, 5, 6],  # 3 duplicates -> invalid seq
+                [0, 0, 1, 1, 2, 3, 4, 5, 6, 6],
+                # 2 duplicates, since the last 6 is a padding
+            ],
+            dtype=np.int32,
+        )
+        labelpaddings[3, 9:] = 1
+        per_seq_loss = optax.ctc_loss(logits, logitpaddings, labels, labelpaddings)
+        # per_seq_loss[0:1] and per_seq_loss[3] should near log(400) * 15, while
+        # per_seq_loss[2] should be around logepsilon
+        print(per_seq_loss)
+        per_seq_validality = is_valid_ctc_seq(logitpaddings, labels, labelpaddings)
+        self.assertAllClose(per_seq_validality, [1.0, 1.0, 0.0, 1.0])
 
 
 class CTCPrefixMergerTest(TestCase):

--- a/axlearn/audio/asr_decoder_test.py
+++ b/axlearn/audio/asr_decoder_test.py
@@ -179,7 +179,6 @@ class ValidCtcSeqTest(TestCase):
         per_seq_validality = _is_valid_ctc_seq(paddings, target_labels, target_paddings).astype(
             jnp.float32
         )
-        import pdb; pdb.set_trace()
         self.assertTensorAllClose(per_seq_validality, [1.0, 1.0, 0.0, 1.0])
 
 

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -56,7 +56,7 @@ from axlearn.experiments.trainer_config_utils import TrainerConfigFn
 _default_prng_impl = "rbg"
 _PYTEST_OPT_REGISTERED = {}
 
-_dtype = lambda x: getattr(x, 'dtype', None) or np.asarray(x).dtype
+_dtype = lambda x: getattr(x, "dtype", None) or np.asarray(x).dtype
 
 
 def assert_allclose(actual, desired, atol=1e-6, rtol=1e-3, err_msg=""):
@@ -198,11 +198,12 @@ class TestCase(parameterized.TestCase):
             ref_layer(**ref_inputs) if isinstance(ref_inputs, dict) else ref_layer(ref_inputs)
         )
         return test_outputs, ref_outputs
-    
+
     def assertDtypesMatch(self, x, y):
         self.assertEqual(
             jax.dtypes.canonicalize_dtype(_dtype(x)),
-            jax.dtypes.canonicalize_dtype(_dtype(y)),)
+            jax.dtypes.canonicalize_dtype(_dtype(y)),
+        )
 
     def assertNestedAllClose(self, a, b, atol=1e-6, rtol=1e-3):
         a_items = sorted(flatten_items(a), key=lambda x: x[0])
@@ -237,8 +238,7 @@ class TestCase(parameterized.TestCase):
             if hasattr(a_value, "dtype"):
                 self.assertEqual(a_value.dtype, b_value.dtype)
 
-    def assertAllClose(
-      self, x, y, check_dtypes=True, rtol=1e-5, atol=1e-5, **kwargs):
+    def assertAllClose(self, x, y, check_dtypes=True, rtol=1e-5, atol=1e-5, **kwargs):
         """Wrapper for np.testing.assert_allclose()."""
         x = np.asarray(x)
         y = np.asarray(y)

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -56,8 +56,6 @@ from axlearn.experiments.trainer_config_utils import TrainerConfigFn
 _default_prng_impl = "rbg"
 _PYTEST_OPT_REGISTERED = {}
 
-_dtype = lambda x: getattr(x, "dtype", None) or np.asarray(x).dtype
-
 
 def assert_allclose(actual, desired, atol=1e-6, rtol=1e-3, err_msg=""):
     actual = jnp.asarray(actual).astype(np.float32)
@@ -199,12 +197,6 @@ class TestCase(parameterized.TestCase):
         )
         return test_outputs, ref_outputs
 
-    def assertDtypesMatch(self, x, y):
-        self.assertEqual(
-            jax.dtypes.canonicalize_dtype(_dtype(x)),
-            jax.dtypes.canonicalize_dtype(_dtype(y)),
-        )
-
     def assertNestedAllClose(self, a, b, atol=1e-6, rtol=1e-3):
         a_items = sorted(flatten_items(a), key=lambda x: x[0])
         b_items = sorted(flatten_items(b), key=lambda x: x[0])
@@ -237,16 +229,6 @@ class TestCase(parameterized.TestCase):
             np.testing.assert_array_equal(a_value, b_value, err_msg=k)
             if hasattr(a_value, "dtype"):
                 self.assertEqual(a_value.dtype, b_value.dtype)
-
-    def assertTensorAllClose(self, x, y, rtol=1e-5, atol=1e-5, check_dtypes=True, **kwargs):
-        """assert Tensor are all close."""
-        x = np.asarray(x)
-        y = np.asarray(y)
-        if check_dtypes:
-            self.assertDtypesMatch(x, y)
-        x = x.astype(np.float32) if x.dtype == jnp.bfloat16 else x
-        y = y.astype(np.float32) if y.dtype == jnp.bfloat16 else y
-        np.testing.assert_allclose(x, y, rtol=rtol, atol=atol, **kwargs)
 
 
 # TODO(markblee): Move this to axlearn/experiments/test_utils.py, where it's used.

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -238,8 +238,8 @@ class TestCase(parameterized.TestCase):
             if hasattr(a_value, "dtype"):
                 self.assertEqual(a_value.dtype, b_value.dtype)
 
-    def assertAllClose(self, x, y, rtol=1e-5, atol=1e-5, check_dtypes=True, **kwargs):
-        """Wrapper for assertNestedAllClose."""
+    def assertTensorAllClose(self, x, y, rtol=1e-5, atol=1e-5, check_dtypes=True, **kwargs):
+        """assert Tensor are all close."""
         x = np.asarray(x)
         y = np.asarray(y)
         if check_dtypes:

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -238,8 +238,8 @@ class TestCase(parameterized.TestCase):
             if hasattr(a_value, "dtype"):
                 self.assertEqual(a_value.dtype, b_value.dtype)
 
-    def assertAllClose(self, x, y, check_dtypes=True, rtol=1e-5, atol=1e-5, **kwargs):
-        """Wrapper for np.testing.assert_allclose()."""
+    def assertAllClose(self, x, y, rtol=1e-5, atol=1e-5, check_dtypes=True, **kwargs):
+        """Wrapper for assertNestedAllClose."""
         x = np.asarray(x)
         y = np.asarray(y)
         if check_dtypes:


### PR DESCRIPTION
For invalid sequence, optax.ctc_loss will return -log(eps), default -1e5 as the loss. Currently we only drop sequence is the input_length is shorter than output_length, but there are edge cases, this could  result in invalid sequence used in the loss calculation, and a loss value  spike. In the backward pass, the offending sequence get 0 gradient, but the other sequence in the same batch get a very high gradient. 

For example, if the input sequence has 3 frames, and the label sequence is [a, a, b], CTC cannot align the label sequence with the input sequence, because it is require from a to a, it must travel a blank symbol. 