### PR TITLE
Deprecate legacy TPU API and switch to persistent discovery resource.

### DIFF
--- a/axlearn/cloud/gcp/job.py
+++ b/axlearn/cloud/gcp/job.py
@@ -4,6 +4,7 @@
 
 Note that these utilities do not handle resource management.
 """
+
 import atexit
 import logging
 import os
@@ -18,7 +19,7 @@ from google.auth.credentials import Credentials
 from axlearn.cloud.common.job import Job
 from axlearn.cloud.common.utils import subprocess_run
 from axlearn.cloud.gcp.scopes import DEFAULT_TPU_SCOPES
-from axlearn.cloud.gcp.tpu import _qrm_resource, _tpu_resource, get_queued_tpu_node, get_tpu_node
+from axlearn.cloud.gcp.tpu import get_queued_tpu_node, get_tpu_node, qrm_resource, tpu_resource
 from axlearn.cloud.gcp.utils import get_credentials, running_from_vm
 from axlearn.common.config import REQUIRED, Required, config_class
 
@@ -53,7 +54,8 @@ class GCPJob(Job):
             The temporary credentials, possibly impersonating `cfg.service_account`.
         """
         return get_credentials(
-            impersonate_account=self.config.service_account, impersonate_scopes=impersonate_scopes
+            impersonate_account=self.config.service_account,
+            impersonate_scopes=impersonate_scopes,
         )
 
 
@@ -92,12 +94,12 @@ class TPUJob(GCPJob):
             if cfg.num_slices > 1:
                 node = get_queued_tpu_node(
                     cfg.name,
-                    _qrm_resource(self._get_job_credentials(DEFAULT_TPU_SCOPES)),
+                    qrm_resource(self._get_job_credentials(DEFAULT_TPU_SCOPES)),
                 )
             else:
                 node = get_tpu_node(
                     cfg.name,
-                    _tpu_resource(self._get_job_credentials(DEFAULT_TPU_SCOPES)),
+                    tpu_resource(self._get_job_credentials(DEFAULT_TPU_SCOPES)),
                 )
             if node is None:
                 raise ValueError(f"Expected TPU {cfg.name} to exist")

--- a/axlearn/cloud/gcp/jobs/dataflow_test.py
+++ b/axlearn/cloud/gcp/jobs/dataflow_test.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 """Tests dataflow launch."""
+
 import contextlib
 from unittest import mock
 
@@ -56,15 +57,6 @@ def _mock_flags():
     return fv
 
 
-def _mock_dataflow(module_name: str):
-    return mock.patch.multiple(
-        module_name,
-        get_credentials=mock.MagicMock(),
-        _dataflow_resource=mock.MagicMock(),
-        _get_dataflow_jobs=mock.MagicMock(),
-    )
-
-
 class DataflowJobTest(TestWithTemporaryCWD):
     def test_from_flags_bundler(self):
         with _mock_gcp_settings():
@@ -91,14 +83,16 @@ class DataflowJobTest(TestWithTemporaryCWD):
             self.assertEqual(settings["project"], dataflow_spec["project"])
             self.assertEqual(settings["zone"], dataflow_spec["region"])
             self.assertEqual(
-                settings["service_account_email"], dataflow_spec["service_account_email"]
+                settings["service_account_email"],
+                dataflow_spec["service_account_email"],
             )
             self.assertEqual(
                 f"{settings['docker_repo']}/test_image:test_name",
                 dataflow_spec["sdk_container_image"],
             )
             self.assertEqual(
-                f"gs://{settings['ttl_bucket']}/tmp/test_name/", dataflow_spec["temp_location"]
+                f"gs://{settings['ttl_bucket']}/tmp/test_name/",
+                dataflow_spec["temp_location"],
             )
             self.assertEqual(
                 f"https://www.googleapis.com/compute/v1/{settings['subnetwork']}",
@@ -112,7 +106,11 @@ class DataflowJobTest(TestWithTemporaryCWD):
             # Test overridding specs (including a multi-flag)
             fv.set_default(
                 "dataflow_spec",
-                ["project=other_project", "temp_location=other_location", "experiments=exp1,exp2"],
+                [
+                    "project=other_project",
+                    "temp_location=other_location",
+                    "experiments=exp1,exp2",
+                ],
             )
             cfg = DataflowJob.from_flags(fv)
             # pylint: disable-next=protected-access

--- a/axlearn/cloud/gcp/jobs/tpu_runner_test.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner_test.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 """Tests TPU runner job."""
+
 # pylint: disable=protected-access
 import contextlib
 import os
@@ -55,11 +56,10 @@ def mock_tpu(module_name: str, running_from_vm: bool = True):
         ]
 
     mocks = {
-        "create_tpu": mock_create_tpu,
-        "get_tpu_node": mock_get_tpu_node,
+        "create_queued_tpu": mock_create_tpu,
         "get_queued_tpu_node": mock_get_tpu_node,
-        "_tpu_resource": mock_tpu_resource,
-        "delete_tpu": mock_delete_tpu,
+        "tpu_resource": mock_tpu_resource,
+        "delete_queued_tpu": mock_delete_tpu,
         "running_from_vm": mock_running_from_vm,
         "list_tpu_info": mock_list_tpu_info,
     }
@@ -189,11 +189,11 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
             tpu_runner.__name__, running_from_vm
         ) as mocks:
             # Create a dummy TPU.
-            mocks["create_tpu"](cfg.name)
+            mocks["create_queued_tpu"](cfg.name)
             # Issue start command.
             job._start()
-            mocks["delete_tpu"].assert_called()
-            mocks["create_tpu"].assert_called()
+            mocks["delete_queued_tpu"].assert_called()
+            mocks["create_queued_tpu"].assert_called()
             # Bundling should happen if not on VM.
             self.assertEqual(not running_from_vm, job._bundler.bundle.called)
 
@@ -206,11 +206,11 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
 
         with mock_credentials, mock_tpu(tpu_runner.__name__) as mocks, mock_execute as mock_exec:
             # Create a dummy TPU.
-            mocks["create_tpu"](cfg.name)
+            mocks["create_queued_tpu"](cfg.name)
             job._delete()
             # Outputs should be copied. call_args get the args of the last call.
             self.assertIn("gsutil cp", mock_exec.call_args.args[0])
-            self.assertIn(cfg.name, mocks["delete_tpu"].call_args.args)
+            self.assertIn(cfg.name, mocks["delete_queued_tpu"].call_args.args)
 
     def test_get_status(self):
         mocks = [

--- a/axlearn/cloud/gcp/tpu_cleaner_test.py
+++ b/axlearn/cloud/gcp/tpu_cleaner_test.py
@@ -47,6 +47,8 @@ class TestTPUCleaner(parameterized.TestCase):
 
         module_name = tpu_cleaner.__name__
         mocks = [
+            mock.patch(f"{module_name}.qrm_resource", return_value=mock.MagicMock()),
+            mock.patch(f"{module_name}.tpu_resource", return_value=mock.MagicMock()),
             mock.patch(f"{module_name}.get_credentials", side_effect=mock_get_credentials),
             mock.patch(f"{module_name}.list_tpu_info", side_effect=mock_list_tpu_info),
             mock.patch(

--- a/axlearn/cloud/gcp/tpu_test.py
+++ b/axlearn/cloud/gcp/tpu_test.py
@@ -13,7 +13,7 @@ from axlearn.cloud.gcp.tpu import (
     QueuedResourceInfo,
     TPUCreationError,
     TpuInfo,
-    _create_multislice_tpu,
+    create_queued_tpu,
     format_queued_resource_info,
     format_tpu_info,
     infer_tpu_cores,
@@ -199,7 +199,7 @@ class TpuUtilsTest(parameterized.TestCase):
             list_blobs=[2, 2, 2],
         ),
     )
-    def test_create_multislice_tpu(self, nodes, list_blobs, expected=None):
+    def test_create_queued_tpu(self, nodes, list_blobs, expected=None):
         module = tpu.__name__
         # Mock sleep to finish instantly.
         mock_sleep = mock.patch(f"{module}.time.sleep")
@@ -207,7 +207,7 @@ class TpuUtilsTest(parameterized.TestCase):
             module,
             get_queued_tpu_node=mock.Mock(side_effect=nodes),
             _execute_create_tpu_request=mock.Mock(),
-            _delete_multislice_tpu=mock.Mock(),
+            delete_queued_tpu=mock.Mock(),
             list_blobs=mock.Mock(side_effect=[list(range(x)) for x in list_blobs]),
         )
         mock_settings = mock_gcp_settings(
@@ -222,9 +222,9 @@ class TpuUtilsTest(parameterized.TestCase):
 
             with ctx:
                 assert infer_tpu_workers("v4-16") == 2
-                _create_multislice_tpu(
+                create_queued_tpu(
                     "test",
+                    mock.Mock(),
                     tpu_type="v4-16",  # 2 workers.
-                    credentials=mock.Mock(),
                     bundler_type="test-bundler",
                 )

--- a/axlearn/cloud/gcp/utils.py
+++ b/axlearn/cloud/gcp/utils.py
@@ -75,13 +75,20 @@ def running_from_vm() -> bool:
     return (out.returncode == 0) and "Metadata-Flavor: Google" in out.stdout
 
 
-def is_valid_resource_name(name: Optional[str]) -> bool:
+def validate_resource_name(name: Optional[str]) -> bool:
     """Validates names (e.g. TPUs, VMs, jobs) to ensure compat with GCP.
 
     Reference:
     https://cloud.google.com/compute/docs/naming-resources#resource-name-format
+
+    Raises:
+        ValueError: If name is invalid.
     """
-    return name is not None and re.fullmatch(r"^[a-z]([-a-z0-9]*[a-z0-9])?", name) is not None
+    if name is None or len(name) > 63 or re.fullmatch(r"^[a-z]([-a-z0-9]*[a-z0-9])?", name) is None:
+        raise ValueError(
+            f"{name} is not a valid resource name. Please see "
+            "https://cloud.google.com/compute/docs/naming-resources#resource-name-format."
+        )
 
 
 def catch_auth(fn):

--- a/axlearn/cloud/gcp/utils_test.py
+++ b/axlearn/cloud/gcp/utils_test.py
@@ -11,9 +11,14 @@ class UtilsTest(parameterized.TestCase):
     """Tests utils."""
 
     @parameterized.parameters(
-        dict(name="test--01-exp123", expected=True),
-        dict(name="123-test", expected=False),  # Must begin with letter.
-        dict(name="test+123", expected=False),  # No other special characters allowed.
+        dict(name="test--01-exp123", should_raise=False),
+        dict(name="123-test", should_raise=True),  # Must begin with letter.
+        dict(name="test+123", should_raise=True),  # No other special characters allowed.
+        dict(name="a" * 64, should_raise=True),  # Too long.
     )
-    def test_is_valid_resource_name(self, name: str, expected: bool):
-        self.assertEqual(expected, utils.is_valid_resource_name(name))
+    def test_validate_resource_name(self, name: str, should_raise: bool):
+        if should_raise:
+            with self.assertRaises(ValueError):
+                utils.validate_resource_name(name)
+        else:
+            utils.validate_resource_name(name)

--- a/axlearn/cloud/gcp/vm.py
+++ b/axlearn/cloud/gcp/vm.py
@@ -15,7 +15,7 @@ from googleapiclient import discovery, errors
 from axlearn.cloud.common.docker import registry_from_repo
 from axlearn.cloud.common.utils import format_table
 from axlearn.cloud.gcp.config import gcp_settings
-from axlearn.cloud.gcp.utils import infer_cli_name, is_valid_resource_name
+from axlearn.cloud.gcp.utils import infer_cli_name, validate_resource_name
 
 
 class VMCreationError(RuntimeError):
@@ -54,8 +54,7 @@ def create_vm(
         VMCreationError: If an exeption is raised on the creation request.
         ValueError: If an invalid name is provided.
     """
-    if not is_valid_resource_name(name):
-        raise ValueError(f"{name} is not a valid resource name.")
+    validate_resource_name(name)
     resource = _compute_resource(credentials)
     attempt = 0
     while True:


### PR DESCRIPTION
By default constructing a discovery resource seems to create a new http object, which combined with cache_discovery=False means we're making an extra connection which is discarded each time we construct a resource.

Instead, we construct and reuse the same resource in most of the APIs in tpu_runner.