### PR TITLE
Fixes a bug in dataflow.py that causes stdout, stderr to be None when an error occurs:

### DIFF
--- a/axlearn/cloud/gcp/jobs/dataflow.py
+++ b/axlearn/cloud/gcp/jobs/dataflow.py
@@ -251,7 +251,9 @@ class DataflowJob(GCPJob):
         cmd = f"{cfg.setup_command} && {cmd}"
         cmd = f"bash -c {shlex.quote(cmd)}"
         logging.info("Executing in subprocess: %s", cmd)
-        with subprocess.Popen(cmd, shell=True, text=True) as proc:
+        with subprocess.Popen(
+            cmd, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ) as proc:
             # Attempt to cleanup the process when exiting.
             def sig_handler(sig: int, _):
                 send_signal(proc, sig=sig)


### PR DESCRIPTION
```
RuntimeError: Popen command bash -c '...' returned non-zero exit code 1:
stdout=None
stderr=None
```

According to https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate:

> Note that if you want to send data to the process’s stdin, you need to create the Popen object with stdin=PIPE. Similarly, to get anything other than None in the result tuple, you need to give stdout=PIPE and/or stderr=PIPE too.