### PR TITLE
setup conda env in cpu jobs

### DIFF
--- a/axlearn/cloud/gcp/job.py
+++ b/axlearn/cloud/gcp/job.py
@@ -214,7 +214,8 @@ class CPUJob(GCPJob):
         cfg = self.config
         logging.debug("Executing remote command: '%s'", cmd)
         cmd = _prepare_cmd_for_gcloud_ssh(f"pushd /root && {cmd}")
-        cmd = f"sudo bash -c {cmd}"
+        # Use login shell. Note `-i` is not interactive.
+        cmd = f"sudo -i bash -c {cmd}"
         if detached_session:
             cmd = f"sudo screen -dmS {detached_session} {cmd}"
         # Run via screen to persist command after SSH.

--- a/axlearn/cloud/gcp/scripts/start_vm.sh
+++ b/axlearn/cloud/gcp/scripts/start_vm.sh
@@ -65,6 +65,8 @@ if [[ " ${tar_bundlers[*]} " =~ " ${BUNDLER_TYPE} " ]]; then
     conda create -y -n py310 python=3.10
     conda activate py310
     conda info --envs
+    # Add conda to .profile file, and use login shell to source.
+    echo 'source /opt/conda/etc/profile.d/conda.sh && conda activate py310' >> ~/.profile
   }
   install_py310 >> ${SETUP_LOG_PATH} 2>&1
   echo "Using python3: $(which python3)" >> ${SETUP_LOG_PATH} 2>&1


### PR DESCRIPTION
This PR enables use of conda python instead of system python for CPUJob. This does not effect non-cpu jobs.