### PR TITLE
Update attrs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.9"
 # Production dependencies.
 # Every time we upgrade JAX, we should try to bring the rest to the newest versions.
 dependencies = [
-    "attrs>=21.3.0",
+    "attrs>=23.1.0", # We use `type` in `attrs.field`
     "absl-py",
     "chex<0.1.81",  # chex 0.1.81 depends on numpy>=1.25.0.
     "importlab==0.7",  # breaks pytype on 0.8


### PR DESCRIPTION
Seeing

```
File "/Users/fw/miniforge3/envs/ajax/lib/python3.9/site-packages/axlearn/common/config.py", line 688, in _attr_field_from_signature_param
    return attr.field(default=default_value, type=param.annotation)
TypeError: field() got an unexpected keyword argument 'type'
```
.
This will increase the dependency version to minimum required for type keyword.