### PR TITLE
Print step time for each step

### DIFF
--- a/axlearn/common/launch_trainer.py
+++ b/axlearn/common/launch_trainer.py
@@ -37,6 +37,7 @@ flags.DEFINE_integer(
     "Used for initializing model parameters and pseudo-random number generation during training.",
 )
 flags.DEFINE_list("trace_at_steps", [], "Step numbers to start a 3-step profile at.")
+flags.DEFINE_bool("log_step_time", False, "Log the time it takes for each step")
 flags.DEFINE_list(
     "eval_trace_at_iters",
     [],
@@ -94,6 +95,7 @@ def get_trainer_config(
     trainer_config.mesh_shape = trainer_config.mesh_shape or (len(jax.devices()), 1)
     trainer_config.mesh_shape = infer_mesh_shape(trainer_config.mesh_shape)
     trainer_config.start_trace_steps = [int(el) for el in flag_values.trace_at_steps]
+    trainer_config.log_step_time = flag_values.log_step_time
     if trainer_config.watchdog_timeout_seconds is None:
         trainer_config.watchdog_timeout_seconds = flag_values.trainer_watchdog_timeout_seconds
 

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -431,6 +431,8 @@ class SpmdTrainer(Module):
                     stop_trace_step = self._maybe_stop_or_start_tracing(stop_trace_step, output)
 
                     self._step = self._step + 1
+
+                    step_start_time = time.perf_counter()
                     self.vlog(3, "Start step %s", self.step)
                     output = self._run_step(
                         utils.host_to_global_device_array(input_batch),
@@ -439,6 +441,11 @@ class SpmdTrainer(Module):
                         else None,
                     )
                     self.vlog(3, "Done step %s", self.step)
+
+                    step_time = time.perf_counter() - step_start_time
+                    self._step_log("Step %s took %s seconds", self.step, step_time)
+                    self.summary_writer(self.step, {"step_time": step_time})
+
                     num_steps += 1
                     if num_steps % 100 == 0:
                         now = time.perf_counter()


### PR DESCRIPTION
This is helpful in cases where there is variable step time and looking at the logs would quickly allow you to identify such cases.