### PR TITLE
Allows Decoder.attention_mask to be None

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -1628,7 +1628,7 @@ class MultiheadAttention(BaseLayer):
         *,
         time_step: Tensor,
         query: Tensor,
-        attention_logit_biases: Tensor,
+        attention_logit_biases: Optional[Tensor],
     ) -> Tuple[NestedTensor, Output]:
         """Initializes cache for autoregressive cached decoding.
 
@@ -1660,7 +1660,7 @@ class MultiheadAttention(BaseLayer):
         cached_states: NestedTensor,
         query: Tensor,
         *,
-        attention_logit_biases: Tensor,
+        attention_logit_biases: Optional[Tensor],
     ) -> Tuple[NestedTensor, Output]:
         """Computes the value vector given the query of the current step.
         This function is used by autoregressive decoding.
@@ -1997,7 +1997,7 @@ class MultiheadAttentionXL(MultiheadAttention):
         cached_states: NestedTensor,
         query: Tensor,
         *,
-        attention_logit_biases: Tensor,
+        attention_logit_biases: Optional[Tensor],
     ) -> Tuple[NestedTensor, MultiheadAttention.Output]:
         raise NotImplementedError(type(self))
 
@@ -2191,7 +2191,7 @@ class TransformerAttentionLayer(BaseLayer):
         *,
         time_step: NestedTensor,
         target: Tensor,
-        attention_logit_biases: Tensor,
+        attention_logit_biases: Optional[Tensor],
     ) -> Tuple[NestedTensor, Output]:
         """Initializes cache for autoregressive cached decoding.
 
@@ -2223,7 +2223,7 @@ class TransformerAttentionLayer(BaseLayer):
         cached_states: NestedTensor,
         target: Tensor,
         *,
-        attention_logit_biases: Tensor,
+        attention_logit_biases: Optional[Tensor],
     ) -> Tuple[NestedTensor, Output]:
         """Computes the value vector given the query of the current step.
         This function is used by autoregressive decoding.

--- a/axlearn/common/decoder.py
+++ b/axlearn/common/decoder.py
@@ -462,7 +462,7 @@ class Decoder(DecodingMixin, BaseLayer):
         *,
         mode: ForwardMode,
         input_ids: Tensor,
-        self_attention_logit_biases: Tensor,
+        self_attention_logit_biases: Optional[Tensor],
         token_type_ids: Optional[Tensor] = None,
         cross_attention_data: Optional[Tensor] = None,
         cross_attention_logit_biases: Optional[Tensor] = None,

--- a/axlearn/common/decoder.py
+++ b/axlearn/common/decoder.py
@@ -411,9 +411,9 @@ class Decoder(DecodingMixin, BaseLayer):
 
         # attention_mask can be None if the attention layer supports the causal mode, e.g.,
         # FlashAttention with `causal=True`.
-        attention_mask: Optional[AttentionLogitBiasLayer.Config] = (
-            CausalAttentionLogitBiasLayer.default_config()
-        )
+        attention_mask: Optional[
+            AttentionLogitBiasLayer.Config
+        ] = CausalAttentionLogitBiasLayer.default_config()
         vocab_size: Required[int] = REQUIRED  # Size of vocabulary.
         # Dimensionality of embeddings and inputs to each transformer layer.
         dim: Required[int] = REQUIRED

--- a/axlearn/common/decoder_test.py
+++ b/axlearn/common/decoder_test.py
@@ -18,17 +18,17 @@ from axlearn.common import decoding, utils
 from axlearn.common.attention import (
     NEG_INF,
     ALiBiAttentionLogitBiasLayer,
+    MultiheadAttention,
     RepeatedTransformerLayer,
     StackedTransformerLayer,
     TransformerAttentionLayer,
     TransformerLayer,
-    MultiheadAttention,
 )
-from axlearn.common.flash_attention.layer import FlashAttention
 from axlearn.common.base_layer import RematSpec
 from axlearn.common.causal_lm import gpt_decoder_config
 from axlearn.common.config import InstantiableConfig
 from axlearn.common.decoder import Decoder, LmHead, _segment_ids_from_causal_input_ids
+from axlearn.common.flash_attention.layer import FlashAttention
 from axlearn.common.layers import set_bias_recursively
 from axlearn.common.module import functional
 from axlearn.common.test_utils import TestCase, assert_allclose

--- a/axlearn/common/decoder_test.py
+++ b/axlearn/common/decoder_test.py
@@ -35,7 +35,9 @@ from axlearn.common.test_utils import TestCase, assert_allclose
 
 
 def _enable_flash_attention(cfg: Decoder.Config) -> Decoder.Config:
+    # Since FlashAttention supports the causal mode natively, we don't need attention_mask.
     cfg.attention_mask = None
+    # Replace layer_cfg.self_attention.attention with a FlashAttention.Config.
     layer_cfg: TransformerLayer.Config = cfg.transformer.layer
     orig_atten: MultiheadAttention.Config = layer_cfg.self_attention.attention
     kvs = {k: v for k, v in orig_atten.items() if k != "klass"}

--- a/axlearn/common/decoder_test.py
+++ b/axlearn/common/decoder_test.py
@@ -9,8 +9,10 @@ from unittest import mock
 import jax
 import jax.numpy as jnp
 import numpy as np
+from absl import logging
 from absl.testing import absltest, parameterized
-from jax.experimental import checkify
+from jax.experimental import checkify, mesh_utils
+from jax.sharding import Mesh
 
 from axlearn.common import decoding, utils
 from axlearn.common.attention import (
@@ -19,13 +21,28 @@ from axlearn.common.attention import (
     RepeatedTransformerLayer,
     StackedTransformerLayer,
     TransformerAttentionLayer,
+    TransformerLayer,
+    MultiheadAttention,
 )
+from axlearn.common.flash_attention.layer import FlashAttention
 from axlearn.common.base_layer import RematSpec
 from axlearn.common.causal_lm import gpt_decoder_config
 from axlearn.common.config import InstantiableConfig
 from axlearn.common.decoder import Decoder, LmHead, _segment_ids_from_causal_input_ids
+from axlearn.common.layers import set_bias_recursively
 from axlearn.common.module import functional
 from axlearn.common.test_utils import TestCase, assert_allclose
+
+
+def _enable_flash_attention(cfg: Decoder.Config) -> Decoder.Config:
+    cfg.attention_mask = None
+    layer_cfg: TransformerLayer.Config = cfg.transformer.layer
+    orig_atten: MultiheadAttention.Config = layer_cfg.self_attention.attention
+    kvs = {k: v for k, v in orig_atten.items() if k != "klass"}
+    logging.info("atten kvs=%s", kvs)
+    flash_atten = FlashAttention.default_config().set(causal=True, **kvs)
+    layer_cfg.self_attention.attention = flash_atten
+    return cfg
 
 
 class TestDecoder(TestCase):
@@ -113,6 +130,58 @@ class TestDecoder(TestCase):
         # Set untied head weight to tied lm_head value and check again.
         untied_head_state["lm_head"]["weight"] = tied_head_state["emb"]["token_emb"]["weight"]
         check_grads(tied_head_state, untied_head_state)
+
+    def test_causal_flash_attention(self):
+      """Tests that FlashAttention with causal=True and attention_mask=None
+
+      ... is equivalent to a regular attention with CausalAttentionLogitBiasLayer.
+      """
+      mesh = [1, 1, 1]
+      mesh_axis_names = ["data", "fsdp", "model"]
+      with Mesh(mesh_utils.create_device_mesh(mesh), mesh_axis_names):
+        hidden_dim = 12
+        num_heads = 4
+        vocab_size = 24
+        source_length = 11
+
+        # Similarities with encoder_decoder_test.
+        # pylint: disable=duplicate-code
+        decoder_cfg = gpt_decoder_config(
+            stack_cfg=StackedTransformerLayer.default_config(),
+            num_layers=2,
+            hidden_dim=hidden_dim,
+            num_heads=num_heads,
+            vocab_size=vocab_size,
+            activation_function="nn.relu",
+            max_position_embeddings=source_length,
+        ).set(name="decoder")
+        # Flash attention does not support bias.
+        set_bias_recursively(decoder_cfg, bias=False)
+        decoder = decoder_cfg.instantiate(parent=None)
+        # pylint: enable=duplicate-code
+        decoder_state = decoder.initialize_parameters_recursively(jax.random.PRNGKey(0))
+
+        flash_decoder_cfg = _enable_flash_attention(decoder_cfg.clone())
+        flash_decoder = flash_decoder_cfg.instantiate(parent=None)
+        flash_decoder_state = decoder_state
+
+        inputs = jax.random.randint(
+            jax.random.PRNGKey(1), minval=1, maxval=vocab_size, shape=(3, source_length)
+        )
+
+        # Test values.
+        def layer_output(state, layer):
+            return functional(
+                layer,
+                inputs=dict(input_ids=inputs),
+                state=state,
+                is_training=False,
+                prng_key=jax.random.PRNGKey(2),
+            )[0]["logits"]
+
+        decoder_logits = layer_output(decoder_state, decoder)
+        flash_decoder_logits = layer_output(flash_decoder_state, flash_decoder)
+        np.testing.assert_allclose(decoder_logits, flash_decoder_logits)
 
     @parameterized.parameters(None, 0.0, 0.2)
     def test_dropout_rate(self, output_dropout_rate):

--- a/axlearn/common/t5.py
+++ b/axlearn/common/t5.py
@@ -140,7 +140,7 @@ class T5RelativePositionalEmbedding(BaseLayer):
             "emb", Embedding.default_config().set(num_embeddings=cfg.num_buckets, dim=cfg.dim)
         )
 
-    def forward(self, attention_logit_biases: Tensor) -> Tensor:
+    def forward(self, attention_logit_biases: Optional[Tensor]) -> Tensor:
         """Applies relative positional biases to 'attention_logit_biases'.
 
         Args:

--- a/axlearn/common/t5.py
+++ b/axlearn/common/t5.py
@@ -140,7 +140,7 @@ class T5RelativePositionalEmbedding(BaseLayer):
             "emb", Embedding.default_config().set(num_embeddings=cfg.num_buckets, dim=cfg.dim)
         )
 
-    def forward(self, attention_logit_biases: Optional[Tensor]) -> Tensor:
+    def forward(self, attention_logit_biases: Tensor) -> Tensor:
         """Applies relative positional biases to 'attention_logit_biases'.
 
         Args:


### PR DESCRIPTION
This is useful when the attention layer natively supports causal masking (e.g., FlashAttention).

Adds a test to show that FlashAttention with causal=True and attention_mask=None is equivalent to a regular attention with CausalAttentionLogitBiasLayer.
