### PR TITLE
[misc] Update urls to lingvo/jax with fixed commit

### DIFF
--- a/axlearn/common/pipeline.py
+++ b/axlearn/common/pipeline.py
@@ -11,7 +11,7 @@
 https://arxiv.org/abs/1811.06965
 
 Adapted from:
-https://github.com/tensorflow/lingvo/blob/master/lingvo/jax/layers/pipeline.py
+https://github.com/tensorflow/lingvo/blob/2d46faf8/lingvo/jax/layers/pipeline.py
 
 A pipeline layer consists a stack of N identical sub layers, where
   * The variables are stacked across layers. Each stacked variable has shape [N, ...].

--- a/axlearn/common/repeat.py
+++ b/axlearn/common/repeat.py
@@ -9,8 +9,8 @@
 """A generic repeat layer.
 
 Adapted from:
-https://github.com/tensorflow/lingvo/blob/master/lingvo/core/repeat_layer.py
-https://github.com/tensorflow/lingvo/blob/master/lingvo/jax/layers/repeats.py
+https://github.com/tensorflow/lingvo/blob/2d46faf8/lingvo/core/repeat_layer.py
+https://github.com/tensorflow/lingvo/blob/2d46faf8/lingvo/jax/layers/repeats.py
 
 A repeat layer consists a stack of N identical sub layers, where
   * The variables are stacked across layers. Each stacked variable has shape [N, ...].


### PR DESCRIPTION
lingvo/jax was deleted from master in:
https://github.com/tensorflow/lingvo/commit/5bbe38c046519b86fa5c0488f813ffbf8b467d7e