### PR TITLE
Don't override user-supplied tf loglevel.

### DIFF
--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 """A library with common flags to launch a trainer."""
+
 # pylint: disable=wrong-import-position,wrong-import-order
 import os
 import sys
@@ -38,7 +39,7 @@ os.environ["LIBTPU_INIT_ARGS"] = " ".join(libtpu_init_args)
 # Set TF_CPP_MIN_LOG_LEVEL to ignore msg like  "PNG warning: iCCP: known incorrect sRGB profile"
 # Reference: https://stackoverflow.com/questions/35869137/avoid-tensorflow-print-on-standard-error
 # Note: this will disable other TF_CPP info and warnnings.
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
 
 # Import jax before tensorflow else to avoid problems such as:
 # tpu_library_init_fns.inc:98] TpuEmbeddingEngine_ExecutePartitioner not available in this library.


### PR DESCRIPTION
From Sam:
> When we set export TF_CPP_MIN_LOG_LEVEL=0 we're expecting some XLA logs but for some reason they're not popping up. Could there be anything in axlearn that's supressing these logs?