### PR TITLE
Fix CLIP attention param converter with qknorm

### DIFF
--- a/axlearn/vision/param_converter.py
+++ b/axlearn/vision/param_converter.py
@@ -286,7 +286,7 @@ def _parameters_from_clip_attention_dense(src: hf_clip.CLIPAttention) -> NestedT
         weight=output_dense.weight.view(-1, num_heads, per_head_dim),
         bias=output_dense.bias,
     )
-    return dict(i_proj=i_proj, o_proj=o_proj, dropout={})
+    return dict(i_proj=i_proj, o_proj=o_proj, dropout={}, scale_key={}, scale_query={})
 
 
 def _parameters_from_clip_attention(


### PR DESCRIPTION
Some leftover from https://github.com/apple/axlearn/pull/206