### PR TITLE
Adds norm summaries to clip_by_block_rms.

### DIFF
--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -153,7 +153,7 @@ class InvocationContext:  # pylint: disable=too-many-instance-attributes
 
     name: str
     parent: Optional["InvocationContext"]
-    module: "Module"
+    module: Optional["Module"]
     state: NestedTensor
     is_training: bool
     prng_key: Optional[Tensor]

--- a/axlearn/common/optimizers.py
+++ b/axlearn/common/optimizers.py
@@ -1043,8 +1043,9 @@ def clip_by_block_rms(threshold: Optional[float]) -> PartitionedGradientTransfor
 
     Args:
         threshold: the maximum rms for the gradient of each param vector or matrix.
-            If None, does not clip, but only adds norms to summaries of the current
-            context (if set).
+            If None, does not clip.
+            In either case, norms will be added to summaries of the current context
+            (if a context is set).
 
     Returns:
         An (init_fn, update_fn) tuple.

--- a/axlearn/common/optimizers_test.py
+++ b/axlearn/common/optimizers_test.py
@@ -814,7 +814,7 @@ class OptimizerTest(TestCase):
             updates["x"], [[1e-5] * 4, [1.8708287, 1.8708287, 1.8708287, 1.8708287]], atol=1e-6
         )
 
-    @parameterized.parameters(100.0, 1e-3)
+    @parameterized.parameters(100.0, 1e-3, None)
     def test_clip_by_block_rms(self, max_norm):
         clip = clip_by_block_rms(threshold=max_norm)
         params = dict(layer=VDict(x=jnp.asarray([[0, 0, 0, 0], [0, 1, 2, -3]], dtype=jnp.float32)))
@@ -846,7 +846,7 @@ class OptimizerTest(TestCase):
         with set_current_context(context):
             updates, _ = clip.update(grads, state=state, params=params)
         x_updates = updates["layer"]["x"]
-        if max_norm > 1:
+        if max_norm is None or max_norm > 1:
             np.testing.assert_allclose(x_updates, x_grads, atol=1e-6)
         else:
             np.testing.assert_allclose(

--- a/axlearn/common/optimizers_test.py
+++ b/axlearn/common/optimizers_test.py
@@ -15,6 +15,7 @@ from jax import numpy as jnp
 from axlearn.common import schedule
 from axlearn.common.base_layer import FactorizationSpec, NestedParameterSpec, ParameterSpec
 from axlearn.common.config import config_for_function
+from axlearn.common.module import InvocationContext, new_output_collection, set_current_context
 from axlearn.common.optimizer_base import OptParam, OptStateSpec, PartitionedGradientTransformation
 from axlearn.common.optimizers import (
     ParamEmaState,
@@ -816,29 +817,45 @@ class OptimizerTest(TestCase):
     @parameterized.parameters(100.0, 1e-3)
     def test_clip_by_block_rms(self, max_norm):
         clip = clip_by_block_rms(threshold=max_norm)
-        params = VDict(x=jnp.asarray([[0, 0, 0, 0], [0, 1, 2, -3]], dtype=jnp.float32))
+        params = dict(layer=VDict(x=jnp.asarray([[0, 0, 0, 0], [0, 1, 2, -3]], dtype=jnp.float32)))
         state = clip.init(params)
         self.assertEqual(optax.EmptyState, type(state))
 
         def loss(params):
-            return -jax.nn.log_softmax(params["x"])[:, 1].mean()
+            return -jax.nn.log_softmax(params["layer"]["x"])[:, 1].mean()
 
         loss, grads = jax.value_and_grad(loss)(params)
         assert_allclose(loss, 1.399186)
+        x_grads = grads["layer"]["x"]
         assert_allclose(
-            [[0.125, -0.375, 0.125, 0.125], [0.044814, -0.378182, 0.331136, 0.002231]], grads["x"]
+            [[0.125, -0.375, 0.125, 0.125], [0.044814, -0.378182, 0.331136, 0.002231]], x_grads
         )
 
-        g_norm = jax.vmap(rms_norm)(grads["x"])
+        g_norm = jax.vmap(rms_norm)(x_grads)
         assert_allclose([0.216506, 0.252332], g_norm)
 
-        updates, _ = clip.update(grads, state=state, params=params)
+        context = InvocationContext(
+            name="root",
+            parent=None,
+            module=None,
+            state=None,
+            output_collection=new_output_collection(),
+            is_training=True,
+            prng_key=None,
+        )
+        with set_current_context(context):
+            updates, _ = clip.update(grads, state=state, params=params)
+        x_updates = updates["layer"]["x"]
         if max_norm > 1:
-            np.testing.assert_allclose(updates["x"], grads["x"], atol=1e-6)
+            np.testing.assert_allclose(x_updates, x_grads, atol=1e-6)
         else:
             np.testing.assert_allclose(
-                jax.vmap(rms_norm)(updates["x"]), [max_norm] * 2, atol=1e-6, rtol=1e-6
+                jax.vmap(rms_norm)(x_updates), [max_norm] * 2, atol=1e-6, rtol=1e-6
             )
+        summaries = context.output_collection.summaries
+        self.assertNestedAllClose(
+            {"layer/0/x/norm": g_norm[0], "layer/1/x/norm": g_norm[1]}, summaries
+        )
 
     @parameterized.parameters(100.0, 1e-3)
     def test_scale_by_param_block_rms(self, threshold):

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -254,6 +254,17 @@ def vectorized_tree_map(fn, tree, *rest):
 
 
 def expand_vdicts(tree: NestedTensor) -> NestedTensor:
+    """Expands each VDict in `tree` to a list.
+
+    Args:
+        tree: A nested tree of Tensors. All leaf nodes under a VDict must be tensors with the same
+            dim 0 size.
+
+    Returns:
+        Returns a tree where every VDict is replaced by a list of dicts, where the length of the
+        list equals to the dim 0 size of tensors in the VDict and list element i corresponds to
+        slice i of the VDict tensors. The only exception is empty VDicts, which are not expanded.
+    """
     is_leaf = lambda x: isinstance(x, VDict)
 
     def fn(value: Union[Tensor, VDict]) -> NestedTensor:

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -298,7 +298,7 @@ def expand_vdicts(tree: NestedTensor) -> NestedTensor:
 
         expanded: List[VDict] = []
         for ind in range(vdict_size):
-            value_i: VDict = jax.tree_util.tree_map(lambda x: x[ind], value)
+            value_i: VDict = jax.tree_util.tree_map(lambda x, i=ind: x[i], value)
             expanded_i = {k: expand_vdicts(v) for k, v in value_i.items()}
             expanded.append(expanded_i)
         return expanded

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -265,7 +265,6 @@ def expand_vdicts(tree: NestedTensor) -> NestedTensor:
         list equals to the dim 0 size of tensors in the VDict and list element i corresponds to
         slice i of the VDict tensors. The only exception is empty VDicts, which are not expanded.
     """
-    is_leaf = lambda x: isinstance(x, VDict)
 
     def fn(value: Union[Tensor, VDict]) -> NestedTensor:
         if not isinstance(value, VDict):
@@ -293,7 +292,7 @@ def expand_vdicts(tree: NestedTensor) -> NestedTensor:
         if different_vdict_size_tensors:
             raise ValueError(
                 "Expected a tree of vectorized Tensors of same dim 0, "
-                f"got {different_vdict_size_tensors[0].shape} vs. {vdict_size} in {tree}"
+                f"got {different_vdict_size_tensors[0].shape[0]} vs. {vdict_size} in {tree}"
             )
 
         expanded: List[VDict] = []
@@ -303,7 +302,7 @@ def expand_vdicts(tree: NestedTensor) -> NestedTensor:
             expanded.append(expanded_i)
         return expanded
 
-    return jax.tree_util.tree_map(fn, tree, is_leaf=is_leaf)
+    return jax.tree_util.tree_map(fn, tree, is_leaf=lambda x: isinstance(x, VDict))
 
 
 class StackedKeyArray(NamedTuple):

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -55,6 +55,7 @@ from axlearn.common.utils import (
     count_model_params,
     create_device_mesh,
     dispatch_input_batch,
+    expand_vdicts,
     flatten_items,
     get_data_dir,
     get_recursively,
@@ -174,6 +175,26 @@ class TreeUtilsTest(TestCase):
         d2 = OrderedDict(reversed(kv))
         self.assertEqual([("a", 1), ("b", 2)], sorted(flatten_items(d1)))
         self.assertEqual([("a", 1), ("b", 2)], sorted(flatten_items(d2)))
+
+    def test_expand_vdicts(self):
+        tree = VDict(a=jnp.asarray([1, 2, 3]))
+        self.assertEqual([dict(a=jnp.asarray(i)) for i in (1, 2, 3)], expand_vdicts(tree))
+        with self.assertRaisesRegex(ValueError, "Expected a tree of Tensors"):
+            expand_vdicts(VDict(a="x"))
+        with self.assertRaisesRegex(
+            ValueError, "Expected a tree of vectorized Tensors, got scalar"
+        ):
+            expand_vdicts(VDict(a=jnp.asarray(10)))
+        with self.assertRaisesRegex(
+            ValueError, "Expected a tree of vectorized Tensors of same dim 0"
+        ):
+            expand_vdicts(VDict(a=jnp.asarray([0, 1]), b=jnp.asarray([2, 3, 4])))
+        tree = VDict(a=jnp.asarray([1, 2, 3]), b=VDict(c=jnp.asarray([[4, 5]] * 3)))
+        # Nested VDict.
+        self.assertEqual(
+            [dict(a=jnp.asarray(i), b=[dict(c=jnp.asarray(j)) for j in (4, 5)]) for i in (1, 2, 3)],
+            expand_vdicts(tree),
+        )
 
     def assertTensorEqual(self, a, b):
         self.assertIsInstance(a, jnp.ndarray)

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -177,6 +177,8 @@ class TreeUtilsTest(TestCase):
         self.assertEqual([("a", 1), ("b", 2)], sorted(flatten_items(d2)))
 
     def test_expand_vdicts(self):
+        # An empty VDict is not expanded.
+        self.assertEqual(VDict(), expand_vdicts(VDict()))
         tree = VDict(a=jnp.asarray([1, 2, 3]))
         self.assertEqual([dict(a=jnp.asarray(i)) for i in (1, 2, 3)], expand_vdicts(tree))
         with self.assertRaisesRegex(ValueError, "Expected a tree of Tensors"):


### PR DESCRIPTION
This allows us to track per-variable gradient/update norms by applying clip_by_block_rms with a generous clip threshold.

Adds `utils.expand_vdicts` to expand Tensors in VDicts. This is needed to support applying clip_by_block_rms on parameters of a repeated layer separately on a layer-by-layer basis and reporting norms separately.