### PR TITLE
Propagate num_kv_heads from child input_linear for RoFormerQKVLinear.

### DIFF
--- a/axlearn/common/lora.py
+++ b/axlearn/common/lora.py
@@ -508,6 +508,10 @@ class LoraFusedQKVLinear(BaseQKVLinear):
             ),
         )
 
+    @property
+    def num_kv_heads(self):
+        return self.layer.num_kv_heads
+
     def forward(
         self,
         query: Tensor,


### PR DESCRIPTION
Also remove default impl of `num_kv_heads` in `BaseQKVLinear`.