### PR TITLE
Use Peter Novig spell corrector for similar_names

### DIFF
--- a/axlearn/common/config_test.py
+++ b/axlearn/common/config_test.py
@@ -718,6 +718,12 @@ class ConfigTest(parameterized.TestCase):
         self.assertEqual(cfg.dtype, jnp.float32)
         self.assertFalse(hasattr(cfg, not_exist_key))
 
+    def test_similar_names(self):
+        candidates = ["apple", "banana", "cherry"]
+        assert similar_names("appl", candidates) == "apple"
+        assert similar_names("bnna", candidates) == "banana"
+        assert similar_names("chey", candidates) == "cherry"
+
 
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
Guoli Yin pointed me to this code snippet for field name correction. I instantly thought of Peter Novig's spell checker, which is available at https://norvig.com/spell-check.html. This pull request makes advantage of Peter Novig's technique for name suggestions.

I'm preserving the original function name,'similar_names'. However, the new algorithm only suggests one name. I think this makes more sense than suggesting multiple choices because a class's collection of properties is typically far smaller than the English vocabulary, and users may prefer one accurate correction when they misspell.

Please let me know if I mis-interpret the problem here. Thanks!