### PR TITLE
Requires flags to be parsed before `gcp_settings` is called.

### DIFF
--- a/axlearn/cloud/common/bundler.py
+++ b/axlearn/cloud/common/bundler.py
@@ -199,7 +199,7 @@ class Bundler(Configurable):
         return temp_dir
 
     @classmethod
-    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> Config:
+    def from_spec(cls, spec: List[str], *, fv: Optional[flags.FlagValues]) -> Config:
         """Converts a spec to a bundler."""
         raise NotImplementedError(cls)
 
@@ -293,7 +293,7 @@ class BaseDockerBundler(Bundler):
             )
 
     @classmethod
-    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> Config:
+    def from_spec(cls, spec: List[str], *, fv: Optional[flags.FlagValues]) -> Config:
         """Converts a spec to a bundler.
 
         Possible options:
@@ -466,7 +466,7 @@ class BaseTarBundler(Bundler):
         editable: bool = False
 
     @classmethod
-    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> Config:
+    def from_spec(cls, spec: List[str], *, fv: Optional[flags.FlagValues]) -> Config:
         """Converts a spec to a bundler.
 
         Possible options:
@@ -582,7 +582,10 @@ class BaseTarBundler(Bundler):
 
 
 def get_bundler_config(
-    *, bundler_type: str, spec: List[str], fv: flags.FlagValues = FLAGS
+    *,
+    bundler_type: str,
+    spec: List[str],
+    fv: Optional[flags.FlagValues] = None,
 ) -> Bundler.Config:
     """Constructs a bundler config from the given spec.
 
@@ -636,9 +639,9 @@ def main_flags():
 
 
 def main(_):
-    cfg = get_bundler_config(bundler_type=FLAGS.bundler_type, spec=FLAGS.bundler_spec).set(
-        exclude=FLAGS.bundler_exclude
-    )
+    cfg = get_bundler_config(
+        bundler_type=FLAGS.bundler_type, spec=FLAGS.bundler_spec, fv=FLAGS
+    ).set(exclude=FLAGS.bundler_exclude)
     bundler = cfg.instantiate()
     bundler.bundle(FLAGS.name)
 

--- a/axlearn/cloud/common/bundler.py
+++ b/axlearn/cloud/common/bundler.py
@@ -199,7 +199,7 @@ class Bundler(Configurable):
         return temp_dir
 
     @classmethod
-    def from_spec(cls, spec: List[str]) -> Config:
+    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> Config:
         """Converts a spec to a bundler."""
         raise NotImplementedError(cls)
 
@@ -293,7 +293,7 @@ class BaseDockerBundler(Bundler):
             )
 
     @classmethod
-    def from_spec(cls, spec: List[str]) -> Config:
+    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> Config:
         """Converts a spec to a bundler.
 
         Possible options:
@@ -466,7 +466,7 @@ class BaseTarBundler(Bundler):
         editable: bool = False
 
     @classmethod
-    def from_spec(cls, spec: List[str]) -> Config:
+    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> Config:
         """Converts a spec to a bundler.
 
         Possible options:
@@ -581,7 +581,9 @@ class BaseTarBundler(Bundler):
         )
 
 
-def get_bundler_config(*, bundler_type: str, spec: List[str]) -> Bundler.Config:
+def get_bundler_config(
+    *, bundler_type: str, spec: List[str], fv: flags.FlagValues = FLAGS
+) -> Bundler.Config:
     """Constructs a bundler config from the given spec.
 
     Bundlers must be registered via `register_bundler`.
@@ -589,12 +591,13 @@ def get_bundler_config(*, bundler_type: str, spec: List[str]) -> Bundler.Config:
     Args:
         bundler_type: Type of bundler class.
         spec: Bundler specs. See the corresponding `from_spec` method of the bundler class.
+        fv: The flag values.
 
     Returns:
         The bundler config.
     """
     if bundler_class := _bundlers.get(bundler_type, None):
-        return bundler_class.from_spec(spec)
+        return bundler_class.from_spec(spec, fv=fv)
     raise NotImplementedError(
         f"Unknown bundler type: {bundler_type}. "
         f"Supported types are {sorted(list(_bundlers.keys()))}"

--- a/axlearn/cloud/common/bundler_test.py
+++ b/axlearn/cloud/common/bundler_test.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from unittest import mock
 
 import toml
+from absl import flags
 from absl.testing import parameterized
 
 from axlearn.cloud.common import bundler, config
@@ -18,6 +19,8 @@ from axlearn.cloud.common.bundler import BaseTarBundler, Bundler, DockerBundler,
 from axlearn.cloud.common.config import CONFIG_DIR, CONFIG_FILE, DEFAULT_CONFIG_FILE
 from axlearn.cloud.common.config_test import create_default_config
 from axlearn.common.test_utils import TestCase, TestWithTemporaryCWD, temp_chdir
+
+FLAGS = flags.FLAGS
 
 
 @contextmanager
@@ -153,6 +156,7 @@ class RegistryTest(TestCase):
                 "external=test_external",
                 "target=test_target",
             ],
+            fv=FLAGS,
         )
         self.assertEqual(cfg.image, "test_image")
         self.assertEqual(cfg.repo, "test_repo")

--- a/axlearn/cloud/common/bundler_test.py
+++ b/axlearn/cloud/common/bundler_test.py
@@ -20,8 +20,6 @@ from axlearn.cloud.common.config import CONFIG_DIR, CONFIG_FILE, DEFAULT_CONFIG_
 from axlearn.cloud.common.config_test import create_default_config
 from axlearn.common.test_utils import TestCase, TestWithTemporaryCWD, temp_chdir
 
-FLAGS = flags.FLAGS
-
 
 @contextmanager
 def _fake_dockerfile():
@@ -156,7 +154,7 @@ class RegistryTest(TestCase):
                 "external=test_external",
                 "target=test_target",
             ],
-            fv=FLAGS,
+            fv=flags.FlagValues(),
         )
         self.assertEqual(cfg.image, "test_image")
         self.assertEqual(cfg.repo, "test_repo")

--- a/axlearn/cloud/gcp/bundler.py
+++ b/axlearn/cloud/gcp/bundler.py
@@ -122,10 +122,10 @@ class CloudBuildBundler(BaseDockerBundler):
     TYPE = "cloudbuild"
 
     @classmethod
-    def default_config(cls):
-        cfg = super().default_config()
-        cfg.repo = gcp_settings("docker_repo", required=False)
-        cfg.dockerfile = gcp_settings("default_dockerfile", required=False)
+    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> BaseDockerBundler.Config:
+        cfg = super().from_spec(spec, fv=fv)
+        cfg.repo = cfg.repo or gcp_settings("docker_repo", required=False, fv=fv)
+        cfg.dockerfile = cfg.dockerfile or gcp_settings("default_dockerfile", required=False, fv=fv)
         return cfg
 
     # pylint: disable-next=no-self-use,unused-argument

--- a/axlearn/cloud/gcp/bundler.py
+++ b/axlearn/cloud/gcp/bundler.py
@@ -72,7 +72,7 @@ class GCSTarBundler(BaseTarBundler):
     TYPE = "gcs"
 
     @classmethod
-    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> "Config":
+    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> BaseTarBundler.Config:
         """Converts a spec to a bundler.
 
         Possible options:

--- a/axlearn/cloud/gcp/bundler.py
+++ b/axlearn/cloud/gcp/bundler.py
@@ -48,7 +48,7 @@ Examples (cloudbuild):
 
 import os
 import subprocess
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from absl import app, flags, logging
 
@@ -72,7 +72,7 @@ class GCSTarBundler(BaseTarBundler):
     TYPE = "gcs"
 
     @classmethod
-    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> BaseTarBundler.Config:
+    def from_spec(cls, spec: List[str], *, fv: Optional[flags.FlagValues]) -> BaseTarBundler.Config:
         """Converts a spec to a bundler.
 
         Possible options:
@@ -98,12 +98,10 @@ class ArtifactRegistryBundler(DockerBundler):
     TYPE = "artifactregistry"
 
     @classmethod
-    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> DockerBundler.Config:
+    def from_spec(cls, spec: List[str], *, fv: Optional[flags.FlagValues]) -> DockerBundler.Config:
         cfg = super().from_spec(spec, fv=fv)
-        if not cfg.repo:
-            cfg.repo = gcp_settings("docker_repo", required=False, fv=fv)
-        if not cfg.dockerfile:
-            cfg.dockerfile = gcp_settings("default_dockerfile", required=False, fv=fv)
+        cfg.repo = cfg.repo or gcp_settings("docker_repo", required=False, fv=fv)
+        cfg.dockerfile = cfg.dockerfile or gcp_settings("default_dockerfile", required=False, fv=fv)
         return cfg
 
     def _build_and_push(self, *args, **kwargs):
@@ -122,7 +120,9 @@ class CloudBuildBundler(BaseDockerBundler):
     TYPE = "cloudbuild"
 
     @classmethod
-    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> BaseDockerBundler.Config:
+    def from_spec(
+        cls, spec: List[str], *, fv: Optional[flags.FlagValues]
+    ) -> BaseDockerBundler.Config:
         cfg = super().from_spec(spec, fv=fv)
         cfg.repo = cfg.repo or gcp_settings("docker_repo", required=False, fv=fv)
         cfg.dockerfile = cfg.dockerfile or gcp_settings("default_dockerfile", required=False, fv=fv)

--- a/axlearn/cloud/gcp/bundler.py
+++ b/axlearn/cloud/gcp/bundler.py
@@ -98,10 +98,12 @@ class ArtifactRegistryBundler(DockerBundler):
     TYPE = "artifactregistry"
 
     @classmethod
-    def default_config(cls):
-        cfg = super().default_config()
-        cfg.repo = gcp_settings("docker_repo", required=False)
-        cfg.dockerfile = gcp_settings("default_dockerfile", required=False)
+    def from_spec(cls, spec: List[str], *, fv: flags.FlagValues) -> DockerBundler.Config:
+        cfg = super().from_spec(spec, fv=fv)
+        if not cfg.repo:
+            cfg.repo = gcp_settings("docker_repo", required=False, fv=fv)
+        if not cfg.dockerfile:
+            cfg.dockerfile = gcp_settings("default_dockerfile", required=False, fv=fv)
         return cfg
 
     def _build_and_push(self, *args, **kwargs):

--- a/axlearn/cloud/gcp/bundler_test.py
+++ b/axlearn/cloud/gcp/bundler_test.py
@@ -2,6 +2,7 @@
 
 """Tests bundling utilities."""
 
+from absl import flags
 from absl.testing import parameterized
 
 from axlearn.cloud.common.bundler import get_bundler_config
@@ -39,6 +40,7 @@ class RegistryTest(TestCase):
 
     @parameterized.parameters(ArtifactRegistryBundler, CloudBuildBundler)
     def test_get_docker_bundler(self, bundler_cls):
+        flags.FLAGS.mark_as_parsed()
         # Test without settings.
         with mock_gcp_settings(bundler.__name__, settings={}):
             cfg = get_bundler_config(

--- a/axlearn/cloud/gcp/bundler_test.py
+++ b/axlearn/cloud/gcp/bundler_test.py
@@ -25,6 +25,7 @@ class RegistryTest(TestCase):
                     # Make sure parent configs can be set from spec.
                     "external=test_external",
                 ],
+                fv=None,
             )
             self.assertEqual(cfg.remote_dir, "test_bucket")
             self.assertEqual(cfg.external, "test_external")
@@ -34,6 +35,7 @@ class RegistryTest(TestCase):
             cfg = get_bundler_config(
                 bundler_type=GCSTarBundler.TYPE,
                 spec=["external=test_external"],
+                fv=None,
             )
             self.assertEqual(cfg.remote_dir, "gs://default_bucket/axlearn/jobs")
             self.assertEqual(cfg.external, "test_external")
@@ -54,6 +56,7 @@ class RegistryTest(TestCase):
                     "external=test_external",
                     "target=test_target",
                 ],
+                fv=None,
             )
             self.assertEqual(cfg.image, "test_image")
             self.assertEqual(cfg.repo, "test_repo")
@@ -77,6 +80,7 @@ class RegistryTest(TestCase):
                     "external=test_external",
                     "target=test_target",
                 ],
+                fv=None,
             )
             self.assertEqual(cfg.image, "test_image")
             self.assertEqual(cfg.repo, "default_repo")

--- a/axlearn/cloud/gcp/bundler_test.py
+++ b/axlearn/cloud/gcp/bundler_test.py
@@ -2,7 +2,6 @@
 
 """Tests bundling utilities."""
 
-from absl import flags
 from absl.testing import parameterized
 
 from axlearn.cloud.common.bundler import get_bundler_config
@@ -42,7 +41,6 @@ class RegistryTest(TestCase):
 
     @parameterized.parameters(ArtifactRegistryBundler, CloudBuildBundler)
     def test_get_docker_bundler(self, bundler_cls):
-        flags.FLAGS.mark_as_parsed()
         # Test without settings.
         with mock_gcp_settings(bundler.__name__, settings={}):
             cfg = get_bundler_config(

--- a/axlearn/cloud/gcp/config.py
+++ b/axlearn/cloud/gcp/config.py
@@ -79,7 +79,6 @@ def gcp_settings(
     if key not in ("project", "zone") and not fv.is_parsed():
         raise RuntimeError(f"fv must be parsed before gcp_settings is called for key: {key}")
     required = required and default is None
-    config_file, configs = config.load_configs(CONFIG_NAMESPACE, required=required)
     flag_values = fv.flag_values_dict()
     project = flag_values.get("project", None)
     if key == "project" and project:
@@ -87,6 +86,7 @@ def gcp_settings(
     zone = flag_values.get("zone", None)
     if key == "zone" and zone:
         return zone
+    config_file, configs = config.load_configs(CONFIG_NAMESPACE, required=required)
     if project and zone:
         config_name = _project_config_key(project, zone)
     else:

--- a/axlearn/cloud/gcp/config.py
+++ b/axlearn/cloud/gcp/config.py
@@ -52,12 +52,12 @@ FLAGS = flags.FLAGS
 CONFIG_NAMESPACE = "gcp"
 
 
-def _flag_values() -> Dict[str, Any]:
-    return FLAGS.flag_values_dict()
-
-
 def gcp_settings(
-    key: str, *, default: Optional[Any] = None, required: bool = True
+    key: str,
+    *,
+    default: Optional[Any] = None,
+    required: bool = True,
+    fv: flags.FlagValues = FLAGS,
 ) -> Optional[str]:
     """Reads a specific value from config file under the "GCP" namespace.
 
@@ -66,20 +66,21 @@ def gcp_settings(
         default: Optional default value to assign, if the field is not set.
             A default is assigned only if the field is None; explicitly falsey values are kept.
         required: Whether we require the field to exist.
+        fv: The flag values, which can override project and zone settings. Must be parsed.
 
     Returns:
         The config value (possibly None if required is False).
 
     Raises:
-        RuntimeError: If FLAGS have not been parsed and the config field value depends on flags.
+        RuntimeError: If `fv` have not been parsed and the config field value depends on flags.
         SystemExit: If a required config could not be read, i.e. the value is None even after
             applying default (if applicable).
     """
-    if key not in ("project", "zone") and not FLAGS.is_parsed():
-        raise RuntimeError(f"FLAGS must be parsed before gcp_settings is called for key: {key}")
+    if key not in ("project", "zone") and not fv.is_parsed():
+        raise RuntimeError(f"fv must be parsed before gcp_settings is called for key: {key}")
     required = required and default is None
     config_file, configs = config.load_configs(CONFIG_NAMESPACE, required=required)
-    flag_values = _flag_values()
+    flag_values = fv.flag_values_dict()
     project = flag_values.get("project", None)
     zone = flag_values.get("zone", None)
     if project and zone:

--- a/axlearn/cloud/gcp/config.py
+++ b/axlearn/cloud/gcp/config.py
@@ -42,7 +42,7 @@ Examples:
 
 import sys
 from functools import partial
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from absl import app, flags, logging
 

--- a/axlearn/cloud/gcp/config.py
+++ b/axlearn/cloud/gcp/config.py
@@ -71,8 +71,9 @@ def gcp_settings(
         The config value (possibly None if required is False).
 
     Raises:
+        RuntimeError: If FLAGS have not been parsed.
         SystemExit: If a required config could not be read, i.e. the value is None even after
-        applying default (if applicable).
+            applying default (if applicable).
     """
     if not FLAGS.is_parsed():
         raise RuntimeError("FLAGS must be parsed before gcp_settings is called.")

--- a/axlearn/cloud/gcp/config.py
+++ b/axlearn/cloud/gcp/config.py
@@ -71,12 +71,12 @@ def gcp_settings(
         The config value (possibly None if required is False).
 
     Raises:
-        RuntimeError: If FLAGS have not been parsed.
+        RuntimeError: If FLAGS have not been parsed and the config field value depends on flags.
         SystemExit: If a required config could not be read, i.e. the value is None even after
             applying default (if applicable).
     """
-    if not FLAGS.is_parsed():
-        raise RuntimeError("FLAGS must be parsed before gcp_settings is called.")
+    if key not in ("project", "zone") and not FLAGS.is_parsed():
+        raise RuntimeError(f"FLAGS must be parsed before gcp_settings is called for key: {key}")
     required = required and default is None
     config_file, configs = config.load_configs(CONFIG_NAMESPACE, required=required)
     flag_values = _flag_values()

--- a/axlearn/cloud/gcp/config.py
+++ b/axlearn/cloud/gcp/config.py
@@ -74,6 +74,8 @@ def gcp_settings(
         SystemExit: If a required config could not be read, i.e. the value is None even after
         applying default (if applicable).
     """
+    if not FLAGS.is_parsed():
+        raise RuntimeError("FLAGS must be parsed before gcp_settings is called.")
     required = required and default is None
     config_file, configs = config.load_configs(CONFIG_NAMESPACE, required=required)
     flag_values = _flag_values()

--- a/axlearn/cloud/gcp/config.py
+++ b/axlearn/cloud/gcp/config.py
@@ -74,7 +74,7 @@ def default_zone():
 def gcp_settings(
     key: str,
     *,
-    fv: Optional[flags.FlagValues],
+    fv: Optional[flags.FlagValues] = FLAGS,
     default: Optional[Any] = None,
     required: bool = True,
 ) -> Optional[str]:

--- a/axlearn/cloud/gcp/config.py
+++ b/axlearn/cloud/gcp/config.py
@@ -82,7 +82,11 @@ def gcp_settings(
     config_file, configs = config.load_configs(CONFIG_NAMESPACE, required=required)
     flag_values = fv.flag_values_dict()
     project = flag_values.get("project", None)
+    if key == "project" and project:
+        return project
     zone = flag_values.get("zone", None)
+    if key == "zone" and zone:
+        return zone
     if project and zone:
         config_name = _project_config_key(project, zone)
     else:

--- a/axlearn/cloud/gcp/config.py
+++ b/axlearn/cloud/gcp/config.py
@@ -53,7 +53,7 @@ CONFIG_NAMESPACE = "gcp"
 
 
 def _gcp_settings_from_active_config(key: str) -> Optional[str]:
-    config_file, configs = config.load_configs(CONFIG_NAMESPACE, required=True)
+    _, configs = config.load_configs(CONFIG_NAMESPACE, required=False)
     config_name = configs.get("_active", None)
     if not config_name:
         return None

--- a/axlearn/cloud/gcp/config_test.py
+++ b/axlearn/cloud/gcp/config_test.py
@@ -24,15 +24,14 @@ class ConfigTest(TestWithTemporaryCWD):
         flags.DEFINE_string("zone", None, "The zone name.", flag_values=flag_values)
         flag_values.project = "test"
         flag_values.zone = "test"
-        print(flag_values.flag_values_dict())
 
         with self.assertRaisesRegex(RuntimeError, expected_regex="fv must be parsed"):
             gcp_config.gcp_settings("bucket", required=False, fv=flag_values)
 
+        flag_values.mark_as_parsed()
+
         self.assertEqual("test", gcp_config.gcp_settings("project", fv=flag_values))
         self.assertEqual("test", gcp_config.gcp_settings("zone", fv=flag_values))
-
-        flag_values.mark_as_parsed()
 
         # By default, should fail because no config file exists.
         with self.assertRaises(SystemExit):
@@ -75,4 +74,38 @@ class ConfigTest(TestWithTemporaryCWD):
         self.assertIsNone(gcp_config.gcp_settings("unknown_key", fv=flag_values, required=False))
 
         # Should succeed.
+        self.assertEqual("test-bucket", gcp_config.gcp_settings("bucket", fv=flag_values))
+
+    def test_gcp_settings_with_active_config(self):
+        temp_dir = os.path.realpath(self._temp_root.name)
+        _setup_fake_repo(temp_dir)
+
+        flag_values = flags.FlagValues()
+        # Flags do not set project/zone.
+        flags.DEFINE_string("project", None, "The project name.", flag_values=flag_values)
+        flags.DEFINE_string("zone", None, "The zone name.", flag_values=flag_values)
+        flag_values.mark_as_parsed()
+
+        # Create a default config, which should get picked up.
+        default_config = create_default_config(temp_dir)
+        # Write some values to the config.
+        config.write_configs_with_header(
+            str(default_config),
+            {
+                gcp_config.CONFIG_NAMESPACE: {
+                    "_active": gcp_config._project_config_key(
+                        project="test-proj", zone="test-zone"
+                    ),
+                    "test-proj:test-zone": {
+                        "project": "test-proj",
+                        "zone": "test-zone",
+                        "bucket": "test-bucket",
+                    },
+                }
+            },
+        )
+
+        # We follow the default config.
+        self.assertEqual("test-proj", gcp_config.gcp_settings("project", fv=flag_values))
+        self.assertEqual("test-zone", gcp_config.gcp_settings("zone", fv=flag_values))
         self.assertEqual("test-bucket", gcp_config.gcp_settings("bucket", fv=flag_values))

--- a/axlearn/cloud/gcp/config_test.py
+++ b/axlearn/cloud/gcp/config_test.py
@@ -16,30 +16,36 @@ from axlearn.common.test_utils import TestWithTemporaryCWD
 class ConfigTest(TestWithTemporaryCWD):
     """Tests config utils."""
 
-    @mock.patch(
-        f"{gcp_config.__name__}._flag_values", return_value={"project": "test", "zone": "test"}
-    )
-    def test_gcp_settings(self, flag_values):
-        del flag_values
-
+    def test_gcp_settings(self):
         temp_dir = os.path.realpath(self._temp_root.name)
         _setup_fake_repo(temp_dir)
 
-        with self.assertRaisesRegex(RuntimeError, expected_regex="FLAGS must be parsed"):
-            gcp_config.gcp_settings("project", required=False)
+        flag_values = flags.FlagValues()
+        flags.DEFINE_string("project", None, "The project name.", flag_values=flag_values)
+        flags.DEFINE_string("zone", None, "The zone name.", flag_values=flag_values)
+        flag_values.project = "test"
+        flag_values.zone = "test"
+        print(flag_values.flag_values_dict())
 
-        flags.FLAGS.mark_as_parsed()
+        with self.assertRaisesRegex(RuntimeError, expected_regex="fv must be parsed"):
+            gcp_config.gcp_settings("bucket", required=False, fv=flag_values)
+
+        self.assertEqual("test", gcp_config.gcp_settings("project", fv=flag_values))
+        self.assertEqual("test", gcp_config.gcp_settings("zone", fv=flag_values))
+
+        flag_values.mark_as_parsed()
 
         # By default, should fail because no config file exists.
         with self.assertRaises(SystemExit):
-            gcp_config.gcp_settings("project")
+            gcp_config.gcp_settings("bucket", fv=flag_values)
 
         # Should not fail if not required.
-        self.assertIsNone(gcp_config.gcp_settings("project", required=False))
+        self.assertIsNone(gcp_config.gcp_settings("bucket", required=False, fv=flag_values))
 
         # Should not fail if a default exists.
         self.assertEqual(
-            "default", gcp_config.gcp_settings("project", required=True, default="default")
+            "default",
+            gcp_config.gcp_settings("bucket", required=True, default="default", fv=flag_values),
         )
 
         # Create a default config, which should get picked up.
@@ -47,23 +53,27 @@ class ConfigTest(TestWithTemporaryCWD):
 
         # Should fail because no config for --project and --zone.
         with self.assertRaises(SystemExit):
-            gcp_config.gcp_settings("project")
+            gcp_config.gcp_settings("bucket", fv=flag_values)
 
         # Should not fail if not required.
-        self.assertIsNone(gcp_config.gcp_settings("project", required=False))
+        self.assertIsNone(gcp_config.gcp_settings("bucket", required=False, fv=flag_values))
 
         # Write some values to the config.
         config.write_configs_with_header(
             str(default_config),
-            {gcp_config.CONFIG_NAMESPACE: {"test:test": {"project": "test", "zone": "test"}}},
+            {
+                gcp_config.CONFIG_NAMESPACE: {
+                    "test:test": {"project": "test", "zone": "test", "bucket": "test-bucket"}
+                }
+            },
         )
 
         # Should fail because key cannot be found.
         with self.assertRaises(SystemExit):
-            gcp_config.gcp_settings("unknown_key")
+            gcp_config.gcp_settings("unknown_key", fv=flag_values)
 
         # Should not fail if not required.
-        self.assertIsNone(gcp_config.gcp_settings("unknown_key", required=False))
+        self.assertIsNone(gcp_config.gcp_settings("unknown_key", fv=flag_values, required=False))
 
         # Should succeed.
-        self.assertEqual(gcp_config.gcp_settings("project"), "test")
+        self.assertEqual("test-bucket", gcp_config.gcp_settings("bucket", fv=flag_values))

--- a/axlearn/cloud/gcp/config_test.py
+++ b/axlearn/cloud/gcp/config_test.py
@@ -86,6 +86,9 @@ class ConfigTest(TestWithTemporaryCWD):
         flags.DEFINE_string("zone", None, "The zone name.", flag_values=flag_values)
         flag_values.mark_as_parsed()
 
+        self.assertIsNone(gcp_config.default_project())
+        self.assertIsNone(gcp_config.default_zone())
+
         # Create a default config, which should get picked up.
         default_config = create_default_config(temp_dir)
         # Write some values to the config.
@@ -93,9 +96,7 @@ class ConfigTest(TestWithTemporaryCWD):
             str(default_config),
             {
                 gcp_config.CONFIG_NAMESPACE: {
-                    "_active": gcp_config._project_config_key(
-                        project="test-proj", zone="test-zone"
-                    ),
+                    "_active": "test-proj:test-zone",
                     "test-proj:test-zone": {
                         "project": "test-proj",
                         "zone": "test-zone",
@@ -104,6 +105,8 @@ class ConfigTest(TestWithTemporaryCWD):
                 }
             },
         )
+        self.assertEqual("test-proj", gcp_config.default_project())
+        self.assertEqual("test-zone", gcp_config.default_zone())
 
         # We follow the default config.
         self.assertEqual("test-proj", gcp_config.gcp_settings("project", fv=flag_values))

--- a/axlearn/cloud/gcp/config_test.py
+++ b/axlearn/cloud/gcp/config_test.py
@@ -3,7 +3,6 @@
 """Tests config utils."""
 
 import os
-from unittest import mock
 
 from absl import flags
 

--- a/axlearn/cloud/gcp/config_test.py
+++ b/axlearn/cloud/gcp/config_test.py
@@ -5,6 +5,8 @@
 import os
 from unittest import mock
 
+from absl import flags
+
 from axlearn.cloud.common import config
 from axlearn.cloud.common.config_test import _setup_fake_repo, create_default_config
 from axlearn.cloud.gcp import config as gcp_config
@@ -22,6 +24,11 @@ class ConfigTest(TestWithTemporaryCWD):
 
         temp_dir = os.path.realpath(self._temp_root.name)
         _setup_fake_repo(temp_dir)
+
+        with self.assertRaisesRegex(RuntimeError, expected_regex="FLAGS must be parsed"):
+            gcp_config.gcp_settings("project", required=False)
+
+        flags.FLAGS.mark_as_parsed()
 
         # By default, should fail because no config file exists.
         with self.assertRaises(SystemExit):

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -511,7 +511,7 @@ def main(argv: Sequence[str], *, flag_values: flags.FlagValues = FLAGS):
     elif action == "history":
         if flag_values.job_name:
             # Print job history.
-            history = _job_history(bastion_name=flag_values.name, job_name=flag_values.job_name)
+            history = _job_history(root_dir=root_dir(), job_name=flag_values.job_name)
         else:
             # Print project history.
             if len(argv) > 2:

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -111,7 +111,7 @@ import shlex
 import subprocess
 import tempfile
 import time
-from typing import Sequence
+from typing import Optional, Sequence
 
 from absl import app, flags, logging
 from tensorflow import io as tf_io
@@ -199,7 +199,7 @@ def _private_flags(flag_values: flags.FlagValues = FLAGS):
     )
 
 
-def shared_bastion_name(fv: flags.FlagValues) -> str:
+def shared_bastion_name(fv: flags.FlagValues) -> Optional[str]:
     # The zone-namespacing is necessary because of quirks with compute API. Specifically, even if
     # creating VMs within a specific zone, names are global. On the other hand, the list API only
     # returns VMs within a zone, so there's no easy way to check if a shared bastion already exists

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -204,13 +204,12 @@ def shared_bastion_name(fv: Optional[flags.FlagValues]) -> Optional[str]:
     # creating VMs within a specific zone, names are global. On the other hand, the list API only
     # returns VMs within a zone, so there's no easy way to check if a shared bastion already exists
     # in another zone.
-    zone = fv.zone or gcp_settings("zone", fv=fv)
+    zone = gcp_settings("zone", fv=fv)
     bastion_name = gcp_settings(  # pytype: disable=bad-return-type
         "bastion_name",
         default=f"{zone}-{_SHARED_BASTION_SUFFIX}",
         fv=fv,
     )
-    # print(f"fv.zone={fv.zone} zone={zone} bastion_name={bastion_name}")
     return bastion_name
 
 

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -199,15 +199,19 @@ def _private_flags(flag_values: flags.FlagValues = FLAGS):
     )
 
 
-def shared_bastion_name(zone: str) -> str:
+def shared_bastion_name(fv: flags.FlagValues) -> str:
     # The zone-namespacing is necessary because of quirks with compute API. Specifically, even if
     # creating VMs within a specific zone, names are global. On the other hand, the list API only
     # returns VMs within a zone, so there's no easy way to check if a shared bastion already exists
     # in another zone.
-    return gcp_settings(  # pytype: disable=bad-return-type
+    zone = fv.zone or gcp_settings("zone", fv=fv)
+    bastion_name = gcp_settings(  # pytype: disable=bad-return-type
         "bastion_name",
         default=f"{zone}-{_SHARED_BASTION_SUFFIX}",
+        fv=fv,
     )
+    # print(f"fv.zone={fv.zone} zone={zone} bastion_name={bastion_name}")
+    return bastion_name
 
 
 def bastion_root_dir(bastion: str) -> str:

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -199,7 +199,7 @@ def _private_flags(flag_values: flags.FlagValues = FLAGS):
     )
 
 
-def shared_bastion_name(fv: flags.FlagValues) -> Optional[str]:
+def shared_bastion_name(fv: Optional[flags.FlagValues]) -> Optional[str]:
     # The zone-namespacing is necessary because of quirks with compute API. Specifically, even if
     # creating VMs within a specific zone, names are global. On the other hand, the list API only
     # returns VMs within a zone, so there's no easy way to check if a shared bastion already exists
@@ -214,7 +214,7 @@ def shared_bastion_name(fv: flags.FlagValues) -> Optional[str]:
     return bastion_name
 
 
-def bastion_root_dir(bastion: str, *, fv: flags.FlagValues) -> str:
+def bastion_root_dir(bastion: str, *, fv: Optional[flags.FlagValues]) -> str:
     """Directory in gs where jobs are recorded."""
     return os.path.join("gs://", gcp_settings("permanent_bucket", fv=fv), bastion)
 

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -130,7 +130,7 @@ from axlearn.cloud.common.quota import QUOTA_CONFIG_PATH, get_resource_limits
 from axlearn.cloud.common.scheduler import JobScheduler
 from axlearn.cloud.common.uploader import Uploader, with_interval
 from axlearn.cloud.common.utils import configure_logging, parse_action
-from axlearn.cloud.gcp.config import gcp_settings
+from axlearn.cloud.gcp.config import default_project, default_zone, gcp_settings
 from axlearn.cloud.gcp.job import CPUJob, docker_command
 from axlearn.cloud.gcp.tpu_cleaner import TPUCleaner
 from axlearn.cloud.gcp.utils import catch_auth, common_flags
@@ -145,8 +145,8 @@ FLAGS = flags.FLAGS
 def _private_flags(flag_values: flags.FlagValues = FLAGS):
     common_flags(flag_values=flag_values)
     bastion_job_flags(flag_values=flag_values)
-    flag_values.set_default("project", gcp_settings("project", required=False))
-    flag_values.set_default("zone", gcp_settings("zone", required=False))
+    flag_values.set_default("project", default_project())
+    flag_values.set_default("zone", default_zone())
 
     flags.DEFINE_string(
         "vm_type", "n2-highmem-128", "Machine spec to boot for VM.", flag_values=flag_values

--- a/axlearn/cloud/gcp/jobs/bastion_vm_test.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm_test.py
@@ -62,6 +62,7 @@ def _mock_create_config():
         max_tries=1,
         retry_interval=1,
         bundler=config_for_function(lambda: mock_bundler),
+        root_dir="temp_dir",
     )
 
 
@@ -74,10 +75,7 @@ class RemoteBastionJobTest(TestWithTemporaryCWD):
 
         mock_execute = mock.patch.object(job, "_execute_remote_cmd", return_value=None)
         mock_creds = mock.patch.object(job, "_get_job_credentials", return_value=None)
-        mock_output_dir = mock.patch(
-            f"{bastion_vm.__name__}.bastion_root_dir", return_value="temp_dir"
-        )
-        with mock_output_dir, mock_execute, mock_creds, mock_vm(bastion_vm.__name__) as mocks:
+        with mock_execute, mock_creds, mock_vm(bastion_vm.__name__) as mocks:
             job._execute()
             self.assertTrue(mocks["create_vm"].called)
             self.assertIn(cfg.name, mocks["create_vm"].call_args.args)

--- a/axlearn/cloud/gcp/jobs/cpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/cpu_runner.py
@@ -129,9 +129,9 @@ class CPURunnerJob(CPUJob):
         cfg = super().from_flags(fv, **kwargs)
         cfg.name = cfg.name or generate_job_name()
         cfg.output_dir = (
-            cfg.output_dir or f"gs://{gcp_settings('ttl_bucket')}/axlearn/jobs/{cfg.name}"
+            cfg.output_dir or f"gs://{gcp_settings('ttl_bucket', fv=fv)}/axlearn/jobs/{cfg.name}"
         )
-        cfg.bundler = get_bundler_config(bundler_type=fv.bundler_type, spec=fv.bundler_spec)
+        cfg.bundler = get_bundler_config(bundler_type=fv.bundler_type, spec=fv.bundler_spec, fv=fv)
         return cfg
 
     def __init__(self, cfg: Config):

--- a/axlearn/cloud/gcp/jobs/cpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/cpu_runner.py
@@ -56,7 +56,7 @@ from absl import app, flags, logging
 from axlearn.cloud.common.bundler import bundler_flags, get_bundler_config
 from axlearn.cloud.common.utils import configure_logging, generate_job_name, parse_action
 from axlearn.cloud.gcp.bundler import GCSTarBundler
-from axlearn.cloud.gcp.config import gcp_settings
+from axlearn.cloud.gcp.config import default_project, default_zone, gcp_settings
 from axlearn.cloud.gcp.job import CPUJob
 from axlearn.cloud.gcp.utils import catch_auth, common_flags, get_credentials, running_from_vm
 from axlearn.cloud.gcp.vm import (
@@ -78,8 +78,8 @@ FLAGS = flags.FLAGS
 def launch_flags(flag_values: flags.FlagValues = FLAGS):
     common_flags(flag_values=flag_values)
     bundler_flags(flag_values=flag_values)
-    flag_values.set_default("project", gcp_settings("project", required=False))
-    flag_values.set_default("zone", gcp_settings("zone", required=False))
+    flag_values.set_default("project", default_project())
+    flag_values.set_default("zone", default_zone())
     flag_values.set_default("bundler_type", GCSTarBundler.TYPE)
     # Note: don't use generate_taskname() here, as the VM may not have $USER.
     flags.DEFINE_string("name", None, "Job name.", flag_values=flag_values)

--- a/axlearn/cloud/gcp/jobs/dataflow.py
+++ b/axlearn/cloud/gcp/jobs/dataflow.py
@@ -96,7 +96,7 @@ from axlearn.cloud.common.utils import (
 )
 from axlearn.cloud.gcp import bundler
 from axlearn.cloud.gcp.bundler import ArtifactRegistryBundler
-from axlearn.cloud.gcp.config import gcp_settings
+from axlearn.cloud.gcp.config import default_project, default_zone, gcp_settings
 from axlearn.cloud.gcp.job import GCPJob
 from axlearn.cloud.gcp.utils import catch_auth, common_flags, get_credentials
 from axlearn.common.config import REQUIRED, Required, config_class
@@ -107,8 +107,8 @@ FLAGS = flags.FLAGS
 def launch_flags(flag_values: flags.FlagValues = FLAGS):
     common_flags(flag_values=flag_values)
     bundler_flags(flag_values=flag_values)
-    flag_values.set_default("project", gcp_settings("project", required=False))
-    flag_values.set_default("zone", gcp_settings("zone", required=False))
+    flag_values.set_default("project", default_project())
+    flag_values.set_default("zone", default_zone())
     flag_values.set_default("bundler_type", ArtifactRegistryBundler.TYPE)
     # Note: don't use generate_taskname() here, as the VM may not have $USER.
     flags.DEFINE_string("name", None, "Dataflow job name.", flag_values=flag_values)

--- a/axlearn/cloud/gcp/jobs/dataflow.py
+++ b/axlearn/cloud/gcp/jobs/dataflow.py
@@ -144,7 +144,7 @@ class DataflowJob(GCPJob):
         cfg.name = cfg.name or generate_job_name()
 
         # Construct bundler.
-        cfg.bundler = get_bundler_config(bundler_type=fv.bundler_type, spec=fv.bundler_spec)
+        cfg.bundler = get_bundler_config(bundler_type=fv.bundler_type, spec=fv.bundler_spec, fv=fv)
         if not issubclass(cfg.bundler.klass, DockerBundler):
             raise NotImplementedError("Expected a DockerBundler.")
         cfg.bundler.image = cfg.bundler.image or cfg.name
@@ -184,14 +184,14 @@ class DataflowJob(GCPJob):
     ) -> Tuple[Dict[str, Any], List[str]]:
         """Returns a flag dict and a list of flags considered as 'multi-flags'."""
         # Construct dataflow args, providing some defaults.
-        service_account = cfg.service_account or gcp_settings("service_account_email")
+        service_account = cfg.service_account or gcp_settings("service_account_email", fv=fv)
         dataflow_spec = {
             "job_name": cfg.name,
             "project": cfg.project,
             "region": cfg.zone.rsplit("-", 1)[0],
             "worker_machine_type": cfg.vm_type,
             "sdk_container_image": f"{cfg.bundler.repo}/{cfg.bundler.image}:{cfg.name}",
-            "temp_location": f"gs://{gcp_settings('ttl_bucket')}/tmp/{cfg.name}/",
+            "temp_location": f"gs://{gcp_settings('ttl_bucket', fv=fv)}/tmp/{cfg.name}/",
             "service_account_email": service_account,
             "dataflow_service_options": ["enable_secure_boot", "enable_google_cloud_heap_sampling"],
             "experiments": ["use_network_tags=allow-internet-egress", "use_runner_v2"],
@@ -211,7 +211,7 @@ class DataflowJob(GCPJob):
         if "network" not in dataflow_spec and "subnetwork" not in dataflow_spec:
             # Following https://cloud.google.com/dataflow/docs/guides/specifying-networks,
             # only --subnetwork is required, and we use the "complete URL" format.
-            subnetwork = gcp_settings("subnetwork")
+            subnetwork = gcp_settings("subnetwork", fv=fv)
             subnetwork_pat = r"projects/.+/regions/.+/subnetworks/.+"
             if not re.match(subnetwork_pat, subnetwork):
                 raise ValueError(

--- a/axlearn/cloud/gcp/jobs/dataflow_test.py
+++ b/axlearn/cloud/gcp/jobs/dataflow_test.py
@@ -37,6 +37,10 @@ def _mock_gcp_settings():
         mock_gcp_settings(module.__name__, settings=mock_settings)
         for module in [dataflow, bundler, cpu_runner]
     ]
+    mocks += [
+        mock.patch(f"{dataflow.__name__}.default_project", return_value="test_project"),
+        mock.patch(f"{dataflow.__name__}.default_zone", return_value="test_zone"),
+    ]
     with contextlib.ExitStack() as stack:
         for m in mocks:
             stack.enter_context(m)

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -219,7 +219,9 @@ class BaseBastionManagedJob(Job):
         cfg = super().from_flags(fv, **kwargs)
         # Construct bundler config only for start.
         if action == "start":
-            cfg.bundler = get_bundler_config(bundler_type=fv.bundler_type, spec=fv.bundler_spec)
+            cfg.bundler = get_bundler_config(
+                bundler_type=fv.bundler_type, spec=fv.bundler_spec, fv=fv
+            )
         cfg.bastion_name = fv.bastion
         return cfg
 

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -215,6 +215,7 @@ class BaseBastionManagedJob(Job):
         cfg = super().from_flags(fv, **kwargs)
         if not cfg.bastion_name:
             cfg.bastion_name = shared_bastion_name(fv)
+        cfg.bastion_dir.root_dir = bastion_root_dir(cfg.bastion_name, fv=fv)
         # Default output_dir depends on the final value of --name.
         if not cfg.output_dir:
             cfg.output_dir = f"gs://{gcp_settings('ttl_bucket', fv=fv)}/axlearn/jobs/{fv.name}"
@@ -230,9 +231,7 @@ class BaseBastionManagedJob(Job):
         cfg = self.config
         if not (cfg.instance_type and cfg.output_dir):
             raise ValueError("instance_type, output_dir cannot be empty")
-        self._bastion_dir = cfg.bastion_dir.set(
-            root_dir=bastion_root_dir(cfg.bastion_name)
-        ).instantiate()
+        self._bastion_dir = cfg.bastion_dir.instantiate()
 
     def _delete(self):
         """Submits a delete request to bastion."""

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -629,6 +629,7 @@ def main(_):
             command = shlex.join(sys.argv[i + 1 :])
             break
     cfg = launcher.job_cls.from_flags(FLAGS, command=command, action=action)
+    logging.info("Launcher config:\n%s", cfg)
     job: BaseBastionManagedJob = cfg.instantiate()
     if FLAGS.dry_run:
         print(f"Action: {action}\nJob config:\n{job.config}")

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -212,17 +212,17 @@ class BaseBastionManagedJob(Job):
         Returns:
             The job config.
         """
-        # Default bastion name depends on the final value of --zone.
-        fv.set_default("bastion", shared_bastion_name(fv.zone))
-        # Default output_dir depends on the final value of --name.
-        fv.set_default("output_dir", f"gs://{gcp_settings('ttl_bucket')}/axlearn/jobs/{fv.name}")
         cfg = super().from_flags(fv, **kwargs)
+        if not cfg.bastion_name:
+            cfg.bastion_name = shared_bastion_name(fv)
+        # Default output_dir depends on the final value of --name.
+        if not cfg.output_dir:
+            cfg.output_dir = f"gs://{gcp_settings('ttl_bucket', fv=fv)}/axlearn/jobs/{fv.name}"
         # Construct bundler config only for start.
         if action == "start":
             cfg.bundler = get_bundler_config(
                 bundler_type=fv.bundler_type, spec=fv.bundler_spec, fv=fv
             )
-        cfg.bastion_name = fv.bastion
         return cfg
 
     def __init__(self, cfg: Config):

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -108,7 +108,7 @@ class TestBaseBastionManagedJob(parameterized.TestCase):
                     test_fixture.assertEqual(spec.metadata.project_id, cfg.project_id or "none")
                     test_fixture.assertEqual(spec.metadata.priority, cfg.priority)
 
-        return cfg.set(bastion_dir=FakeBastionDirectory.default_config())
+        return cfg.set(bastion_dir=FakeBastionDirectory.default_config().set(root_dir="temp_dir"))
 
     @parameterized.parameters(
         dict(output_dir="", instance_type="test", expected=ValueError("output_dir")),
@@ -124,10 +124,7 @@ class TestBaseBastionManagedJob(parameterized.TestCase):
         mock_get_vm_node = mock.patch(
             f"{launch.__name__}._get_bastion_vm", return_value=dict(status="RUNNING")
         )
-        mock_bastion_root_dir = mock.patch(
-            f"{launch.__name__}.bastion_root_dir", return_value="temp_dir"
-        )
-        with mock_get_vm_node, mock_bastion_root_dir:
+        with mock_get_vm_node:
             # Test with defaults.
             job = self._mock_config().instantiate()
             job._execute()
@@ -208,13 +205,10 @@ class TestBaseBastionManagedJob(parameterized.TestCase):
                 cleanup_proc=None,
             ),
         }
-        mock_bastion_root_dir = mock.patch(
-            f"{launch.__name__}.bastion_root_dir", return_value="temp_dir"
-        )
         mock_download_job_batch = mock.patch(
             f"{launch.__name__}.download_job_batch", return_value=(mock_jobs, set())
         )
-        with mock_download_job_batch, mock_bastion_root_dir:
+        with mock_download_job_batch:
             job = self._mock_config().instantiate()
             out = job._list()
             self.assertEqual(out["jobs"], mock_jobs)

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -343,10 +343,11 @@ class TestBastionManagedTPUJob(TestWithTemporaryCWD):
             # Check bastion flag. If None, we should infer from zone in mock_settings.
             if zone is None:
                 self.assertEqual(
-                    cfg.bastion_name, f"{mock_settings['zone']}-{bastion_vm._SHARED_BASTION_SUFFIX}"
+                    f"{mock_settings['zone']}-{bastion_vm._SHARED_BASTION_SUFFIX}",
+                    cfg.bastion_name,
                 )
             else:
-                self.assertEqual(cfg.bastion_name, f"{zone}-{bastion_vm._SHARED_BASTION_SUFFIX}")
+                self.assertEqual(f"{zone}-{bastion_vm._SHARED_BASTION_SUFFIX}", cfg.bastion_name)
 
             # Check output_dir.
             if output_dir is None:

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -297,7 +297,7 @@ class TestBastionManagedTPUJob(TestWithTemporaryCWD):
         mock_settings = {
             "ttl_bucket": "ttl_bucket",
             "permanent_bucket": "permanent_bucket",
-            "zone": "default-zone",
+            "zone": zone or "default-zone",
         }
         patch_settings = mock_gcp_settings(
             [launch.__name__, bastion_vm.__name__, tpu_runner.__name__], settings=mock_settings
@@ -319,7 +319,7 @@ class TestBastionManagedTPUJob(TestWithTemporaryCWD):
             # Check some basic flags.
             self.assertEqual(fv.bastion, None)
             self.assertEqual(fv.name, name or "job-name")
-            self.assertEqual(fv.zone, zone or "default-zone")
+            self.assertEqual(fv.zone, zone)
             self.assertIn("tpu_type", fv)
             self.assertIn("bundler_type", fv)
             self.assertIsNotNone(fv["name"].default)

--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -182,10 +182,10 @@ class TPURunnerJob(TPUJob):
         cfg.name = cfg.name or generate_job_name()
         cfg.env_vars = {**cfg.env_vars, **parse_kv_flags(fv.env)}
         cfg.output_dir = (
-            cfg.output_dir or f"gs://{gcp_settings('ttl_bucket')}/axlearn/jobs/{cfg.name}"
+            cfg.output_dir or f"gs://{gcp_settings('ttl_bucket', fv=fv)}/axlearn/jobs/{cfg.name}"
         )
         cfg.bundler = with_tpu_extras(
-            get_bundler_config(bundler_type=fv.bundler_type, spec=fv.bundler_spec)
+            get_bundler_config(bundler_type=fv.bundler_type, spec=fv.bundler_spec, fv=fv)
         )
         return cfg
 

--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -550,7 +550,7 @@ def with_tpu_training_defaults(
         TENSORSTORE_CURL_LOW_SPEED_LIMIT_BYTES=256,
     )
     vertexai_tb_uploader = None
-    if is_vertexai_tensorboard_configured():
+    if is_vertexai_tensorboard_configured(flag_values=flag_values):
         vertexai_tb_uploader = VertexAITensorboardUploader.default_config()
 
     return cfg.set(

--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -74,7 +74,7 @@ from axlearn.cloud.common.utils import (
     parse_kv_flags,
 )
 from axlearn.cloud.gcp.bundler import GCSTarBundler, with_tpu_extras
-from axlearn.cloud.gcp.config import gcp_settings
+from axlearn.cloud.gcp.config import default_project, default_zone, gcp_settings
 from axlearn.cloud.gcp.job import TPUJob, docker_command
 from axlearn.cloud.gcp.scopes import DEFAULT_TPU_SCOPES
 from axlearn.cloud.gcp.tpu import (
@@ -104,8 +104,8 @@ _COMMAND_SESSION_NAME = "command"
 def launch_flags(flag_values: flags.FlagValues = FLAGS):
     common_flags(flag_values=flag_values)
     bundler_flags(flag_values=flag_values)
-    flag_values.set_default("project", gcp_settings("project", required=False))
-    flag_values.set_default("zone", gcp_settings("zone", required=False))
+    flag_values.set_default("project", default_project())
+    flag_values.set_default("zone", default_zone())
     flag_values.set_default("bundler_type", GCSTarBundler.TYPE)
     # Note: don't use generate_job_name() here, as the VM may not have $USER.
     flags.DEFINE_string("name", None, "Job name.", flag_values=flag_values)

--- a/axlearn/cloud/gcp/test_utils.py
+++ b/axlearn/cloud/gcp/test_utils.py
@@ -17,8 +17,7 @@ def mock_gcp_settings(module_name: Union[str, Sequence[str]], settings: Dict[str
         required: bool = True,
         fv: flags.FlagValues = flags.FLAGS,
     ):
-        if key not in ("project", "zone") and not fv.is_parsed():
-            raise RuntimeError(f"fv must be parsed before gcp_settings is called for key: {key}")
+        del fv
         value = settings.get(key, default)
         if required and value is None:
             raise ValueError(f"{key} is required")

--- a/axlearn/cloud/gcp/test_utils.py
+++ b/axlearn/cloud/gcp/test_utils.py
@@ -13,9 +13,10 @@ from absl import flags
 def mock_gcp_settings(module_name: Union[str, Sequence[str]], settings: Dict[str, str]):
     def gcp_settings(
         key: str,
+        *,
+        fv: Optional[flags.FlagValues] = None,
         default: Optional[Any] = None,
         required: bool = True,
-        fv: flags.FlagValues = flags.FLAGS,
     ):
         del fv
         value = settings.get(key, default)

--- a/axlearn/cloud/gcp/test_utils.py
+++ b/axlearn/cloud/gcp/test_utils.py
@@ -6,10 +6,19 @@ import contextlib
 from typing import Any, Dict, Optional, Sequence, Union
 from unittest import mock
 
+from absl import flags
+
 
 @contextlib.contextmanager
 def mock_gcp_settings(module_name: Union[str, Sequence[str]], settings: Dict[str, str]):
-    def gcp_settings(key: str, default: Optional[Any] = None, required: bool = True):
+    def gcp_settings(
+        key: str,
+        default: Optional[Any] = None,
+        required: bool = True,
+        fv: flags.FlagValues = flags.FLAGS,
+    ):
+        if key not in ("project", "zone") and not fv.is_parsed():
+            raise RuntimeError(f"fv must be parsed before gcp_settings is called for key: {key}")
         value = settings.get(key, default)
         if required and value is None:
             raise ValueError(f"{key} is required")

--- a/axlearn/cloud/gcp/vertexai_tensorboard.py
+++ b/axlearn/cloud/gcp/vertexai_tensorboard.py
@@ -5,7 +5,7 @@
 import multiprocessing
 import re
 
-from absl import logging
+from absl import flags, logging
 
 try:
     from google.cloud.aiplatform import initializer
@@ -40,12 +40,12 @@ def _vertexai_experiment_name_from_output_dir(output_dir: str) -> str:
     return experiment_name
 
 
-def is_vertexai_tensorboard_configured() -> bool:
+def is_vertexai_tensorboard_configured(*, flag_values: flags.FlagValues) -> bool:
     """Checks the config to see whether VertexAI Tensorboard should be enabled."""
     return _VERTEXAI_INSTALLED and bool(
-        gcp_config.gcp_settings("vertexai_tensorboard", required=False)
-        and gcp_config.gcp_settings("vertexai_region", required=False)
-        and gcp_config.gcp_settings("project", required=False)
+        gcp_config.gcp_settings("vertexai_tensorboard", required=False, fv=flag_values)
+        and gcp_config.gcp_settings("vertexai_region", required=False, fv=flag_values)
+        and gcp_config.gcp_settings("project", required=False, fv=flag_values)
     )
 
 


### PR DESCRIPTION
Motivation: the axlearn CLI sometimes does not respect the --zone flag. This often happens when gcp_settings is called before the --zone flag is parsed.

Since the return value of gcp_settings depends on flag values, it is more principled if we require the flag values to be parsed before gcp_settings can be called.

This PR fixes two common patterns of gcp_settings usage to set flag default values and config field default values. Instead, we set the default to None and call gcp_settings in from_flags or from_spec.