### PR TITLE
Workaround qrm API segfaults.

### DIFF
--- a/axlearn/cloud/gcp/tpu_cleaner.py
+++ b/axlearn/cloud/gcp/tpu_cleaner.py
@@ -2,8 +2,6 @@
 
 """TPU job cleaner, e.g. to be used with BastionJob."""
 
-import functools
-from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, Sequence
 
 from absl import logging
@@ -95,8 +93,5 @@ class TPUCleaner(Cleaner):
             except TPUDeletionError as e:
                 logging.warning("Failed to delete TPU %s: %s", tpu_name, e)
 
-        with ThreadPoolExecutor() as pool:
-            pool.map(
-                functools.partial(_delete_tpu_async, resource_qrm=resource_qrm),
-                tpu_names,
-            )
+        for tpu_name in tpu_names:
+            _delete_tpu_async(tpu_name, resource_qrm=resource_qrm)


### PR DESCRIPTION
Discovery resource (httplib2) is not threadsafe, which can trigger a segfault now that we share discovery resources. These calls are mostly non-blocking so it's probably OK to run serially (the alternative option is to build a new http client per call, like we were doing before, but can risk hitting socket limits).