### PR TITLE
Fix last pooling dtype

### DIFF
--- a/axlearn/common/poolings.py
+++ b/axlearn/common/poolings.py
@@ -275,7 +275,7 @@ class LastNTokenPooling(BasePoolingLayer):
         # with the flipped input_masks.
         input_masks = input_masks[:, ::-1]
         input_masks_cumsum = input_masks.cumsum(axis=1)[:, ::-1]
-        dispatch = jax.nn.one_hot(input_masks_cumsum - 1, num_outputs)
+        dispatch = jax.nn.one_hot(input_masks_cumsum - 1, num_outputs, dtype=tokens.dtype)
         chosen_tokens = jnp.einsum("bsd,bso->bod", tokens, dispatch)
 
         return chosen_tokens

--- a/axlearn/common/poolings_test.py
+++ b/axlearn/common/poolings_test.py
@@ -293,6 +293,7 @@ class PoolingTest(TestCase):
         # Test w/o mask.
         outputs_expected = inputs[:, -2:][:, ::-1]
         assert_allclose(outputs, outputs_expected, atol=atol)
+        self.assertEqual(outputs.dtype, dtype)
 
         # Test w/ mask.
         paddings = jnp.hstack(
@@ -309,6 +310,7 @@ class PoolingTest(TestCase):
 
         outputs_expected = inputs[:, -3:-1][:, ::-1]
         assert_allclose(outputs, outputs_expected, atol=atol)
+        self.assertEqual(outputs.dtype, dtype)
 
         # Test w/ specific mask.
         inputs = jax.random.normal(input_key, [3, 3, input_dim])
@@ -322,6 +324,7 @@ class PoolingTest(TestCase):
         )
         outputs_expected = jnp.stack((inputs[0, :2], inputs[1, :2], inputs[2, 1:]), axis=0)[:, ::-1]
         assert_allclose(outputs, outputs_expected, atol=atol)
+        self.assertEqual(outputs.dtype, dtype)
 
         # Test w/ invalid masks.
         inputs = jnp.asarray(
@@ -341,11 +344,13 @@ class PoolingTest(TestCase):
             [[[0, 0, 0], [0.1, 0.2, 0.3]], [[0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]]
         )[:, ::-1]
         assert_allclose(outputs, outputs_expected, atol=atol)
+        self.assertEqual(outputs.dtype, dtype)
 
         # Test w/ jit.
         jit_f = jax.jit(pooler.forward)
-        outputs = jit_f(inputs, paddings)
-        assert_allclose(outputs, outputs_expected)
+        outputs = jit_f(inputs.astype(dtype), paddings)
+        assert_allclose(outputs, outputs_expected, atol=atol)
+        self.assertEqual(outputs.dtype, dtype)
 
     @parameterized.parameters(
         itertools.product([1, 2, 3, 4, 5], [jnp.float32, jnp.bfloat16], [8, 10, 12])


### PR DESCRIPTION
Without the fix, the forward of LastNTokenPooling always produces fp32 even with input tokens being bf16.
It was b/c jax.nn.one_hot by default gives fp32 if dtype was not set and jnp.einsum did the auto cast.