### PR TITLE
Renames mask to live_targets for cross_entropy_loss and binary_cross_entropy_loss.

### DIFF
--- a/axlearn/common/causal_lm.py
+++ b/axlearn/common/causal_lm.py
@@ -290,7 +290,7 @@ class Model(BaseModel):
         loss, loss_dict = cross_entropy(
             logits=logits,
             target_labels=target_labels,
-            mask=live_targets,
+            live_targets=live_targets,
             z_loss_scale=self.config.z_loss_scale,
         )
         per_token_loss = loss_dict["pre_mask_loss"] * live_targets

--- a/axlearn/common/causal_lm.py
+++ b/axlearn/common/causal_lm.py
@@ -293,7 +293,7 @@ class Model(BaseModel):
             live_targets=live_targets,
             z_loss_scale=self.config.z_loss_scale,
         )
-        per_token_loss = loss_dict["pre_mask_loss"] * live_targets
+        per_token_loss = loss_dict["per_target_loss"] * live_targets
         self.add_summary("accuracy", WeightedScalar(accuracy, num_targets))
         self.add_summary("z_loss", WeightedScalar(loss_dict["z_loss"], num_targets))
         if target_num_bytes is not None:

--- a/axlearn/common/causal_lm_test.py
+++ b/axlearn/common/causal_lm_test.py
@@ -177,7 +177,7 @@ class ModelMetricsTest(TestCase):
         self.assertAlmostEqual(loss, summaries["loss"].mean)
         self.assertEqual(5, summaries["loss"].weight)
         self.assertAlmostEqual(jnp.exp(loss), summaries["perplexity"].mean, places=6)
-        per_token_loss = loss_dict["pre_mask_loss"] * live_targets
+        per_token_loss = loss_dict["per_target_loss"] * live_targets
         total_bytes = target_num_bytes.sum()
         bits_per_byte = per_token_loss.sum() / jnp.maximum(1, total_bytes) / jnp.log(2)
         self.assertAlmostEqual(bits_per_byte, summaries["bits_per_byte"].mean)

--- a/axlearn/common/causal_lm_test.py
+++ b/axlearn/common/causal_lm_test.py
@@ -171,7 +171,7 @@ class ModelMetricsTest(TestCase):
         loss, loss_dict = cross_entropy(
             logits=logits[0],
             target_labels=target_labels[0],
-            mask=live_targets[0],
+            live_targets=live_targets[0],
         )
         self.assertEqual(2.0 / 5, summaries["accuracy"].mean)
         self.assertAlmostEqual(loss, summaries["loss"].mean)

--- a/axlearn/common/encoder_decoder.py
+++ b/axlearn/common/encoder_decoder.py
@@ -161,7 +161,7 @@ class EncoderDecoderModel(BaseEncoderDecoderModel):
             z_loss_scale=cfg.z_loss_scale,
             label_smoothing=cfg.label_smoothing,
         )
-        per_token_loss = loss_dict["pre_mask_loss"] * live_targets
+        per_token_loss = loss_dict["per_target_loss"] * live_targets
         self.add_summary("loss", WeightedScalar(loss, num_targets))
         self.add_summary("perplexity", WeightedScalar(jnp.exp(loss), num_targets))
         self.add_summary("token_accuracy", WeightedScalar(loss_dict["accuracy"], num_targets))

--- a/axlearn/common/encoder_decoder.py
+++ b/axlearn/common/encoder_decoder.py
@@ -157,7 +157,7 @@ class EncoderDecoderModel(BaseEncoderDecoderModel):
         loss, loss_dict = cross_entropy(
             logits=logits,
             target_labels=target_labels,
-            mask=live_targets,
+            live_targets=live_targets,
             z_loss_scale=cfg.z_loss_scale,
             label_smoothing=cfg.label_smoothing,
         )

--- a/axlearn/common/layers.py
+++ b/axlearn/common/layers.py
@@ -1316,7 +1316,7 @@ class ClassificationMetric(BaseClassificationMetric):
 
         loss, all_losses = cross_entropy(
             logits,
-            labels,
+            target_labels=labels,
             mask=mask,
             label_smoothing=cfg.label_smoothing,
             soft_target_labels=soft_labels,
@@ -1379,17 +1379,17 @@ class BinaryClassificationMetric(BaseClassificationMetric):
                 f"Binary classification is only defined for two classes; "
                 f"{cfg.num_classes} were provided"
             )
-        mask = jnp.logical_and(0 <= labels, labels < cfg.num_classes)
-        num_examples = mask.sum()
+        live_targets = jnp.logical_and(0 <= labels, labels < cfg.num_classes)
+        num_examples = live_targets.sum()
         loss, all_losses = binary_cross_entropy(
             logits,
-            labels,
-            mask=mask,
+            target_labels=labels,
+            live_targets=live_targets,
         )
         preds = jnp.where(jnp.greater(nn.sigmoid(logits), cfg.prediction_threshold), 1, 0)
         scores = precision_recall_f_score(
-            y_true=(mask * labels).reshape(-1),
-            y_pred=(mask * preds).reshape(-1),
+            y_true=(live_targets * labels).reshape(-1),
+            y_pred=(live_targets * preds).reshape(-1),
         )
         self.add_summary("precision", scores["precision"])
         self.add_summary("recall", scores["recall"])
@@ -1449,18 +1449,18 @@ class CategoricalHingeLossMetric(BaseClassificationMetric):
 
         pre_mask_loss = categorical_hinge_loss(logits, one_hot_labels)
 
-        mask = jnp.logical_and(0 <= labels, labels < cfg.num_classes)
-        mask = mask.astype(pre_mask_loss.dtype)
-        num_unmasked = mask.sum()
-        denominator = jnp.maximum(1, num_unmasked)
-        loss = (pre_mask_loss * mask).sum() / denominator
+        live_targets = jnp.logical_and(0 <= labels, labels < cfg.num_classes)
+        live_targets = live_targets.astype(pre_mask_loss.dtype)
+        num_live_targets = live_targets.sum()
+        denominator = jnp.maximum(1, num_live_targets)
+        loss = (pre_mask_loss * live_targets).sum() / denominator
 
         predictions = jnp.argmax(logits, axis=-1)
         accuracy = jnp.equal(predictions, labels).sum() / denominator
 
-        self.add_summary("loss", WeightedScalar(loss, num_unmasked))
-        self.add_summary("perplexity", WeightedScalar(jnp.exp(loss), num_unmasked))
-        self.add_summary("accuracy", WeightedScalar(accuracy, num_unmasked))
+        self.add_summary("loss", WeightedScalar(loss, num_live_targets))
+        self.add_summary("perplexity", WeightedScalar(jnp.exp(loss), num_live_targets))
+        self.add_summary("accuracy", WeightedScalar(accuracy, num_live_targets))
 
         return loss
 

--- a/axlearn/common/layers.py
+++ b/axlearn/common/layers.py
@@ -1447,13 +1447,13 @@ class CategoricalHingeLossMetric(BaseClassificationMetric):
 
         one_hot_labels = jax.nn.one_hot(labels, cfg.num_classes)
 
-        pre_mask_loss = categorical_hinge_loss(logits, one_hot_labels)
+        per_target_loss = categorical_hinge_loss(logits, one_hot_labels)
 
         live_targets = jnp.logical_and(0 <= labels, labels < cfg.num_classes)
-        live_targets = live_targets.astype(pre_mask_loss.dtype)
+        live_targets = live_targets.astype(per_target_loss.dtype)
         num_live_targets = live_targets.sum()
         denominator = jnp.maximum(1, num_live_targets)
-        loss = (pre_mask_loss * live_targets).sum() / denominator
+        loss = (per_target_loss * live_targets).sum() / denominator
 
         predictions = jnp.argmax(logits, axis=-1)
         accuracy = jnp.equal(predictions, labels).sum() / denominator

--- a/axlearn/common/layers.py
+++ b/axlearn/common/layers.py
@@ -1311,13 +1311,13 @@ class ClassificationMetric(BaseClassificationMetric):
             A float Tensor represents the loss.
         """
         cfg = self.config
-        mask = jnp.logical_and(0 <= labels, labels < cfg.num_classes)
-        num_examples = mask.sum()
+        live_targets = jnp.logical_and(0 <= labels, labels < cfg.num_classes)
+        num_examples = live_targets.sum()
 
         loss, all_losses = cross_entropy(
             logits,
             target_labels=labels,
-            mask=mask,
+            live_targets=live_targets,
             label_smoothing=cfg.label_smoothing,
             soft_target_labels=soft_labels,
         )

--- a/axlearn/common/loss.py
+++ b/axlearn/common/loss.py
@@ -108,7 +108,7 @@ def cross_entropy(
         target_labels: An int Tensor of shape [...].
             The per-example loss will be 0 if the corresponding target is masked, or out-of-class
             (i.e. target_labels[i] < 0 or target_labels[i] >= num_classes).
-        live_targets: Indicates which example should contribute to the loss.
+        live_targets: Indicates which examples should contribute to the loss.
             A bool or 0/1 Tensor broadcastable to `target_labels`. 1 indicates positions that
             contribute to the loss. If None, infer from 0 <= target_labels < num_classes.
         mask: (deprecated) Used as `live_targets` if `live_targets is None`.
@@ -156,8 +156,7 @@ def cross_entropy(
     if live_targets is None:
         live_targets = jnp.logical_and(0 <= target_labels, target_labels < num_classes)
     live_targets = live_targets.astype(pre_mask_loss.dtype)
-    num_live_targets = live_targets.sum()
-    denominator = jnp.maximum(num_live_targets, 1)
+    denominator = jnp.maximum(live_targets.sum(), 1)
     cross_entropy_loss = (pre_mask_cross_entropy_loss * live_targets).sum() / denominator
     z_loss = (pre_mask_z_loss * live_targets).sum() / denominator
     loss = (pre_mask_loss * live_targets).sum() / denominator
@@ -189,7 +188,7 @@ def binary_cross_entropy(
         logits: A float Tensor of shape [batch_size, d0, ..., dN].
         target_labels: An 0/1 int Tensor of the same shape as `logits`.
             The per-example loss will be 0 if the corresponding target is masked.
-        live_targets: Indicates which example should contribute to the loss.
+        live_targets: Indicates which examples should contribute to the loss.
             A bool or 0/1 Tensor broadcastable to `target_labels`. 1 indicates positions that
             contribute to the loss. If None, infer from 0 <= target_labels < 2.
         mask: (deprecated) Used as `live_targets` if `live_targets is None`.

--- a/axlearn/common/loss.py
+++ b/axlearn/common/loss.py
@@ -1080,7 +1080,7 @@ def negative_cosine_similarity_loss(
     *,
     normalize_embedding: bool = True,
     eps: float = 1e-8,
-    mask: Optional[Tensor] = None,
+    live_targets: Optional[Tensor] = None,
     reduction: ReductionMethod = ReductionMethod.MEAN,
 ) -> Tuple[Tensor, Dict[str, Tensor]]:
     """Compute the negative cross similarity loss between predictions and targets.
@@ -1090,8 +1090,8 @@ def negative_cosine_similarity_loss(
         targets: A float Tensor of shape [..., dim].
         normalize_embedding: If True, apply normalization to embeddings.
         eps: minimum norm for terms in the denominator of the cosine similarity.
-        mask: A bool or 0/1 Tensor of shape [...] indicates the valid positions for computing loss.
-            1 indicates positions that contribute to the loss.
+        live_targets: A bool or 0/1 Tensor of shape [...] indicates the valid positions for
+            computing loss. 1 indicates positions that contribute to the loss.
         reduction: The reduction method.
 
     Returns:
@@ -1110,7 +1110,9 @@ def negative_cosine_similarity_loss(
     elementwise_similarity = targets * predictions
     # Compute cosine_similarity.
     cosine_similarity = jnp.sum(elementwise_similarity, axis=-1)
-    loss = -1 * _reduce_loss(loss=cosine_similarity, reduction=reduction, sample_weight=mask)
+    loss = -1 * _reduce_loss(
+        loss=cosine_similarity, reduction=reduction, sample_weight=live_targets
+    )
     return loss, {
         "cosine_similarity": cosine_similarity,
         "elementwise_similarity": elementwise_similarity,

--- a/axlearn/common/loss.py
+++ b/axlearn/common/loss.py
@@ -86,7 +86,9 @@ def _reduce_loss(
 def cross_entropy(
     logits: Tensor,
     target_labels: Tensor,
-    mask: Tensor = None,
+    *,
+    live_targets: Optional[Tensor] = None,
+    mask: Optional[Tensor] = None,
     z_loss_scale: float = 0.0,
     label_smoothing: float = 0.0,
     soft_target_labels: Optional[Tensor] = None,
@@ -106,9 +108,11 @@ def cross_entropy(
         target_labels: An int Tensor of shape [...].
             The per-example loss will be 0 if the corresponding target is masked, or out-of-class
             (i.e. target_labels[i] < 0 or target_labels[i] >= num_classes).
-        mask: Indicates which example should contribute to the loss.
+        live_targets: Indicates which example should contribute to the loss.
             A bool or 0/1 Tensor broadcastable to `target_labels`. 1 indicates positions that
-            contribute to the loss.
+            contribute to the loss. If None, infer from 0 <= target_labels < num_classes.
+        mask: (deprecated) Used as `live_targets` if `live_targets is None`.
+            Must be None if `live_targets` is specified.
         z_loss_scale: Coefficient for auxilliary z-loss loss term.
         label_smoothing: The factor to control label smoothing.
         soft_target_labels: Optional labels that are already smoothed/in one-hot form. If provided,
@@ -122,7 +126,7 @@ def cross_entropy(
                 loss = cross_entropy_loss + z_loss_scale * z_loss.
             * "cross_entropy_loss": the cross_entropy_loss.
             * "z_loss": the unscaled z_loss.
-            * "pre_mask_loss": the loss across all tokens unmasked.
+            * "pre_mask_loss": the loss per target, of the same shape as `target_labels`.
 
     Raises:
         ValueError: If z_loss_scale is negative.
@@ -144,15 +148,21 @@ def cross_entropy(
     pre_mask_loss, pre_mask_cross_entropy_loss, pre_mask_z_loss = _stable_cross_entropy(
         logits, targets, z_loss_scale
     )
-    if mask is None:
-        mask = jnp.logical_and(0 <= target_labels, target_labels < num_classes)
-    mask = mask.astype(pre_mask_loss.dtype)
-    num_unmasked = jnp.maximum(mask.sum(), 1)
-    cross_entropy_loss = (pre_mask_cross_entropy_loss * mask).sum() / num_unmasked
-    z_loss = (pre_mask_z_loss * mask).sum() / num_unmasked
-    loss = (pre_mask_loss * mask).sum() / num_unmasked
+    if mask is not None:
+        if live_targets is None:
+            live_targets = mask
+        else:
+            raise ValueError("mask and live_targets must not be specified together")
+    if live_targets is None:
+        live_targets = jnp.logical_and(0 <= target_labels, target_labels < num_classes)
+    live_targets = live_targets.astype(pre_mask_loss.dtype)
+    num_live_targets = live_targets.sum()
+    denominator = jnp.maximum(num_live_targets, 1)
+    cross_entropy_loss = (pre_mask_cross_entropy_loss * live_targets).sum() / denominator
+    z_loss = (pre_mask_z_loss * live_targets).sum() / denominator
+    loss = (pre_mask_loss * live_targets).sum() / denominator
     predicted_labels = jnp.argmax(logits, axis=-1)
-    accuracy = (jnp.equal(predicted_labels, target_labels) * mask).sum() / num_unmasked
+    accuracy = (jnp.equal(predicted_labels, target_labels) * live_targets).sum() / denominator
     return loss, {
         "total_loss": loss,
         "z_loss": z_loss,
@@ -164,7 +174,9 @@ def cross_entropy(
 
 def binary_cross_entropy(
     logits: Tensor,
+    *,
     target_labels: Tensor,
+    live_targets: Optional[Tensor] = None,
     mask: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Dict[str, Tensor]]:
     """Compute the binary cross entropy loss between logits and targets.
@@ -175,11 +187,13 @@ def binary_cross_entropy(
 
     Args:
         logits: A float Tensor of shape [batch_size, d0, ..., dN].
-        target_labels: An 0/1 int Tensor of shape [batch_size, d0, ..., dN].
+        target_labels: An 0/1 int Tensor of the same shape as `logits`.
             The per-example loss will be 0 if the corresponding target is masked.
-        mask: Indicates which example should contribute to the loss.
-            A bool or 0/1 Tensor of same shape as batch_size.
-            If None, infer from 0 <= target_labels < 2.
+        live_targets: Indicates which example should contribute to the loss.
+            A bool or 0/1 Tensor broadcastable to `target_labels`. 1 indicates positions that
+            contribute to the loss. If None, infer from 0 <= target_labels < 2.
+        mask: (deprecated) Used as `live_targets` if `live_targets is None`.
+            Must be None if `live_targets` is specified.
 
     Returns:
         (loss, all_losses), where
@@ -191,11 +205,17 @@ def binary_cross_entropy(
     if logits.dtype in (jnp.bfloat16, jnp.float16):
         logits = logits.astype(jnp.float32)
     pre_mask_cross_entropy_loss = sigmoid_cross_entropy_with_logits(logits, target_labels)
-    if mask is None:
-        mask = jnp.logical_and(0 <= target_labels, target_labels < 2)
-    mask = mask.astype(pre_mask_cross_entropy_loss.dtype)
-    num_unmasked = jnp.maximum(mask.sum(), 1)
-    binary_cross_entropy_loss = (pre_mask_cross_entropy_loss * mask).sum() / num_unmasked
+    if mask is not None:
+        if live_targets is None:
+            live_targets = mask
+        else:
+            raise ValueError("mask and live_targets must not be specified together")
+    if live_targets is None:
+        live_targets = jnp.logical_and(0 <= target_labels, target_labels < 2)
+    live_targets = live_targets.astype(pre_mask_cross_entropy_loss.dtype)
+    binary_cross_entropy_loss = (pre_mask_cross_entropy_loss * live_targets).sum() / jnp.maximum(
+        live_targets.sum(), 1
+    )
     return binary_cross_entropy_loss, {
         "binary_cross_entropy_loss": binary_cross_entropy_loss,
         "pre_mask_loss": pre_mask_cross_entropy_loss,

--- a/axlearn/common/loss_test.py
+++ b/axlearn/common/loss_test.py
@@ -86,24 +86,30 @@ def test_accuracy():
             [2, pad_token_id, pad_token_id],
         ]
     )
-    mask = (targets != pad_token_id).astype(jnp.float32)
-    _, loss_dict = cross_entropy(logits, targets, mask=mask)
+    live_targets = (targets != pad_token_id).astype(jnp.float32)
+    _, loss_dict = cross_entropy(logits, targets, live_targets=live_targets)
     assert jnp.allclose(loss_dict["accuracy"], 2 / 3)
 
 
 def test_binary_cross_entropy():
     logits = jnp.asarray([[100.0, 5.0, 0.0], [0.0, 100.0, 25.0], [0.0, 2000.0, 100.0]])
     targets = jnp.asarray([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
-    mask = jnp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
+    live_targets = jnp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
     tf_bce = tf.keras.losses.BinaryCrossentropy(from_logits=True)
     tf_cross_entropy = tf_bce(targets, logits)
-    assert jnp.allclose(binary_cross_entropy(logits, targets, mask)[0], tf_cross_entropy.numpy())
+    assert jnp.allclose(
+        binary_cross_entropy(logits, target_labels=targets, live_targets=live_targets)[0],
+        tf_cross_entropy.numpy(),
+    )
 
     logits = jnp.asarray([[100.0, 5.0, 0.0], [5.0, 100.0, 25.0], [0.0, 2000.0, 100.0]])
     targets = jnp.asarray([[1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 1.0]])
-    mask = jnp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
+    live_targets = jnp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
     tf_cross_entropy = tf_bce(targets, logits)
-    assert jnp.allclose(binary_cross_entropy(logits, targets, mask)[0], tf_cross_entropy.numpy())
+    assert jnp.allclose(
+        binary_cross_entropy(logits, target_labels=targets, live_targets=live_targets)[0],
+        tf_cross_entropy.numpy(),
+    )
 
 
 def test_binary_cross_entropy_zero_loss():
@@ -111,10 +117,13 @@ def test_binary_cross_entropy_zero_loss():
         [[100.0, -100.0, -100.0], [-100.0, 100.0, -100.0], [-100.0, -100.0, 100.0]]
     )
     targets = jnp.asarray([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
-    mask = jnp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
+    live_targets = jnp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
     tf_bce = tf.keras.losses.BinaryCrossentropy(from_logits=True)
     tf_cross_entropy = tf_bce(targets, logits)
-    assert jnp.allclose(binary_cross_entropy(logits, targets, mask)[0], tf_cross_entropy.numpy())
+    assert jnp.allclose(
+        binary_cross_entropy(logits, target_labels=targets, live_targets=live_targets)[0],
+        tf_cross_entropy.numpy(),
+    )
 
 
 def test_cross_entropy_with_label_smoothing():
@@ -160,7 +169,7 @@ def test_cross_entropy_with_less_than_0_z_loss_scale_exception():
 def _standard_cross_entropy(
     logits: Tensor,
     target_labels: Tensor,
-    mask: Tensor = None,
+    live_targets: Tensor = None,
     z_loss_scale: float = 0.0,
     soft_target_labels: Tensor = None,
 ) -> Tensor:
@@ -175,8 +184,8 @@ def _standard_cross_entropy(
         )
     ).sum(axis=-1)
 
-    if mask is None:
-        mask = jnp.logical_and(0 <= target_labels, target_labels < num_classes)
+    if live_targets is None:
+        live_targets = jnp.logical_and(0 <= target_labels, target_labels < num_classes)
     # Z-loss.
     logits_sum = jax.scipy.special.logsumexp(logits, axis=-1, keepdims=True)
     log_z = jnp.squeeze(logits_sum, axis=-1)
@@ -184,8 +193,8 @@ def _standard_cross_entropy(
 
     per_example_loss = cross_entropy_loss + total_z_loss * z_loss_scale
 
-    mask = mask.astype(per_example_loss.dtype)
-    return (per_example_loss * mask).sum() / jnp.maximum(mask.sum(), 1)
+    live_targets = live_targets.astype(per_example_loss.dtype)
+    return (per_example_loss * live_targets).sum() / jnp.maximum(live_targets.sum(), 1)
 
 
 def test_cross_entropy_z_loss():
@@ -229,39 +238,54 @@ def test_cross_entropy_soft_target_with_z_loss_gradient():
     assert jnp.allclose(grad, grad_ref)
 
 
-def test_cross_entropy_mask():
+def test_cross_entropy_live_targets():
     logits = jnp.asarray([[100.0, 0.0, 0.0], [100.0, 0.0, 0.0], [100.0, 0.0, 0.0]])
     targets = jnp.asarray([0, 1, 2])
-    mask = jnp.asarray([1, 0, 0])
+    live_targets = jnp.asarray([1, 0, 0])
     assert cross_entropy(logits, targets)[0] > 0.0
-    assert jnp.allclose(cross_entropy(logits, targets, mask)[0], 0.0)
+    assert jnp.allclose(cross_entropy(logits, targets, live_targets=live_targets)[0], 0.0)
+    # Test legacy mask.
+    assert jnp.allclose(cross_entropy(logits, targets, mask=live_targets)[0], 0.0)
 
 
 # TODO(jbiloki): Convert tf style masking to have attribute _keras_mask
 # to allow internal tf logic to mask requires keras >= 2.11.0.
-def test_binary_cross_entropy_mask():
+def test_binary_cross_entropy_live_targets():
     logits = jnp.asarray([100.0, -100.0, -100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0])
     targets = jnp.asarray([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0])
-    mask = jnp.asarray([1, 1, 1, 0, 0, 0, 1, 1, 0])
+    live_targets = jnp.asarray([1, 1, 1, 0, 0, 0, 1, 1, 0])
     tf_bce = tf.keras.losses.BinaryCrossentropy(from_logits=True)
-    tf_cross_entropy = tf_bce(targets[mask > 0], logits[mask > 0])
-    assert jnp.allclose(binary_cross_entropy(logits, targets, mask)[0], tf_cross_entropy.numpy())
+    tf_cross_entropy = tf_bce(targets[live_targets > 0], logits[live_targets > 0])
+    assert jnp.allclose(
+        binary_cross_entropy(logits, target_labels=targets, live_targets=live_targets)[0],
+        tf_cross_entropy.numpy(),
+    )
+    # Test legacy mask.
+    assert jnp.allclose(
+        binary_cross_entropy(logits, target_labels=targets, mask=live_targets)[0],
+        tf_cross_entropy.numpy(),
+    )
 
     logits = jnp.asarray([100.0, -100.0, -100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0])
     targets = jnp.asarray([10.0, -1.0, -5.0, 0.0, 1.0, 0.0, 3.0, 1.0, 1.0])
-    mask = jnp.logical_and(0 <= targets, targets < 2)
+    live_targets = jnp.logical_and(0 <= targets, targets < 2)
     tf_bce = tf.keras.losses.BinaryCrossentropy(from_logits=True)
-    tf_cross_entropy = tf_bce(targets[mask], logits[mask])
-    assert jnp.allclose(binary_cross_entropy(logits, targets)[0], tf_cross_entropy.numpy())
+    tf_cross_entropy = tf_bce(targets[live_targets], logits[live_targets])
+    assert jnp.allclose(
+        binary_cross_entropy(logits, target_labels=targets)[0], tf_cross_entropy.numpy()
+    )
 
 
 def test_binary_cross_entropy_single():
     logits = jnp.asarray([[100.0], [-100], [100.0]])
     targets = jnp.asarray([[1.0], [0.0], [1.0]])
-    mask = jnp.asarray([[1], [1], [1]])
+    live_targets = jnp.asarray([[1], [1], [1]])
     tf_bce = tf.keras.losses.BinaryCrossentropy(from_logits=True)
     tf_cross_entropy = tf_bce(targets, logits)
-    assert jnp.allclose(binary_cross_entropy(logits, targets, mask)[0], tf_cross_entropy.numpy())
+    assert jnp.allclose(
+        binary_cross_entropy(logits, target_labels=targets, live_targets=live_targets)[0],
+        tf_cross_entropy.numpy(),
+    )
 
 
 def test_cross_entropy_valid_targets():
@@ -291,7 +315,7 @@ def test_cross_entropy_soft_target_labels():
 
 
 @pytest.mark.parametrize(
-    "preds,targets,expected,mask,weights",
+    "preds,targets,expected,live_targets,weights",
     [
         ([], [], WeightedScalar(0, 0), "NaN", None),  # No targets.
         ([jnp.inf], [jnp.nan], WeightedScalar(0, 0), "NaN", None),  # No targets.
@@ -324,21 +348,21 @@ def test_cross_entropy_soft_target_labels():
             WeightedScalar(12, 3),
             [True, False, True],
             [2, 10, 1],
-        ),  # Test mask and weights.
+        ),  # Test live_targets and weights.
     ],
 )
 def test_mean_squared_error(
     preds: Sequence[float],
     targets: Sequence[float],
     expected: WeightedScalar,
-    mask: Optional[Sequence[bool]],
+    live_targets: Optional[Sequence[bool]],
     weights: Optional[Sequence[float]],
 ):
     preds = jnp.asarray(preds)
     targets = jnp.asarray(targets)
     static_argnums = ()
-    if isinstance(mask, (list, tuple)):
-        mask = jnp.asarray(mask)
+    if isinstance(live_targets, (list, tuple)):
+        live_targets = jnp.asarray(live_targets)
     else:
         static_argnums = (2,)
     if weights is not None:
@@ -346,7 +370,7 @@ def test_mean_squared_error(
 
     # Makes sure compat with jit.
     actual = jax.jit(mean_squared_error, static_argnums=static_argnums)(
-        preds, targets, mask, weights
+        preds, targets, live_targets, weights
     )
     if not (jnp.isnan(actual.mean) and jnp.isnan(expected.mean)):
         chex.assert_trees_all_close(actual.mean, expected.mean)

--- a/axlearn/common/loss_test.py
+++ b/axlearn/common/loss_test.py
@@ -974,7 +974,7 @@ def test_giou_loss():
 def test_cosine_similarity_without_mask():
     predictions = np.random.uniform(-1, 1, size=[2, 4, 16]).astype(np.float32)
     targets = np.random.uniform(-1, 1, size=[2, 4, 16]).astype(np.float32)
-    _, aux = negative_cosine_similarity_loss(predictions=predictions, targets=targets, mask=None)
+    _, aux = negative_cosine_similarity_loss(predictions=predictions, targets=targets)
     ref = optax.cosine_similarity(predictions, targets)
     assert jnp.allclose(aux["cosine_similarity"], ref, atol=1e-06)
 
@@ -982,8 +982,10 @@ def test_cosine_similarity_without_mask():
 def test_cosine_similarity_with_mask():
     predictions = np.random.rand(2, 4, 16)
     targets = np.random.rand(2, 4, 16)
-    mask = np.array([[0, 1, 1, 0], [0, 1, 1, 0]])
-    loss, _ = negative_cosine_similarity_loss(predictions=predictions, targets=targets, mask=mask)
+    live_targets = np.array([[0, 1, 1, 0], [0, 1, 1, 0]])
+    loss, _ = negative_cosine_similarity_loss(
+        predictions=predictions, targets=targets, live_targets=live_targets
+    )
     masked_predictions = predictions[:, 1:3, :]
     masked_targets = targets[:, 1:3, :]
     ref = optax.cosine_similarity(masked_predictions, masked_targets)
@@ -994,8 +996,10 @@ def test_cosine_similarity_with_mask():
 def test_negative_cosine_similarity_loss_against_torch():
     predictions = np.random.rand(2, 4, 16)
     targets = np.random.rand(2, 4, 16)
-    mask = np.array([[0, 1, 1, 0], [0, 1, 1, 0]])
-    loss, _ = negative_cosine_similarity_loss(predictions=predictions, targets=targets, mask=mask)
+    live_targets = np.array([[0, 1, 1, 0], [0, 1, 1, 0]])
+    loss, _ = negative_cosine_similarity_loss(
+        predictions=predictions, targets=targets, live_targets=live_targets
+    )
     # Ref torch implementation from:
     # https://github.com/baaivision/EVA/blob/86cf99c50612b11bad39bfcf17899c410a7030d4/eva/engine_for_pretraining.py#L39-L42
     masked_predictions = predictions[:, 1:3, :]

--- a/axlearn/vision/coca.py
+++ b/axlearn/vision/coca.py
@@ -628,7 +628,7 @@ class CoCaCaptioningFusionNetwork(FusionNetwork):
         )  # pytype: disable=attribute-error
 
         # Compute prediction loss.
-        loss, _ = cross_entropy(logits, caption_labels, live_targets)
+        loss, _ = cross_entropy(logits, target_labels=caption_labels, live_targets=live_targets)
 
         # Add training metrics.
         token_accuracy = jnp.equal(jnp.argmax(logits, axis=-1), caption_labels)

--- a/axlearn/vision/masked_image_model.py
+++ b/axlearn/vision/masked_image_model.py
@@ -97,7 +97,7 @@ class MaskedImageModel(BaseModel):
         loss, _ = self.config.loss_fn(
             logits.astype(jnp.float32),
             labels.astype(jnp.float32),
-            mask=is_masked,
+            live_targets=is_masked,
         )
         return loss
 

--- a/axlearn/vision/rcnn_losses.py
+++ b/axlearn/vision/rcnn_losses.py
@@ -134,7 +134,7 @@ class RCNNDetectionMetric(BaseLayer):
             A Tensor represents the final loss. `None` is returned if `labels` is None.
         """
         score_loss = cross_entropy(
-            logits=outputs["class_scores"], target_labels=labels["class_targets"], mask=~paddings
+            logits=outputs["class_scores"], target_labels=labels["class_targets"], live_targets=~paddings
         )[1]["cross_entropy_loss"]
 
         # Box weights to only apply loss on positive samples.

--- a/axlearn/vision/rcnn_losses.py
+++ b/axlearn/vision/rcnn_losses.py
@@ -134,7 +134,9 @@ class RCNNDetectionMetric(BaseLayer):
             A Tensor represents the final loss. `None` is returned if `labels` is None.
         """
         score_loss = cross_entropy(
-            logits=outputs["class_scores"], target_labels=labels["class_targets"], live_targets=~paddings
+            logits=outputs["class_scores"],
+            target_labels=labels["class_targets"],
+            live_targets=~paddings,
         )[1]["cross_entropy_loss"]
 
         # Box weights to only apply loss on positive samples.


### PR DESCRIPTION
Motivation: mask is an ambiguous term and should be avoided. https://twitter.com/ericjang11/status/1739411438148739579