### PR TITLE
Refactoring bastion directory related logic

### DIFF
--- a/axlearn/cloud/common/bastion.py
+++ b/axlearn/cloud/common/bastion.py
@@ -882,11 +882,11 @@ class StartBastionJob(CloudJob):
 class BastionDirectory(Configurable):
     """A directory watched by a Bastion.
 
-    submit() writes the job spec to the active job dir watched by the bastion, which will
+    submit_job() writes the job spec to the active job dir watched by the bastion, which will
     start a process on the bastion VM to run the command when resources are ready. The on-bastion
     process usually further creates and watches remote VMs.
 
-    cancel() writes a job state file to the cancel job dir watched by the bastion, which will
+    cancel_job() writes a job state file to the cancel job dir watched by the bastion, which will
     terminate the on-bastion process.
     """
 
@@ -925,7 +925,7 @@ class BastionDirectory(Configurable):
     def user_states_dir(self):
         return os.path.join(self.root_dir, "jobs", "user_states")
 
-    def cancel(self, job_name: str):
+    def cancel_job(self, job_name: str):
         try:
             jobspec = os.path.join(self.active_job_dir, job_name)
             if not tf_io.gfile.exists(jobspec):
@@ -944,7 +944,7 @@ class BastionDirectory(Configurable):
         except ValueError as e:
             logging.info("Failed with error: %s -- Has the job been cancelled already?", e)
 
-    def submit(self, job_name: str, *, job_spec_file: str):
+    def submit_job(self, job_name: str, *, job_spec_file: str):
         dst = os.path.join(self.active_job_dir, job_name)
         if tf_io.gfile.exists(dst):
             logging.info("\n\nNote: Job is already running. To restart it, cancel the job first.\n")

--- a/axlearn/cloud/common/bastion.py
+++ b/axlearn/cloud/common/bastion.py
@@ -902,6 +902,9 @@ class BastionDirectory(Configurable):
     def root_dir(self):
         return self.config.root_dir
 
+    def __str__(self) -> str:
+        return self.root_dir
+
     @property
     def logs_dir(self):
         return os.path.join(self.root_dir, "logs")

--- a/axlearn/cloud/common/bastion.py
+++ b/axlearn/cloud/common/bastion.py
@@ -879,52 +879,60 @@ class StartBastionJob(CloudJob):
         self._bastion.execute()
 
 
-class BastionManagedJob(CloudJob):
-    """A remote job managed by a bastion.
+class BastionDirectory(Configurable):
+    """A directory watched by a Bastion.
 
-    _execute() writes the job spec to the active job dir watched by the bastion, which will
+    submit() writes the job spec to the active job dir watched by the bastion, which will
     start a process on the bastion VM to run the command when resources are ready. The on-bastion
     process usually further creates and watches remote VMs.
 
-    _delete() writes a job state file to the cancel job dir watched by the bastion, which will
+    cancel() writes a job state file to the cancel job dir watched by the bastion, which will
     terminate the on-bastion process.
     """
 
     @config_class
-    class Config(CloudJob.Config):
-        """Configures BastionManagedJob."""
+    class Config(Configurable.Config):
+        """Configures BastionDirectory."""
 
-        # Name of the job. Not to be confused with cfg.name, the bastion name.
-        job_name: Required[str] = REQUIRED
-        # Job spec file local path.
-        job_spec_file: Required[str] = REQUIRED
-        # Output directory used by the bastion. Note that this must be consistent with the output
+        # Directory watched by the bastion. Note that this must be consistent with the output
         # directory used when creating the bastion.
-        bastion_dir: Required[str] = REQUIRED
-
-    @classmethod
-    def default_config(cls):
-        return super().default_config().set(command="")
+        root_dir: Required[str] = REQUIRED
 
     @property
-    def bastion_dir(self):
-        return self.config.bastion_dir
+    def root_dir(self):
+        return self.config.root_dir
 
-    def _job_dir(self):
-        return os.path.join(self.bastion_dir, "jobs")
+    @property
+    def logs_dir(self):
+        return os.path.join(self.root_dir, "logs")
 
-    def _delete(self):
-        cfg: BastionManagedJob.Config = self.config
+    @property
+    def active_job_dir(self):
+        return os.path.join(self.root_dir, "jobs", "active")
+
+    @property
+    def complete_job_dir(self):
+        return os.path.join(self.root_dir, "jobs", "complete")
+
+    @property
+    def job_states_dir(self):
+        return os.path.join(self.root_dir, "jobs", "states")
+
+    @property
+    def user_states_dir(self):
+        return os.path.join(self.root_dir, "jobs", "user_states")
+
+    def cancel(self, job_name: str):
         try:
-            jobspec = os.path.join(self._job_dir(), "active", cfg.job_name)
+            jobspec = os.path.join(self.active_job_dir, job_name)
             if not tf_io.gfile.exists(jobspec):
                 raise ValueError(f"Unable to locate jobspec {jobspec}")
             _upload_job_state(
-                cfg.job_name,
+                job_name,
                 JobState.CANCELLING,
-                remote_dir=os.path.join(self._job_dir(), "user_states"),
+                remote_dir=self.user_states_dir,
             )
-            logging.info("Job %s is cancelling.", cfg.job_name)
+            logging.info("Job %s is cancelling.", job_name)
             # Poll for jobspec to be removed.
             while tf_io.gfile.exists(jobspec):
                 logging.info("Waiting for job to stop (which usually takes a few minutes)...")
@@ -933,11 +941,10 @@ class BastionManagedJob(CloudJob):
         except ValueError as e:
             logging.info("Failed with error: %s -- Has the job been cancelled already?", e)
 
-    def _execute(self):
-        cfg: BastionManagedJob.Config = self.config
-        dst = os.path.join(self._job_dir(), "active", cfg.job_name)
+    def submit(self, job_name: str, *, job_spec_file: str):
+        dst = os.path.join(self.active_job_dir, job_name)
         if tf_io.gfile.exists(dst):
             logging.info("\n\nNote: Job is already running. To restart it, cancel the job first.\n")
         else:
             # Upload the job for bastion to pickup.
-            tf_io.gfile.copy(cfg.job_spec_file, dst)
+            tf_io.gfile.copy(job_spec_file, dst)

--- a/axlearn/cloud/common/bastion_test.py
+++ b/axlearn/cloud/common/bastion_test.py
@@ -870,17 +870,6 @@ class StartBastionJobTest(parameterized.TestCase):
         self.assertTrue(mock_bastion.execute.called)
 
 
-def _mock_submit_config():
-    return bastion.BastionDirectory.default_config().set(
-        name="test",
-        job_name="test-job",
-        job_spec_file="spec",
-        max_tries=1,
-        retry_interval=1,
-        bastion_dir="test-output",
-    )
-
-
 class BastionDirectoryTest(parameterized.TestCase):
     """Tests BastionDirectory."""
 

--- a/axlearn/cloud/common/bastion_test.py
+++ b/axlearn/cloud/common/bastion_test.py
@@ -871,7 +871,7 @@ class StartBastionJobTest(parameterized.TestCase):
 
 
 def _mock_submit_config():
-    return bastion.BastionManagedJob.default_config().set(
+    return bastion.BastionDirectory.default_config().set(
         name="test",
         job_name="test-job",
         job_spec_file="spec",
@@ -881,8 +881,8 @@ def _mock_submit_config():
     )
 
 
-class BastionManagedJobTest(parameterized.TestCase):
-    """Tests BastionManagedJob."""
+class BastionDirectoryTest(parameterized.TestCase):
+    """Tests BastionDirectory."""
 
     @parameterized.parameters(True, False)
     def test_execute(self, spec_exists):

--- a/axlearn/cloud/common/bastion_test.py
+++ b/axlearn/cloud/common/bastion_test.py
@@ -874,7 +874,7 @@ class BastionDirectoryTest(parameterized.TestCase):
     """Tests BastionDirectory."""
 
     @parameterized.parameters(True, False)
-    def test_submit(self, spec_exists):
+    def test_submit_job(self, spec_exists):
         job_name = "test-job"
         job_spec_file = "spec"
         bastion_dir = (
@@ -892,7 +892,7 @@ class BastionDirectoryTest(parameterized.TestCase):
             copy=mock.DEFAULT,
         )
         with patch_tfio as mock_tfio:
-            bastion_dir.submit(job_name, job_spec_file=job_spec_file)
+            bastion_dir.submit_job(job_name, job_spec_file=job_spec_file)
             if not spec_exists:
                 mock_tfio["copy"].assert_called_with(
                     job_spec_file,
@@ -917,7 +917,7 @@ class BastionDirectoryTest(parameterized.TestCase):
             _upload_job_state=mock.DEFAULT,
         )
         with patch_tfio, patch_fns as mock_fns:
-            bastion_dir.cancel(job_name)
+            bastion_dir.cancel_job(job_name)
             if not spec_exists:
                 mock_fns["_upload_job_state"].assert_not_called()
             else:

--- a/axlearn/cloud/common/bastion_test.py
+++ b/axlearn/cloud/common/bastion_test.py
@@ -891,6 +891,12 @@ class BastionDirectoryTest(parameterized.TestCase):
         bastion_dir = (
             bastion.BastionDirectory.default_config().set(root_dir="test-dir").instantiate()
         )
+        self.assertEqual("test-dir", str(bastion_dir))
+        self.assertEqual("test-dir/logs", bastion_dir.logs_dir)
+        self.assertEqual("test-dir/jobs/active", bastion_dir.active_job_dir)
+        self.assertEqual("test-dir/jobs/complete", bastion_dir.complete_job_dir)
+        self.assertEqual("test-dir/jobs/states", bastion_dir.job_states_dir)
+        self.assertEqual("test-dir/jobs/user_states", bastion_dir.user_states_dir)
         patch_tfio = mock.patch.multiple(
             f"{bastion.__name__}.tf_io.gfile",
             exists=mock.MagicMock(return_value=spec_exists),

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -489,7 +489,7 @@ def main(argv: Sequence[str], *, flag_values: flags.FlagValues = FLAGS):
             .set(root_dir=bastion_root_dir(flag_values.name))
             .instantiate()
         )
-        bastion_dir.submit(spec.name, job_spec_file=flag_values.spec)
+        bastion_dir.submit_job(spec.name, job_spec_file=flag_values.spec)
     elif action == "cancel":
         if not flag_values.job_name:
             raise app.UsageError("--job_name must be provided if running 'cancel'.")
@@ -499,7 +499,7 @@ def main(argv: Sequence[str], *, flag_values: flags.FlagValues = FLAGS):
             .set(root_dir=bastion_root_dir(flag_values.name))
             .instantiate()
         )
-        bastion_dir.cancel(flag_values.name)
+        bastion_dir.cancel_job(flag_values.name)
     elif action == "history":
         if flag_values.job_name:
             # Print job history.

--- a/axlearn/cloud/gcp/jobs/bastion_vm_test.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm_test.py
@@ -74,7 +74,9 @@ class CreateBastionJobTest(TestWithTemporaryCWD):
 
         mock_execute = mock.patch.object(job, "_execute_remote_cmd", return_value=None)
         mock_creds = mock.patch.object(job, "_get_job_credentials", return_value=None)
-        mock_output_dir = mock.patch(f"{bastion_vm.__name__}.output_dir", return_value="temp_dir")
+        mock_output_dir = mock.patch(
+            f"{bastion_vm.__name__}.bastion_root_dir", return_value="temp_dir"
+        )
         with mock_output_dir, mock_execute, mock_creds, mock_vm(bastion_vm.__name__) as mocks:
             job._execute()
             self.assertTrue(mocks["create_vm"].called)
@@ -269,7 +271,7 @@ class MainTest(TestWithTemporaryCWD):
             with tempfile.TemporaryDirectory() as temp_dir:
                 if original is not None:
                     set_runtime_options(temp_dir, **original)
-                with mock.patch(f"{bastion_vm.__name__}.output_dir", return_value=temp_dir):
+                with mock.patch(f"{bastion_vm.__name__}.bastion_root_dir", return_value=temp_dir):
                     bastion_vm.main(["cli", "set"], flag_values=fv)
                 return _load_runtime_options(temp_dir)
 

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -83,7 +83,7 @@ from axlearn.cloud.gcp.bundler import with_tpu_extras
 from axlearn.cloud.gcp.config import gcp_settings
 from axlearn.cloud.gcp.job import Job
 from axlearn.cloud.gcp.jobs import tpu_runner
-from axlearn.cloud.gcp.jobs.bastion_vm import output_dir, shared_bastion_name
+from axlearn.cloud.gcp.jobs.bastion_vm import bastion_root_dir, shared_bastion_name
 from axlearn.cloud.gcp.tpu import (
     infer_tpu_cores,
     infer_tpu_version,
@@ -225,7 +225,9 @@ class BaseBastionLaunchJob(Job):
         cfg = self.config
         if not (cfg.instance_type and cfg.output_dir):
             raise ValueError("instance_type, output_dir cannot be empty")
-        self._bastion_dir = cfg.bastion_dir.set(root_dir=output_dir(cfg.bastion_name)).instantiate()
+        self._bastion_dir = cfg.bastion_dir.set(
+            root_dir=bastion_root_dir(cfg.bastion_name)
+        ).instantiate()
 
     def _delete(self):
         """Submits a delete request to bastion."""

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -104,7 +104,7 @@ from axlearn.common.config import (
 FLAGS = flags.FLAGS
 
 
-def _get_bastion_vm(bastion_name: str) -> Dict[str, Any]:
+def _get_bastion_vm(bastion_name: str) -> Optional[Dict[str, Any]]:
     return get_vm_node(bastion_name, _compute_resource(get_credentials()))
 
 

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -235,7 +235,7 @@ class BaseBastionLaunchJob(Job):
 
     def _delete(self):
         """Submits a delete request to bastion."""
-        self._bastion_dir.cancel(self.config.name)
+        self._bastion_dir.cancel_job(self.config.name)
 
     def _list(self, output_file: Optional[TextIO] = None) -> Dict[str, Any]:
         """Lists running jobs and optionally prints them in tabular format.
@@ -336,7 +336,7 @@ class BaseBastionLaunchJob(Job):
                 priority=cfg.priority,
             )
             serialize_jobspec(new_jobspec(name=cfg.name, command=cfg.command, metadata=metadata), f)
-            self._bastion_dir.submit(cfg.name, job_spec_file=f.name)
+            self._bastion_dir.submit_job(cfg.name, job_spec_file=f.name)
         print(
             f"\nStop/cancel the job with:\n"
             f"{infer_cli_name()} gcp launch stop "

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -246,7 +246,6 @@ class BaseBastionLaunchJob(Job):
             * usage_by_project: A dict mapping project_id to (total usage, number of jobs), sorted
                 descending by total usage.
         """
-        cfg = self.config
         with tempfile.TemporaryDirectory() as tmpdir:
             jobs, _ = download_job_batch(
                 spec_dir=self._bastion_dir.active_job_dir,

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -104,6 +104,10 @@ from axlearn.common.config import (
 FLAGS = flags.FLAGS
 
 
+def _get_bastion_vm(bastion_name: str) -> Dict[str, Any]:
+    return get_vm_node(bastion_name, _compute_resource(get_credentials()))
+
+
 class Launcher(NamedTuple):
     """A job launcher.
 
@@ -292,7 +296,7 @@ class BaseBastionLaunchJob(Job):
         """Submits the command to bastion."""
         cfg = self.config
 
-        bastion_node = get_vm_node(cfg.bastion_name, _compute_resource(get_credentials()))
+        bastion_node = _get_bastion_vm(cfg.bastion_name)
         if bastion_node is None or bastion_node.get("status", None) != "RUNNING":
             logging.warning(
                 "Bastion %s does not appear to be running yet. "

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -22,8 +22,8 @@ from axlearn.cloud.gcp.jobs.launch import (
     LaunchTPUJob,
     _get_launcher_or_exit,
     _match_by_regex,
-    output_dir,
 )
+from axlearn.cloud.gcp.jobs.launch import output_dir as bastion_root_dir
 from axlearn.cloud.gcp.test_utils import mock_gcp_settings
 from axlearn.common.config import config_for_function
 from axlearn.common.test_utils import TestWithTemporaryCWD
@@ -100,7 +100,7 @@ class TestBaseBastionLaunchJob(parameterized.TestCase):
 
         class FakeBastionDirectory(BastionDirectory):
             def submit(self, job_name: str, *, job_spec_file: str):
-                test_fixture.assertEqual(self.config.root_dir, output_dir(cfg.bastion_name))
+                test_fixture.assertEqual(self.config.root_dir, bastion_root_dir(cfg.bastion_name))
                 with open(job_spec_file, "r", encoding="utf-8") as f:
                     spec = deserialize_jobspec(f)
                     test_fixture.assertEqual(spec.name, cfg.name)

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -22,8 +22,8 @@ from axlearn.cloud.gcp.jobs.launch import (
     LaunchTPUJob,
     _get_launcher_or_exit,
     _match_by_regex,
+    bastion_root_dir,
 )
-from axlearn.cloud.gcp.jobs.launch import output_dir as bastion_root_dir
 from axlearn.cloud.gcp.test_utils import mock_gcp_settings
 from axlearn.common.config import config_for_function
 from axlearn.common.test_utils import TestWithTemporaryCWD
@@ -204,7 +204,13 @@ class TestBaseBastionLaunchJob(parameterized.TestCase):
                 cleanup_proc=None,
             ),
         }
-        with mock.patch(f"{launch.__name__}.download_job_batch", return_value=(mock_jobs, set())):
+        mock_bastion_root_dir = mock.patch(
+            f"{launch.__name__}.bastion_root_dir", return_value="temp_dir"
+        )
+        mock_download_job_batch = mock.patch(
+            f"{launch.__name__}.download_job_batch", return_value=(mock_jobs, set())
+        )
+        with mock_download_job_batch, mock_bastion_root_dir:
             job = self._mock_config().instantiate()
             out = job._list()
             self.assertEqual(out["jobs"], mock_jobs)

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -22,7 +22,6 @@ from axlearn.cloud.gcp.jobs.launch import (
     LaunchTPUJob,
     _get_launcher_or_exit,
     _match_by_regex,
-    bastion_root_dir,
 )
 from axlearn.cloud.gcp.test_utils import mock_gcp_settings
 from axlearn.common.config import config_for_function

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -122,7 +122,7 @@ class TestBaseBastionLaunchJob(parameterized.TestCase):
 
     def test_start(self):
         mock_get_vm_node = mock.patch(
-            f"{launch.__name__}.get_vm_node", return_value=dict(status="RUNNING")
+            f"{launch.__name__}._get_bastion_vm", return_value=dict(status="RUNNING")
         )
         mock_bastion_root_dir = mock.patch(
             f"{launch.__name__}.bastion_root_dir", return_value="temp_dir"

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -100,7 +100,7 @@ class TestBaseBastionLaunchJob(parameterized.TestCase):
 
         class FakeBastionDirectory(BastionDirectory):
             def submit(self, job_name: str, *, job_spec_file: str):
-                test_fixture.assertEqual(self.config.root_dir, bastion_root_dir(cfg.bastion_name))
+                test_fixture.assertEqual("temp_dir", self.config.root_dir)
                 with open(job_spec_file, "r", encoding="utf-8") as f:
                     spec = deserialize_jobspec(f)
                     test_fixture.assertEqual(spec.name, cfg.name)
@@ -122,8 +122,13 @@ class TestBaseBastionLaunchJob(parameterized.TestCase):
             cfg.instantiate()
 
     def test_start(self):
-        fake_vm_node = dict(status="RUNNING")
-        with mock.patch(f"{launch.__name__}.get_vm_node", return_value=fake_vm_node):
+        mock_get_vm_node = mock.patch(
+            f"{launch.__name__}.get_vm_node", return_value=dict(status="RUNNING")
+        )
+        mock_bastion_root_dir = mock.patch(
+            f"{launch.__name__}.bastion_root_dir", return_value="temp_dir"
+        )
+        with mock_get_vm_node, mock_bastion_root_dir:
             # Test with defaults.
             job = self._mock_config().instantiate()
             job._execute()

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -98,7 +98,7 @@ class TestBaseBastionLaunchJob(parameterized.TestCase):
         test_fixture = self
 
         class FakeBastionDirectory(BastionDirectory):
-            def submit(self, job_name: str, *, job_spec_file: str):
+            def submit_job(self, job_name: str, *, job_spec_file: str):
                 test_fixture.assertEqual("temp_dir", self.config.root_dir)
                 with open(job_spec_file, "r", encoding="utf-8") as f:
                     spec = deserialize_jobspec(f)


### PR DESCRIPTION
* Renames BastionManagedJob to BastionDirectory, since it's not really a Job.
* Removes BastionManagedJob from bastion_vm.py and merge the logic into launch.py.