### PR TITLE
Pass Along soft_label in EncoderModel if Available.

### DIFF
--- a/axlearn/common/encoder.py
+++ b/axlearn/common/encoder.py
@@ -385,8 +385,9 @@ class EncoderModel(BaseModel):
                     representing different parts of the input.
                     Values should be in the range [0, type_vocab_size).
                     If unspecified and type embedding is used, defaults to 0 for all positions.
-                soft_labels: An optional float Tensor for soft labels (e.g. in distillation)
-                    if available.
+                soft_labels: An optional Tensor of labels that are already smoothed/in one-hot
+                    form. If provided, target_labels are typically used for inferring the mask
+                    during loss calculation.
             return_aux: whether to return auxiliary outputs.
 
         Returns:

--- a/axlearn/common/encoder_test.py
+++ b/axlearn/common/encoder_test.py
@@ -393,6 +393,68 @@ class TestEncoderModel(TestCase):
             self.assertIn("logits", test_outputs)
             self.assertEqual(test_outputs["logits"].shape, (batch_size, head.num_classes))
 
+    def test_encoder_model_with_soft_labels_passed(self):
+        batch_size = 4
+        seq_len = 16
+        vocab_size = 1000
+        hidden_dim = 64
+        num_classes = 2
+        head = BertSequenceClassificationHead.default_config().set(num_classes=num_classes)
+        config = EncoderModel.default_config().set(
+            dim=64,
+            vocab_size=vocab_size,
+            head=head,
+        )
+        config.encoder.set(
+            pad_token_id=0,
+            transformer=TransformerLayer.default_config().set(
+                self_attention=TransformerAttentionLayer.default_config().set(
+                    attention=MultiheadAttention.default_config().set(num_heads=1)
+                ),
+                feed_forward=TransformerFeedForwardLayer.default_config().set(
+                    hidden_dim=hidden_dim
+                ),
+            ),
+        )
+        encoder_model: EncoderModel = config.set(name="test").instantiate(parent=None)
+        params = encoder_model.initialize_parameters_recursively(jax.random.PRNGKey(1))
+        input_ids = jax.random.randint(
+            jax.random.PRNGKey(111), [batch_size, seq_len], minval=0, maxval=vocab_size
+        )
+        target_labels = jax.random.randint(
+            jax.random.PRNGKey(123), [batch_size], minval=0, maxval=1
+        )
+
+        input_batch = dict(input_ids=input_ids, target_labels=target_labels)
+        output, _ = F(
+            encoder_model,
+            inputs=[input_batch],
+            state=params,
+            is_training=False,
+            method="forward",
+            prng_key=jax.random.PRNGKey(1),
+        )
+
+        soft_labels = jax.random.uniform(
+            jax.random.PRNGKey(42),
+            [batch_size, num_classes],
+            minval=-1,
+            maxval=1,
+        )
+        input_batch_with_soft_labels = dict(
+            input_ids=input_ids, target_labels=target_labels, soft_labels=soft_labels
+        )
+        output_with_soft_labels, _ = F(
+            encoder_model,
+            inputs=[input_batch_with_soft_labels],
+            state=params,
+            is_training=False,
+            method="forward",
+            prng_key=jax.random.PRNGKey(1),
+        )
+
+        self.assertNotAlmostEqual(output[0].item(), output_with_soft_labels[0].item())
+
 
 if __name__ == "__main__":
     with utils.numeric_checks(True):


### PR DESCRIPTION
If provided, `soft_label` should be passed along in `EncoderModel` forward pass, so that it can be accessed by, for example,  `ClassificationMetric`.