### PR TITLE
Fix retrieving VM info.

### DIFF
--- a/axlearn/cloud/gcp/vm.py
+++ b/axlearn/cloud/gcp/vm.py
@@ -330,16 +330,21 @@ def get_vm_node(name: str, resource: discovery.Resource) -> Optional[Dict[str, A
     Returns:
         The VM with the given name, or None if it doesn't exist.
     """
-    up_nodes = (
-        resource.instances()
-        .list(
-            project=gcp_settings("project"),
-            zone=gcp_settings("zone"),
+    try:
+        node = (
+            resource.instances()
+            .get(
+                project=gcp_settings("project"),
+                zone=gcp_settings("zone"),
+                instance=name,
+            )
+            .execute()
         )
-        .execute()
-    )
-    nodes = [el for el in up_nodes.get("items", {}) if el.get("name", "").split("/")[-1] == name]
-    return None if not nodes else nodes.pop()
+    except errors.HttpError as e:
+        if e.status_code == 404:
+            return None
+        raise
+    return node
 
 
 def list_disk_images(creds: Credentials) -> List[str]:


### PR DESCRIPTION
In some cases, VMs will incorrectly report None with get_vm_node -- this is because list has an implicit limit of 500 VMs. Instead, we switch to get directly.

Validated that returned info is the same as before in both existing and non-existing VM cases.