### PR TITLE
Allow casting dtype while restoring checkpoints

### DIFF
--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -404,7 +404,22 @@ class TensorStoreStateStorage(StateStorage):
         ckpt_dir: str,
         validation: CheckpointValidationType = CheckpointValidationType.EXACT,
         concurrent_gb: int = 32,
+        dtype: Optional[jnp.dtype] = None,
     ) -> NestedTensor:
+        """Restore checkpoints in tensorstore format from a target directory.
+
+        Args:
+            step (int): Step number to restore.
+            state (Union[NestedTensor, NestedTensorSpec]): Model states.
+            ckpt_dir (str): The path to checkpoint directory.
+            validation (CheckpointValidationType): Validation type after loading weights.
+            concurrent_gb (int): Max concurrent size to load for tensorstore checkpoints.
+            dtype (Optional[jnp.dtype]): Target dtype to cast all tensors.
+                By default, it is None and would infer from index file.
+
+        Returns:
+            NestedTensor: Restored model weights.
+        """
         spec = self._get_spec(step, state, ckpt_dir)
         logging.info("Restoring checkpoint from directory %s", ckpt_dir)
         with tf.io.gfile.GFile(os.path.join(ckpt_dir, "index"), "r") as f:
@@ -416,11 +431,19 @@ class TensorStoreStateStorage(StateStorage):
             spec.tf_ckpt_map, dir=os.path.join(ckpt_dir, f"tf_{jax.process_index()}")
         )
 
+        # Override dtype to target cast dtype.
+        # From jax docs,
+        # Cast while reloading on process to avoid 2 copies on device if the
+        # casting is done on device.
+        spec_dtypes = spec.dtypes
+        if dtype is not None:
+            spec_dtypes = [dtype] * len(spec_dtypes)
+
         restored_gda_values = array_serialization.run_deserialization(
             shardings=spec.shardings,
             tensorstore_specs=spec.tensorstore_specs,
             global_shapes=spec.shapes,
-            dtypes=spec.dtypes,
+            dtypes=spec_dtypes,
             concurrent_gb=concurrent_gb,
         )
         state_leaves = []

--- a/axlearn/common/state_builder.py
+++ b/axlearn/common/state_builder.py
@@ -377,6 +377,9 @@ class TensorStoreStateStorageBuilder(Builder):
         dir: Required[str] = REQUIRED
         validation: CheckpointValidationType = CheckpointValidationType.EXACT
         concurrent_gb: int = 32
+        # Data type to cast when restoring the checkpoint.
+        # By default it is None and dtype from index file will be used.
+        dtype: Optional[jnp.dtype] = None
         # A config that instantiates to a StateStorage.
         storage: StateStorage.Config = TensorStoreStateStorage.default_config()
 
@@ -405,6 +408,7 @@ class TensorStoreStateStorageBuilder(Builder):
             ckpt_dir=cfg.dir,
             validation=cfg.validation,
             concurrent_gb=cfg.concurrent_gb,
+            dtype=cfg.dtype,
         )
         built_keys = state.built_keys.union(set(key for key, _ in flatten_items(restored_state)))
         return Builder.State(step=step, trainer_state=restored_state, built_keys=built_keys)

--- a/axlearn/common/state_builder.py
+++ b/axlearn/common/state_builder.py
@@ -379,7 +379,7 @@ class TensorStoreStateStorageBuilder(Builder):
         concurrent_gb: int = 32
         # Data type to cast when restoring the checkpoint.
         # By default it is None and dtype from index file will be used.
-        dtype: Optional[jnp.dtype] = None
+        dtype_cast_func: Optional[jnp.dtype] = None
         # A config that instantiates to a StateStorage.
         storage: StateStorage.Config = TensorStoreStateStorage.default_config()
 
@@ -400,7 +400,7 @@ class TensorStoreStateStorageBuilder(Builder):
             The restored state.
         """
         cfg = self.config
-        storage = cfg.storage.instantiate()
+        storage: StateStorage = cfg.storage.instantiate()
         step = parse_step_from_dir(cfg.dir)
         restored_state = storage.restore_from_dir(
             step=step,
@@ -408,7 +408,7 @@ class TensorStoreStateStorageBuilder(Builder):
             ckpt_dir=cfg.dir,
             validation=cfg.validation,
             concurrent_gb=cfg.concurrent_gb,
-            dtype=cfg.dtype,
+            dtype_cast_func=cfg.dtype_cast_func,
         )
         built_keys = state.built_keys.union(set(key for key, _ in flatten_items(restored_state)))
         return Builder.State(step=step, trainer_state=restored_state, built_keys=built_keys)


### PR DESCRIPTION
- This allows casting to target dtype when restoring the checkpoint. It is similar to pytorch model with `.to(torch.float16)` or `.to(torch.bfloat16)`