### PR TITLE
bump up torchvision to 0.16.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
     "tqdm",  # test-only
     "timm==0.6.12",  # DiT Dependency test-only
     "torch>=1.12.1",  # test-only
-    "torchvision==0.14.1",  # test-only
+    "torchvision==0.16.1",  # test-only
     "transformers==4.36.0",  # test-only
     "wandb",  # test-only
     "wrapt",  # implied by tensorflow-datasets, but also used in config tests.


### PR DESCRIPTION
torchvision was released to be with torch1.13.1. upgrading it to torchvision 0.16.1 for torch2.0+