### PR TITLE
increase timeout from 300s to 900s

### DIFF
--- a/axlearn/common/utils_spmd.py
+++ b/axlearn/common/utils_spmd.py
@@ -80,5 +80,6 @@ def setup(
                 distributed_coordinator,
                 num_processes=num_processes,
                 process_id=process_id,
+                initialization_timeout=900,
             )
         _jax_distributed_initialized = True


### PR DESCRIPTION
The scale up of GPU nodes for large jobs can take up to 10 minutes. So increasing this timeout is needed to wait for all pods to become available.

This change is required to run on 64 nodes with autoscaling enabled. The image pull and VM scale up time are the main reason it takes up to 10 minutes. In some cases the coordinator launches directly while other pods require scale up. In those cases, it's critical that the timeout is set to at least 10 minutes or more.