### PR TITLE
Draft PR to add GoodPut Measurement

### DIFF
--- a/axlearn/common/launch_trainer_main.py
+++ b/axlearn/common/launch_trainer_main.py
@@ -1,15 +1,28 @@
 # Copyright © 2023 Apple Inc.
 
 """Main function for launching the trainer."""
-from absl import app
+from absl import app, logging
 
 from axlearn.common import launch, launch_trainer
 
+from ml_goodput_measurement import goodput
+import jax
 
 def main(_):
     launch.setup()
+    run_name='test'
+    goodput_logger_name = f'goodput_{run_name}'
+    # TODO: create Goodput Recorder object
+    goodput_recorder = goodput.GoodputRecorder(job_name=run_name, logger_name=goodput_logger_name, logging_enabled=(jax.process_index() == 0))
+    # TODO: record job's overall start time
+    goodput_recorder.record_job_start_time()
+    logging.info("===========>STARTED JOB")
+
     trainer_config = launch_trainer.get_trainer_config()
     launch_trainer.run_trainer(trainer_config)
+
+    goodput_recorder.record_job_end_time()
+    logging.info("===========>STOPPED JOB")
 
 
 if __name__ == "__main__":

--- a/axlearn/common/launch_trainer_main.py
+++ b/axlearn/common/launch_trainer_main.py
@@ -10,19 +10,23 @@ import jax
 
 def main(_):
     launch.setup()
+    # TODO: localize GoodPut measurement to within trainer.py
+    # TODO: make the measurement configurable
+
+    # TODO: automatically pick up run_name from job config
     run_name='test'
     goodput_logger_name = f'goodput_{run_name}'
     # TODO: create Goodput Recorder object
     goodput_recorder = goodput.GoodputRecorder(job_name=run_name, logger_name=goodput_logger_name, logging_enabled=(jax.process_index() == 0))
     # TODO: record job's overall start time
     goodput_recorder.record_job_start_time()
-    logging.info("===========>STARTED JOB")
+    logging.info("GOODPUT MEASUREMENT: Recorded job start time.")
 
     trainer_config = launch_trainer.get_trainer_config()
     launch_trainer.run_trainer(trainer_config)
 
     goodput_recorder.record_job_end_time()
-    logging.info("===========>STOPPED JOB")
+    logging.info("GOODPUT MEASUREMENT: Recorded job end time.")
 
 
 if __name__ == "__main__":

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -17,7 +17,6 @@ from jax.experimental.pjit import pjit
 
 # TODO: import for GoodPut
 from ml_goodput_measurement import goodput
-import datetime
 
 from axlearn.common import utils
 from axlearn.common.base_layer import ParameterSpec
@@ -425,14 +424,12 @@ class SpmdTrainer(Module):
                 num_steps = 0
                 output = None
                 stop_trace_step = None
+
                 # TODO: specify a run-specific name for GoodPut Logger
-                run_name='{config.run_name}'
+                run_name='test'
                 goodput_logger_name = f'goodput_{run_name}'
                 # TODO: create Goodput Recorder object
                 goodput_recorder = goodput.GoodputRecorder(job_name=run_name, logger_name=goodput_logger_name, logging_enabled=(jax.process_index() == 0))
-                # TODO: record job's overall start time
-                goodput_recorder.record_job_start_time(datetime.datetime.now())
-                print("===========>STARTED RECORDING GOODPUT FOR JOB")
 
                 for input_batch in self._input_iter:
                     logging.log_first_n(
@@ -447,7 +444,7 @@ class SpmdTrainer(Module):
 
                     # TODO: record step start time
                     goodput_recorder.record_step_start_time(self._step)
-                    print("===========>RECORDED GOODPUT RECORDER ON STEP:", self._step)
+                    logging.info("===========>RECORDED GOODPUT ON STEP:%s", self._step)
 
                     output = self._run_step(
                         utils.host_to_global_device_array(input_batch),
@@ -470,9 +467,6 @@ class SpmdTrainer(Module):
                 if self.step < cfg.max_step:
                     self._step_log("Reached end of inputs. Stopping")
 
-                # TODO: record job's overall end time
-                goodput_recorder.record_job_end_time(datetime.datetime.now())
-                print("===========>STOPPED RECORDING GOODPUT FOR JOB")
 
             self._step_log("Checkpointer flushed.")
             return output

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -425,10 +425,10 @@ class SpmdTrainer(Module):
                 output = None
                 stop_trace_step = None
 
-                # TODO: specify a run-specific name for GoodPut Logger
+                # TODO: automatically pick up run_name from job config
                 run_name='test'
                 goodput_logger_name = f'goodput_{run_name}'
-                # TODO: create Goodput Recorder object
+                # Create Goodput Recorder object
                 goodput_recorder = goodput.GoodputRecorder(job_name=run_name, logger_name=goodput_logger_name, logging_enabled=(jax.process_index() == 0))
 
                 for input_batch in self._input_iter:
@@ -442,9 +442,9 @@ class SpmdTrainer(Module):
                     self._step = self._step + 1
                     self.vlog(3, "Start step %s", self.step)
 
-                    # TODO: record step start time
+                    # Record step start time
                     goodput_recorder.record_step_start_time(self._step)
-                    logging.info("===========>RECORDED GOODPUT ON STEP:%s", self._step)
+                    # logging.info("GOODPUT MEASUREMENT: Recorded GoodPut on step:%s", self._step)
 
                     output = self._run_step(
                         utils.host_to_global_device_array(input_batch),

--- a/axlearn/experiments/text/gpt/c4_trainer.py
+++ b/axlearn/experiments/text/gpt/c4_trainer.py
@@ -108,8 +108,10 @@ def named_trainer_configs() -> Dict[str, TrainerConfigFn]:
     # pytype: disable=annotation-type-mismatch
     cfg: SpmdTrainer.Config = config_map["fuji-7B"]().clone()
     # pytype: enable=annotation-type-mismatch
-    cfg.input.batcher.global_batch_size = 32
+
+    # TODO: made fuji-7B-single even smaller to fit onto v4-8
+    cfg.input.batcher.global_batch_size = 4
     for evaler in cfg.evalers.values():
-        evaler.input.batcher.global_batch_size = 32
+        evaler.input.batcher.global_batch_size = 4
     config_map["fuji-7B-single"] = lambda: cfg
     return config_map

--- a/axlearn/experiments/text/gpt/c4_trainer.py
+++ b/axlearn/experiments/text/gpt/c4_trainer.py
@@ -109,9 +109,8 @@ def named_trainer_configs() -> Dict[str, TrainerConfigFn]:
     cfg: SpmdTrainer.Config = config_map["fuji-7B"]().clone()
     # pytype: enable=annotation-type-mismatch
 
-    # TODO: made fuji-7B-single even smaller to fit onto v4-8
-    cfg.input.batcher.global_batch_size = 4
+    cfg.input.batcher.global_batch_size = 32
     for evaler in cfg.evalers.values():
-        evaler.input.batcher.global_batch_size = 4
+        evaler.input.batcher.global_batch_size = 32
     config_map["fuji-7B-single"] = lambda: cfg
     return config_map

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -58,6 +58,8 @@ def get_trainer_kwargs(model_size: str, *, vocab_size: int) -> Dict[str, Any]:
             learner_kwargs=dict(peak_lr=3e-4, weight_decay=0.1),
             train_batch_size=4 * 1024 * 1024 // MAX_SEQUENCE_LENGTH,  # 4M tokens.
             max_step=500_000,  # 2T tokens // 4M tokens/step.
+            save_every_n_steps=200,
+            eval_every_n_steps=50000,
             mesh_shape=mesh_shape_from_axes(fsdp=-1),
             mesh_rules=(
                 # tpu-v4. step time: 3.03s.

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -58,8 +58,6 @@ def get_trainer_kwargs(model_size: str, *, vocab_size: int) -> Dict[str, Any]:
             learner_kwargs=dict(peak_lr=3e-4, weight_decay=0.1),
             train_batch_size=4 * 1024 * 1024 // MAX_SEQUENCE_LENGTH,  # 4M tokens.
             max_step=500_000,  # 2T tokens // 4M tokens/step.
-            save_every_n_steps=200,
-            eval_every_n_steps=50000,
             mesh_shape=mesh_shape_from_axes(fsdp=-1),
             mesh_rules=(
                 # tpu-v4. step time: 3.03s.

--- a/goodput_demo.py
+++ b/goodput_demo.py
@@ -9,12 +9,17 @@ from google.api import metric_pb2
 from google.cloud import compute_v1
 from google.cloud import monitoring_v3
 
+# An example script to demonstrate using Custom Dashboard in Cloud Monitoring to monitor TPU GoodPut
+
+# Recommend to run this script on a separate machine than your training hardware
+# Demo used the newer version of the package: ml_goodput_measurement==0.0.8
+
+# TODO: In order to obtain the GoodPut throughout a training's life time, consider repeatedly calling GoodPut Calculator
+# and write the results to a persistent data store.
+
 # TODO: fill out your project ID
 PROJECT_ID = "PROJECT ID"
 ZONE = "us-central2-b"
-
-# Recommend to run this script on a separate machine than your ML training machine
-# Demo used the newer version of the package: ml_goodput_measurement==0.0.8
 
 def main():
     # specify the run name you want to query GoodPut from

--- a/goodput_demo.py
+++ b/goodput_demo.py
@@ -1,0 +1,14 @@
+from ml_goodput_measurement import goodput
+
+def main():
+    run_name='{config.run_name}'
+    goodput_logger_name = f'goodput_{run_name}'
+    # Create a GoodPut Calculator object
+    goodput_calculator = goodput.GoodputCalculator(job_name=run_name, logger_name=goodput_logger_name)
+
+    # TODO: make this a loop to periodically pull Goodput
+    current_goodput = goodput_calculator.get_job_goodput()
+    print(f"=========> Current job goodput: {current_goodput:.2f}%")
+
+if __name__ == "__main__":
+    main()

--- a/goodput_demo.py
+++ b/goodput_demo.py
@@ -1,14 +1,129 @@
 from ml_goodput_measurement import goodput
+import time
+from datetime import datetime
+
+import os
+import time
+
+from google.api import metric_pb2
+from google.cloud import compute_v1
+from google.cloud import monitoring_v3
+
+# TODO: fill out your project ID
+PROJECT_ID = "PROJECT ID"
+ZONE = "us-central2-b"
+
+# Recommend to run this script on a separate machine than your ML training machine
+# Demo used the newer version of the package: ml_goodput_measurement==0.0.8
 
 def main():
-    run_name='{config.run_name}'
+    # specify the run name you want to query GoodPut from
+    run_name='test'
     goodput_logger_name = f'goodput_{run_name}'
+    metric_name = f'goodput_metric_{run_name}'
+    project_name = f"projects/{PROJECT_ID}"
+
+    # TODO: if this doesn't already exist
+    set_up_metric(metric_name,project_name)
+
     # Create a GoodPut Calculator object
     goodput_calculator = goodput.GoodputCalculator(job_name=run_name, logger_name=goodput_logger_name)
 
-    # TODO: make this a loop to periodically pull Goodput
-    current_goodput = goodput_calculator.get_job_goodput()
-    print(f"=========> Current job goodput: {current_goodput:.2f}%")
+    # Pull GoodPut metric every 30 seconds and write it to custom metric
+    while True:
+        before_gp = datetime.now()
+        current_goodput = goodput_calculator.get_job_goodput()
+        after_gp = datetime.now()
+        time_diff = after_gp - before_gp
+        print(f"=========> Current job goodput: {current_goodput:.4f}%")
+        print(f'Fetch time: {time_diff.total_seconds():.2f} seconds')
+
+        write_time_series_step(metric_name, run_name, current_goodput)
+        time.sleep(30)
+
+def set_up_metric(metric_name,project_name):
+    # Create a custom metric for Goodput
+    client = get_metrics_service_client()
+
+    descriptor = metric_pb2.MetricDescriptor()
+    descriptor.type = "custom.googleapis.com/" + metric_name
+    descriptor.metric_kind = metric_pb2.MetricDescriptor.MetricKind.GAUGE
+    descriptor.value_type = metric_pb2.MetricDescriptor.ValueType.DOUBLE
+    descriptor.description = "Goodput of the job."
+
+    descriptor = client.create_metric_descriptor(
+        name=project_name, metric_descriptor=descriptor
+    )
+    print("Created custom metric: {}.".format(descriptor.name))
+
+
+def get_metrics_service_client():
+  """Returns Cloud Monitoring API client."""
+  return monitoring_v3.MetricServiceClient()
+
+
+def get_query_service_client():
+  """Returns Cloud Monitoring Query Service client."""
+  return monitoring_v3.QueryServiceClient()
+
+
+def get_compute_instances_client():
+  """Returns Cloud Compute Instances client."""
+  return compute_v1.InstancesClient()
+
+
+def get_instance_id():
+  client = get_compute_instances_client()
+  instance_name = os.uname().nodename
+  instance = client.get(project=PROJECT_ID, zone=ZONE, instance=instance_name)
+  return instance.id
+
+
+def write_time_series_step(metric_name, job_name, goodput_value):
+  """Emits a Goodput data point when a query is made.
+
+  Args:
+    metric_name: name of the metric
+    job_name: training step
+    goodput_value: Current Goodput of job
+  """
+  client = get_metrics_service_client()
+  project_name = f"projects/{PROJECT_ID}"
+
+  seconds_since_epoch_utc = time.time()
+  nanos_since_epoch_utc = int(
+      (seconds_since_epoch_utc - int(seconds_since_epoch_utc)) * 10**9
+  )
+  interval = monitoring_v3.types.TimeInterval({
+      "end_time": {
+          "seconds": int(seconds_since_epoch_utc),
+          "nanos": nanos_since_epoch_utc,
+      }
+  })
+
+  event_time = time.strftime(
+      "%d %b %Y %H:%M:%S UTC", time.gmtime(seconds_since_epoch_utc)
+  )
+
+
+  series = monitoring_v3.types.TimeSeries()
+  series.metric.type = "custom.googleapis.com/" + metric_name
+  series.resource.type = "generic_node"
+  series.resource.labels["location"] = "us-central2-b"
+  series.resource.labels["namespace"] = "namespace"
+  series.resource.labels["node_id"] = "node_id"
+  series.metric.labels["goodput"] = str(goodput_value)
+  series.metric.labels["job_name"] = job_name
+  series.metric.labels["event_time"] = event_time
+  series.points = [
+      monitoring_v3.types.Point(
+          interval=interval,
+          value=monitoring_v3.types.TypedValue(double_value=goodput_value),
+      )
+  ]
+
+  client.create_time_series(name=project_name, time_series=[series])
+
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,8 @@ gcp = [
     "google-cloud-storage==2.11.0",
     "google-cloud-core==2.3.3",
     "ml-goodput-measurement==0.0.2",
+    "google-cloud-monitoring==2.11.3",
+    "google-cloud-compute==1.6.1",
 ]
 # For TPU training.
 # Note: Specify -f https://storage.googleapis.com/jax-releases/libtpu_releases.html during install.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ gcp = [
     "pyOpenSSL>=22.1.0",  # compat with cryptography version.
     "google-cloud-storage==2.11.0",
     "google-cloud-core==2.3.3",
+    "ml-goodput-measurement==0.0.2",
 ]
 # For TPU training.
 # Note: Specify -f https://storage.googleapis.com/jax-releases/libtpu_releases.html during install.


### PR DESCRIPTION
Adding demo code as a skeleton to integrate GoodPut measurement into AXLearn. 

To do's:
1. Consider localizing GoodPut measurement to within trainer.py
2. Make the measurement configurable
3. Automatically pick up run_name from job config
4. In order to obtain the GoodPut throughout a training's life time, consider repeatedly calling GoodPut Calculator and write the results to a persistent data store
5. Add tests in AXLearn
6. Test E2E for multislice jobs and larger single slice jobs 
7. Test E2E for long-running jobs (8hr+)
8. Test for jobs running on v5e, v5p (so far, we only tested v4-8)