### PR TITLE
Adds some tolerance to the check about the sum of resources.

### DIFF
--- a/axlearn/cloud/common/quota.py
+++ b/axlearn/cloud/common/quota.py
@@ -66,10 +66,13 @@ def _convert_and_validate_resources(info: QuotaInfo) -> QuotaInfo:
             resources[resource_type] = value
 
     for resource_type, total in total_project_resources.items():
-        if total > info.total_resources.get(resource_type, 0) + 0.01:
+        limit = info.total_resources.get(resource_type, 0)
+        if total > limit + 0.01:
             logging.warning(
-                f"Sum of {resource_type} project resources ({total}) "
-                f"exceeds total ({info.total_resources[resource_type]})"
+                "Sum of %s project resources (%s) exceeds total (%s)",
+                resource_type,
+                total,
+                info.total_resources[resource_type],
             )
     return info
 

--- a/axlearn/cloud/common/quota.py
+++ b/axlearn/cloud/common/quota.py
@@ -1,13 +1,13 @@
 # Copyright © 2023 Apple Inc.
 
 """Utilities to retrieve quotas."""
-
 import re
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import List, Protocol
 
 import toml
+from absl import logging
 from tensorflow import io as tf_io
 
 from axlearn.cloud.common.types import ProjectResourceMap, ResourceMap
@@ -66,8 +66,8 @@ def _convert_and_validate_resources(info: QuotaInfo) -> QuotaInfo:
             resources[resource_type] = value
 
     for resource_type, total in total_project_resources.items():
-        if total > info.total_resources.get(resource_type, 0):
-            raise ValueError(
+        if total > info.total_resources.get(resource_type, 0) + 0.01:
+            logging.warning(
                 f"Sum of {resource_type} project resources ({total}) "
                 f"exceeds total ({info.total_resources[resource_type]})"
             )

--- a/axlearn/cloud/common/quota_test.py
+++ b/axlearn/cloud/common/quota_test.py
@@ -37,11 +37,15 @@ class QuotaUtilsTest(parameterized.TestCase):
             toml.dump(_mock_config, f)
             f.seek(0)
             self.assertEqual(
-                QuotaInfo(total_resources={'resource_type1': 16, 'resource_type2': 8},
-                          project_resources={'team1': {'resource_type1': 4.80000016},
-                                             'team2': {'resource_type1': 9.60000016,
-                                                       'resource_type2': 8.0}}),
-                get_resource_limits(f.name))
+                QuotaInfo(
+                    total_resources={"resource_type1": 16, "resource_type2": 8},
+                    project_resources={
+                        "team1": {"resource_type1": 4.80000016},
+                        "team2": {"resource_type1": 9.60000016, "resource_type2": 8.0},
+                    },
+                ),
+                get_resource_limits(f.name),
+            )
 
         # Test a case where the totals don't add up.
         with tempfile.NamedTemporaryFile("r+") as f:
@@ -50,10 +54,13 @@ class QuotaUtilsTest(parameterized.TestCase):
             toml.dump(broken_config, f)
             f.seek(0)
             self.assertEqual(
-                QuotaInfo(total_resources={'resource_type1': 16, 'resource_type2': 8},
-                          project_resources={'team1': {'resource_type1': 12.8},
-                                             'team2': {'resource_type1': 9.60000016,
-                                                       'resource_type2': 8.0}}),
+                QuotaInfo(
+                    total_resources={"resource_type1": 16, "resource_type2": 8},
+                    project_resources={
+                        "team1": {"resource_type1": 12.8},
+                        "team2": {"resource_type1": 9.60000016, "resource_type2": 8.0},
+                    },
+                ),
                 get_resource_limits(f.name),
             )
 
@@ -65,10 +72,13 @@ class QuotaUtilsTest(parameterized.TestCase):
             toml.dump(config, f)
             f.seek(0)
             self.assertEqual(
-                QuotaInfo(total_resources={'resource_type1': 16},
-                          project_resources={'team1': {'resource_type1': 4.80000016},
-                                             'team2': {'resource_type1': 9.60000016,
-                                                       'resource_type2': 0.}}),
+                QuotaInfo(
+                    total_resources={"resource_type1": 16},
+                    project_resources={
+                        "team1": {"resource_type1": 4.80000016},
+                        "team2": {"resource_type1": 9.60000016, "resource_type2": 0.0},
+                    },
+                ),
                 get_resource_limits(f.name),
             )
 

--- a/axlearn/cloud/common/quota_test.py
+++ b/axlearn/cloud/common/quota_test.py
@@ -17,8 +17,8 @@ _mock_config = {
         "resource_type2": 8,
     },
     "project_resources": {
-        "team1": {"resource_type1": 0.5},
-        "team2": {"resource_type1": 0.5, "resource_type2": 1.0},
+        "team1": {"resource_type1": 0.3},
+        "team2": {"resource_type1": 0.7, "resource_type2": 1.0},
     },
     "project_membership": {
         "team1": ["user1"],
@@ -36,8 +36,8 @@ class QuotaUtilsTest(parameterized.TestCase):
         expected = QuotaInfo(
             total_resources=dict(resource_type1=16, resource_type2=8),
             project_resources=dict(
-                team1=dict(resource_type1=8),
-                team2=dict(resource_type1=8, resource_type2=8),
+                team1=dict(resource_type1=4.8),
+                team2=dict(resource_type1=11.2, resource_type2=8),
             ),
         )
         with tempfile.NamedTemporaryFile("r+") as f:
@@ -51,8 +51,16 @@ class QuotaUtilsTest(parameterized.TestCase):
             broken_config["project_resources"]["team1"]["resource_type1"] = 0.8
             toml.dump(broken_config, f)
             f.seek(0)
-            with self.assertRaisesRegex(ValueError, "exceeds total"):
-                get_resource_limits(f.name)
+            self.assertEqual(
+                QuotaInfo(
+                    total_resources={"resource_type1": 16, "resource_type2": 8},
+                    project_resources={
+                        "team1": {"resource_type1": 12.8},
+                        "team2": {"resource_type1": 11.2, "resource_type2": 8},
+                    },
+                ),
+                get_resource_limits(f.name),
+            )
 
         # Test a case where the set of resource types changed.
         with tempfile.NamedTemporaryFile("r+") as f:
@@ -65,9 +73,9 @@ class QuotaUtilsTest(parameterized.TestCase):
                 QuotaInfo(
                     total_resources={"resource_type1": 16},
                     project_resources={
-                        "team1": {"resource_type1": 8.0},
+                        "team1": {"resource_type1": 4.8},
                         # Note that the limit on "resource_type2" is 0.
-                        "team2": {"resource_type1": 8.0, "resource_type2": 0.0},
+                        "team2": {"resource_type1": 11.2, "resource_type2": 0},
                     },
                 ),
                 get_resource_limits(f.name),


### PR DESCRIPTION
Do not raise ValueError. Instead, just log a warning.