### PR TITLE
chore(axlearn): Fix typos

### DIFF
--- a/axlearn/audio/asr_decoder.py
+++ b/axlearn/audio/asr_decoder.py
@@ -225,7 +225,7 @@ class BaseASRDecoderModel(BaseModel):
             "input_stats/average_source_length": WeightedScalar(
                 jnp.mean(source_lengths), batch_size
             ),
-            "input_stats/frame_packing_effiency": WeightedScalar(
+            "input_stats/frame_packing_efficiency": WeightedScalar(
                 jnp.sum(source_lengths) / num_source_elements, num_source_elements
             ),
         }
@@ -298,7 +298,7 @@ class CTCDecoderModel(BaseASRDecoderModel):
             "input_stats/average_source_length": WeightedScalar(
                 num_valid_frames / total_example_weights, total_example_weights
             ),
-            "input_stats/frame_packing_effiency": WeightedScalar(
+            "input_stats/frame_packing_efficiency": WeightedScalar(
                 num_valid_frames / num_total_frames, num_total_frames
             ),
         }

--- a/axlearn/audio/asr_decoder_test.py
+++ b/axlearn/audio/asr_decoder_test.py
@@ -595,7 +595,7 @@ class CTCDecoderModelTest(TestCase):
         )
         self._check_summary(
             summaries,
-            "input_stats/frame_packing_effiency",
+            "input_stats/frame_packing_efficiency",
             WeightedScalar(num_valid_frames / paddings.size, paddings.size),
         )
 

--- a/axlearn/cloud/common/bastion_test.py
+++ b/axlearn/cloud/common/bastion_test.py
@@ -191,7 +191,7 @@ class TestDownloadJobBatch(parameterized.TestCase):
     def test_invalid_membership(self):
         # Test that we drop jobs where the user is not a member of the specified quota project id.
         user_ids = ["a", "b", "c"]
-        project_ids = ["proj1", "proj2", "proj3", "non_existant_proj"]
+        project_ids = ["proj1", "proj2", "proj3", "non_existent_proj"]
         jobspecs = {
             str(i): JobSpec(
                 version=0,
@@ -211,7 +211,7 @@ class TestDownloadJobBatch(parameterized.TestCase):
             name
             for name, job_spec in jobspecs.items()
             if job_spec.metadata.project_id == "proj3"
-            or job_spec.metadata.project_id != "non_existant_proj"
+            or job_spec.metadata.project_id != "non_existent_proj"
             and job_spec.metadata.user_id in project_membership[job_spec.metadata.project_id]
         ]
 

--- a/axlearn/cloud/common/bundler.py
+++ b/axlearn/cloud/common/bundler.py
@@ -124,7 +124,7 @@ class Bundler(Configurable):
         exclude_paths = set(canonicalize_to_list(cfg.exclude))
 
         def copytree(src: pathlib.Path, dst: pathlib.Path, exclude: Iterable[str], root=None):
-            """Recusively copies `src` to `dst`.
+            """Recursively copies `src` to `dst`.
 
             Args:
                 src: A path to a file or directory.

--- a/axlearn/cloud/gcp/job.py
+++ b/axlearn/cloud/gcp/job.py
@@ -551,7 +551,7 @@ class TPUGKEJob(GKEJob):
             metadata=dict(
                 name=cfg.name,
                 annotations={
-                    # The exlusive topology annotation will ensure that all Pods will have affinity
+                    # The exclusive topology annotation will ensure that all Pods will have affinity
                     # rules added that will ensure that they are fully scheduled on the same
                     # pod-slice node-pools.
                     "alpha.jobset.sigs.k8s.io/exclusive-topology": "cloud.google.com/gke-nodepool",

--- a/axlearn/cloud/gcp/jobs/dataflow_test.py
+++ b/axlearn/cloud/gcp/jobs/dataflow_test.py
@@ -99,7 +99,7 @@ class DataflowJobTest(TestWithTemporaryCWD):
             self.assertEqual("test_name", dataflow_spec["job_name"])
             self.assertEqual(fv.vm_type, dataflow_spec["worker_machine_type"])
 
-            # Test overridding specs (including a multi-flag)
+            # Test overriding specs (including a multi-flag)
             fv.set_default(
                 "dataflow_spec",
                 [

--- a/axlearn/cloud/gcp/jobs/gke_runner.py
+++ b/axlearn/cloud/gcp/jobs/gke_runner.py
@@ -246,7 +246,7 @@ class GKERunnerJob(GCPJob):
             SUSPENDED: JobSet is suspended.
             STARTUPPOLICYCOMPLETED: JobSet completed StartupPolicy.
             READY: JobSet is ready (all Jobs are ready).
-            SUCCEEDED: JobSet succeeded (all Jobs suceeded). Typically also manifests as COMPLETED.
+            SUCCEEDED: JobSet succeeded (all Jobs succeeded). Typically also manifests as COMPLETED.
             RESCHEDULED: Job was rescheduled onto a different tier.
         """
 

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -531,7 +531,7 @@ def _get_launcher_or_exit(*, action: str, instance_type: str, gcp_api: str) -> L
 
     If there are multiple matches, the first one in the registry is returned.
     """
-    # Idenfity launcher from instance type.
+    # Identify launcher from instance type.
     for launcher in _LAUNCHERS:
         m = maybe_instantiate(launcher.matcher)
         if m(action=action, instance_type=instance_type, gcp_api=gcp_api):

--- a/axlearn/cloud/gcp/jobs/launch_utils.py
+++ b/axlearn/cloud/gcp/jobs/launch_utils.py
@@ -171,7 +171,7 @@ def with_qrm_tpu_state(fn: JobsToTableFn) -> JobsToTableFn:
 def _qrm_tpu_state_from_jobs(
     jobs: Dict[str, BastionJob], tpu_infos: Optional[List[TpuInfo]] = None
 ) -> Dict[str, Any]:
-    """Retrives QRM TPU states for the given jobs."""
+    """Retrieves QRM TPU states for the given jobs."""
     if tpu_infos is None:
         tpu_infos = list_tpu_info(tpu_resource(get_credentials()))
 
@@ -224,7 +224,7 @@ def with_k8s_jobset_state(fn: JobsToTableFn, *, namespace: str) -> JobsToTableFn
 def _k8s_jobset_state_from_jobs(
     jobs: Dict[str, BastionJob], *, namespace: str, k8s_jobsets: Optional[Dict[str, list]] = None
 ) -> List[str]:
-    """Retrives k8s jobset states for the given jobs."""
+    """Retrieves k8s jobset states for the given jobs."""
     if k8s_jobsets is None:
         k8s_jobsets = list_k8s_jobsets(namespace=namespace)
 

--- a/axlearn/cloud/gcp/tpu.py
+++ b/axlearn/cloud/gcp/tpu.py
@@ -307,7 +307,7 @@ def create_queued_tpu(
         reserved: Whether to use reserved or preemptible quota. If None, infers from `gcp_settings`.
 
     Raises:
-        TPUCreationError: If an exeption is raised on the creation request.
+        TPUCreationError: If an exception is raised on the creation request.
         ValueError: If an invalid name is provided.
     """
     validate_resource_name(name)
@@ -705,7 +705,7 @@ def infer_tpu_version(tpu_type: str) -> str:
         ValueError: if the TPU version string is unknown.
     """
     tpu_type = infer_tpu_type(tpu_type)
-    tpu_version = tpu_type.rsplit("-", 1)[0]  # split from the last occurance of '-'
+    tpu_version = tpu_type.rsplit("-", 1)[0]  # split from the last occurrence of '-'
     if tpu_version not in _TPU_VERSIONS:
         raise ValueError(f"Unknown TPU version {tpu_version}. Expected one of {_TPU_VERSIONS}")
     return tpu_version

--- a/axlearn/cloud/gcp/vm.py
+++ b/axlearn/cloud/gcp/vm.py
@@ -51,7 +51,7 @@ def create_vm(
         metadata: Optional metadata for the instance.
 
     Raises:
-        VMCreationError: If an exeption is raised on the creation request.
+        VMCreationError: If an exception is raised on the creation request.
         ValueError: If an invalid name is provided.
     """
     validate_resource_name(name)
@@ -142,7 +142,7 @@ def delete_vm(name: str, *, credentials: Credentials):
         credentials: Credentials to use when interacting with GCP.
 
     Raises:
-        VMDeletionError: If an exeption is raised on the deletion request.
+        VMDeletionError: If an exception is raised on the deletion request.
     """
     resource = _compute_resource(credentials)
     node = get_vm_node(name, resource)

--- a/axlearn/common/adapter_torch.py
+++ b/axlearn/common/adapter_torch.py
@@ -1787,7 +1787,7 @@ class CausalLM(TorchModule):
         return loss, predictions
 
     def extract_logits(self, input_ids: torch.Tensor) -> torch.Tensor:
-        """Obtains logits from the langauge model.
+        """Obtains logits from the language model.
 
         Args:
             input_ids: an int Tensor of shape [batch_size, seq_len].

--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -154,7 +154,7 @@ class MaskTest(absltest.TestCase):
         dim = 32
         logits = jnp.asarray(np.random.random(size=[batch_size, num_heads, dim]))
 
-        # Tesing for biases = None
+        # Testing for biases = None
         masked_logit = apply_attention_logit_biases(logits, attention_logit_biases=None)
         self.assertEqual(masked_logit.dtype, logits.dtype)
         np.testing.assert_array_equal(logits, masked_logit)
@@ -951,7 +951,7 @@ class RoFormerSinusoidalPositionalEmbeddingAgainstLLaMATest(TestCase):
     def llama_ref_precompute_freqs_cis(
         self, *, dim: int, end: int, theta: float = 10000.0
     ) -> torch.Tensor:
-        """Reference LLaMA-1 implemention.
+        """Reference LLaMA-1 implementation.
 
         Ref:
         https://github.com/facebookresearch/llama/blob/1076b9c51c77ad06e9d7ba8a4c6df775741732bd/llama/model.py#L47-L52

--- a/axlearn/common/base_layer_test.py
+++ b/axlearn/common/base_layer_test.py
@@ -459,7 +459,7 @@ class BaseLayerTest(TestCase):
 
     def test_no_remat_inheritance(self):
         # Check that @no_remat is preserved by inheritance unless the method
-        # is explicitly overriden by one without @no_remat.
+        # is explicitly overridden by one without @no_remat.
         class AnotherTestLayer(BaseLayer):
             @no_remat
             def fn(self, st: str):

--- a/axlearn/common/causal_lm.py
+++ b/axlearn/common/causal_lm.py
@@ -208,7 +208,7 @@ class Model(BaseModel):
             )
 
     def extract_logits(self, input_batch: NestedTensor) -> Tensor:
-        """Obtains logits from the langauge model.
+        """Obtains logits from the language model.
 
         Args:
             input_batch: A dict containing:

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -679,7 +679,7 @@ class TensorStoreStateStorageTest(test_utils.TestCase):
                         validation=CheckpointValidationType.EXACT_UP_TO_DTYPE,
                     )
 
-                # Succesfully restores with different dtypes.
+                # Successfully restores with different dtypes.
                 restored_state = restore_state()
                 self.assertNestedEqual(
                     restored_state,

--- a/axlearn/common/decoding.py
+++ b/axlearn/common/decoding.py
@@ -186,7 +186,7 @@ def _gather_topk_beams(
 
 class BrevityPenaltyFn(Protocol):
     def __call__(self, *, length: Tensor, raw_scores: Tensor) -> Tensor:
-        """Compute the brevity penality based on the length of a decoding and its raw scores.
+        """Compute the brevity penalty based on the length of a decoding and its raw scores.
 
         Args:
             length: A tensor of shape broadcastable to [batch_size, beam_size].
@@ -490,7 +490,7 @@ def beam_search_decode(
     Raises:
         NotImplementedError: If an unsupported loop is provided.
     """
-    # If brevity_penalty is set as None, we explictly use the default function
+    # If brevity_penalty is set as None, we explicitly use the default function
     # without length normalization.
     if brevity_penalty is None:
         brevity_penalty = brevity_penalty_fn(alpha=0.0)

--- a/axlearn/common/decoding_test.py
+++ b/axlearn/common/decoding_test.py
@@ -158,7 +158,7 @@ class DecodeTest(parameterized.TestCase):
         init_cache = {}
         init_cache["cur_iter"] = jnp.zeros((batch_size, 1), dtype=jnp.int32)
 
-        # alpha is zero and beam search will perfer shorter sequences.
+        # alpha is zero and beam search will prefer shorter sequences.
         inputs = np.zeros([batch_size, decode_length])
         beam_search_output = decoding.beam_search_decode(
             inputs=inputs,

--- a/axlearn/common/eval_retrieval.py
+++ b/axlearn/common/eval_retrieval.py
@@ -1,6 +1,6 @@
 # Copyright © 2023 Apple Inc.
 
-"""Retreival evaluation pipeline."""
+"""Retrieval evaluation pipeline."""
 import csv
 from collections import defaultdict
 from functools import partial
@@ -268,7 +268,7 @@ class EmbeddingRetrievalMetricCalculator(GlobalMetricCalculator):
         #   * MAP - mean average precision
         #   * MAP@k - mean average precision at K
         #   * accuracy@k - accuracy at K
-        # TODO(atimofeev): add more suported metrics (accuracy, recall, etc.)
+        # TODO(atimofeev): add more supported metrics (accuracy, recall, etc.)
         metrics: Required[List[str]] = REQUIRED
 
         # Optional tuple of cateogory names - category `i` gets name `categories_names[i]`.
@@ -585,8 +585,8 @@ class KnnMetricCalculator(EmbeddingRetrievalMetricCalculator):
 
         chunk_metrics = {}
         for k in cfg.top_ks:
-            top_similarities, top_indicies = jax.lax.top_k(similarities, k)
-            top_labels = jnp.take(index_labels, top_indicies)
+            top_similarities, top_indices = jax.lax.top_k(similarities, k)
+            top_labels = jnp.take(index_labels, top_indices)
             for temp in cfg.temps:
                 weights = jnp.exp(top_similarities / temp)
                 label_scores = batch_segment_sum(weights, top_labels)

--- a/axlearn/common/evaler.py
+++ b/axlearn/common/evaler.py
@@ -250,7 +250,7 @@ class BaseMetricCalculator(Module):
         )
 
     def formatted_metric_name(self, metric_name):
-        """Prepand the prefix to the metric_name."""
+        """Prepend the prefix to the metric_name."""
         if self.config.prefix is not None:
             return f"{self.config.prefix}/{metric_name}"
         else:

--- a/axlearn/common/factorized_rms.py
+++ b/axlearn/common/factorized_rms.py
@@ -62,7 +62,7 @@ def _factored_dims(
 
 @dataclasses.dataclass
 class _UpdateResult:
-    """Opaque containter that is not traversed by jax.tree_util.tree_map."""
+    """Opaque container that is not traversed by jax.tree_util.tree_map."""
 
     update: Tensor  # the update to apply to params.
     v_row: Tensor  # used for factored params.

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -104,7 +104,7 @@ class FlashAttention(GroupedQueryAttention):
     ) -> Tuple[Tensor, Tensor]:
         cfg = self.config
 
-        # Repeats key/value heads dim if neccessary.
+        # Repeats key/value heads dim if necessary.
         k_proj = self._repeat_kv_heads(k_proj)
         v_proj = self._repeat_kv_heads(v_proj)
 

--- a/axlearn/common/input_mlm.py
+++ b/axlearn/common/input_mlm.py
@@ -317,7 +317,7 @@ def apply_mlm_mask(
         # 1. Input already starts with a start-of-word. Masking behavior is unchanged, as the added
         #    dummy token is masked independently and then discarded.
         # 2. Input does not start with, but contains, a start-of-word. The leading segment is then
-        #    treated as a word. This is acceptible given that the segment is likely truncated from
+        #    treated as a word. This is acceptable given that the segment is likely truncated from
         #    an actual start-of-word, e.g. from the previous document.
         # 3. Input does not contain a start-of-word at all. To prevent masking the entire sequence,
         #    this falls back to masking tokens independently (see tf.cond).

--- a/axlearn/common/input_reading_comprehension.py
+++ b/axlearn/common/input_reading_comprehension.py
@@ -380,7 +380,7 @@ def convert_example_to_features(
         doc_tokens, char_to_doc_token_offset = _get_doc_tokens_and_char_offsets(context=context)
 
         # Use the subtokenize of the tokenizer to subtokenize each whitespace-delimited token into
-        # their respective subtokens. Additionally computes the subtoken indicies the answer span by
+        # their respective subtokens. Additionally computes the subtoken indices the answer span by
         # mapping from the original answer character indices to their subtoken indices.
         (
             doc_subtokens,
@@ -499,7 +499,7 @@ def _get_subtokens_and_answer_subtoken_indices(
     """Subtokenize and return the answer subtoken indices
 
     Use the subtokenize of the tokenizer to subtokenize each whitespace-delimited token into
-    their respective subtokens. Additionally computes the subtoken indicies the answer span by
+    their respective subtokens. Additionally computes the subtoken indices the answer span by
     mapping from the original answer character indices to their subtoken indices.
 
     Args:
@@ -509,7 +509,7 @@ def _get_subtokens_and_answer_subtoken_indices(
             the document tokens.
         answer_start_positions: A list containing an int value indicating the index of the start
             character of the answer in the context.
-        answer_texts: A list containing a string value indiciating the answer text in the context.
+        answer_texts: A list containing a string value indicating the answer text in the context.
         is_training: Indicate if these are training examples.
 
     Returns:
@@ -532,7 +532,7 @@ def _get_subtokens_and_answer_subtoken_indices(
             doc_subtokens.append(subtoken)
 
     if is_training and len(answer_start_positions) > 0:
-        # Compute the subtoken indicies the answer span by mapping from the original answer
+        # Compute the subtoken indices the answer span by mapping from the original answer
         # character indices to their context token indices, then to their subtoken indices.
         answer_token_start = char_to_doc_token_offset[answer_start_positions[0]]
         answer_token_end = char_to_doc_token_offset[

--- a/axlearn/common/input_tf_data.py
+++ b/axlearn/common/input_tf_data.py
@@ -582,7 +582,7 @@ def default_pad_example_fn(element_spec: Any) -> Any:
 
 
 def _infer_cardinality(dataset: tf.data.Dataset) -> int:
-    """Returns the size of the dataset, by counting examples if neccessary."""
+    """Returns the size of the dataset, by counting examples if necessary."""
     num_examples = dataset.cardinality()
     if num_examples != tf.data.UNKNOWN_CARDINALITY:
         return num_examples

--- a/axlearn/common/layers.py
+++ b/axlearn/common/layers.py
@@ -1085,7 +1085,7 @@ class Conv1D(BaseLayer):
 
     def __init__(self, cfg: Config, *, parent: Optional[Module]):
         super().__init__(cfg, parent=parent)
-        # Check lhs_dilation and padding setting compatiablity.
+        # Check lhs_dilation and padding setting compatibility.
         if cfg.lhs_dilation is not None and cfg.lhs_dilation != 1 and isinstance(cfg.padding, str):
             raise ValueError("String padding is not supported for LHS dilation.")
 

--- a/axlearn/common/logit_modifiers.py
+++ b/axlearn/common/logit_modifiers.py
@@ -88,20 +88,20 @@ def top_p_logits(p: float) -> LogitsToLogitsFn:
     def fn(logits: Tensor) -> Tensor:
         probs = jax.nn.softmax(logits, axis=-1)
         # Probs in a form suitable for efficient TPU reduction.
-        reduceable_probs = probs
-        reduce_axis = reduceable_probs.ndim - 1
-        if reduceable_probs.ndim > 1:
+        reducible_probs = probs
+        reduce_axis = reducible_probs.ndim - 1
+        if reducible_probs.ndim > 1:
             # As we will be doing many reductions over reduce_axis, transpose it to be
             # the penultimate dimension, so that these reductions happen within vector lanes.
             # (See ref. in docstring for more details).
-            reduceable_probs = jnp.swapaxes(reduceable_probs, -1, -2)
-            reduce_axis = reduceable_probs.ndim - 2
+            reducible_probs = jnp.swapaxes(reducible_probs, -1, -2)
+            reduce_axis = reducible_probs.ndim - 2
 
         def predicate(float32_query: Tensor) -> Tensor:
             float32_query = jnp.expand_dims(float32_query, reduce_axis)
             # [..., 1, float32_query.shape[-1]]
             probability_mass = jnp.sum(
-                jnp.where(reduceable_probs >= float32_query, reduceable_probs, 0.0),
+                jnp.where(reducible_probs >= float32_query, reducible_probs, 0.0),
                 axis=reduce_axis,
             )
             return probability_mass < p
@@ -133,20 +133,20 @@ def top_k_logits(k: int) -> LogitsToLogitsFn:
 
     def fn(logits: Tensor) -> Tensor:
         # Logits in a form suitable for efficient TPU reduction.
-        reduceable_logits = logits
-        reduce_axis = reduceable_logits.ndim - 1
-        if reduceable_logits.ndim > 1:
+        reducible_logits = logits
+        reduce_axis = reducible_logits.ndim - 1
+        if reducible_logits.ndim > 1:
             # As we will be doing many reductions over reduce_axis, transpose it to be
             # the penultimate dimension, so that these reductions happen within vector lanes.
             # (See ref. in docstring for more details).
-            reduceable_logits = jnp.swapaxes(reduceable_logits, -1, -2)
+            reducible_logits = jnp.swapaxes(reducible_logits, -1, -2)
             reduce_axis = logits.ndim - 2
 
         def predicate(float32_query: Tensor) -> Tensor:
             float32_query = -float32_query
             float32_query = jnp.expand_dims(float32_query, reduce_axis)
             # [..., 1, float32_query.shape[-1]]
-            count_number_gt = jnp.sum(reduceable_logits > float32_query, axis=reduce_axis)
+            count_number_gt = jnp.sum(reducible_logits > float32_query, axis=reduce_axis)
             return count_number_gt >= k
 
         batched_shape = logits.shape[:-1]  # All but the last axis are batched.

--- a/axlearn/common/lora.py
+++ b/axlearn/common/lora.py
@@ -348,7 +348,7 @@ class LoraFusedQKVAdapter(_BaseLoraAdapter):
         return cfg.output_dim // cfg.num_heads
 
     @property
-    def _num_enbaled(self):
+    def _num_enabled(self):
         cfg = self.config
         return sum(cfg.enable_lora.values())
 
@@ -375,7 +375,7 @@ class LoraFusedQKVAdapter(_BaseLoraAdapter):
             cfg.lora_down.set(
                 input_dim=cfg.input_dim,
                 output_dim=cfg.rank,
-                num_enabled=self._num_enbaled,
+                num_enabled=self._num_enabled,
             ),
         )
         self._add_child(
@@ -384,7 +384,7 @@ class LoraFusedQKVAdapter(_BaseLoraAdapter):
                 input_dim=cfg.rank,
                 num_heads=cfg.num_heads,
                 per_head_dim=self._per_head_dim,
-                num_enabled=self._num_enbaled,
+                num_enabled=self._num_enabled,
                 param_init=DefaultInitializer.default_config().set(
                     init_by_param_name={
                         PARAM_REGEXP_WEIGHT: ConstantInitializer.default_config().set(value=0.0)

--- a/axlearn/common/loss.py
+++ b/axlearn/common/loss.py
@@ -57,7 +57,7 @@ def _reduce_loss(
         loss: A [...] float tensor of arbitrary shape.
         reduction: The reduction method.
         sample_weight: A [...] float tensor, must be broadcastable to same shape as loss.
-        eps: A small number to prevent divison by zero.
+        eps: A small number to prevent division by zero.
 
     Returns:
         A float tensor:
@@ -99,7 +99,7 @@ def cross_entropy(
         / jnp.sum(live_targets, axis=-1)
     where targets is a categorical one-hot float array based on target_labels.
 
-    This function extends the T5X implmentation by supporting masked labels.
+    This function extends the T5X implementation by supporting masked labels.
 
     Ref: https://github.com/google-research/t5x/blob/90d74f/t5x/losses.py#L26
 
@@ -111,7 +111,7 @@ def cross_entropy(
         live_targets: Indicates which examples should contribute to the loss.
             A bool or 0/1 Tensor broadcastable to `target_labels`. 1 indicates positions that
             contribute to the loss. If None, infer from 0 <= target_labels < num_classes.
-        z_loss_scale: Coefficient for auxilliary z-loss loss term.
+        z_loss_scale: Coefficient for auxiliary z-loss loss term.
         label_smoothing: The factor to control label smoothing.
         soft_target_labels: Optional labels that are already smoothed/in one-hot form. If provided,
             target_labels will only be used for inferring the live targets during loss calculation.
@@ -239,7 +239,7 @@ def _stable_cross_entropy(logits: Tensor, targets: Tensor, z_loss_scale: float) 
       logits: [..., num_classes] float array.
       targets: categorical one-hot targets [..., num_classes] float
         array.
-      z_loss_scale: coefficient for auxilliary z-loss loss term.
+      z_loss_scale: coefficient for auxiliary z-loss loss term.
 
     Returns:
       tuple with the total loss and the z_loss, both
@@ -250,7 +250,7 @@ def _stable_cross_entropy(logits: Tensor, targets: Tensor, z_loss_scale: float) 
     logits_sum = jax.scipy.special.logsumexp(logits, axis=-1, keepdims=True)
     log_softmax = logits - logits_sum
     cross_entropy_loss = -jnp.sum(targets * log_softmax, axis=-1)
-    # Add auxilliary z-loss term.
+    # Add auxiliary z-loss term.
     log_z = jnp.squeeze(logits_sum, axis=-1)
     total_z_loss = jax.lax.square(log_z)
     loss = cross_entropy_loss + total_z_loss * z_loss_scale
@@ -269,7 +269,7 @@ def _stable_cross_entropy_fwd(logits: Tensor, targets: Tensor, z_loss_scale: flo
     sum_exp = jnp.sum(exp_shifted, axis=-1, keepdims=True)
     log_softmax = shifted - jnp.log(sum_exp)
     cross_entropy_loss = -jnp.sum(targets * log_softmax, axis=-1)
-    # Add auxilliary z-loss term.
+    # Add auxiliary z-loss term.
     log_z = jnp.squeeze(jnp.log(sum_exp) + max_logit, axis=-1)
     total_z_loss = jax.lax.square(log_z)
     loss = cross_entropy_loss + total_z_loss * z_loss_scale
@@ -733,7 +733,7 @@ def categorical_hinge_loss(
             targets must be of the same size of logits.
 
     Returns:
-        A tensor of the  shape [...] which accumlates the hinge loss over all categories.
+        A tensor of the  shape [...] which accumulates the hinge loss over all categories.
 
     Reference:
         https://github.com/keras-team/keras/blob/v2.11.0/keras/losses.py#L1833-L1865
@@ -946,7 +946,7 @@ def giou_loss(
             Box format is y1, x1, y2, x2.
         reduction: The reduction method on the final loss.
         sample_weight: A float tensor of shape [...] normalizes per sample loss.
-        eps: Small number to prevent divison by zero.
+        eps: Small number to prevent division by zero.
 
     Returns:
         A float32 tensor representing the loss.

--- a/axlearn/common/metrics_text_dual_encoder.py
+++ b/axlearn/common/metrics_text_dual_encoder.py
@@ -158,7 +158,7 @@ def calculate_retrieval_metrics_from_similarity_matrix(
             scores=sim_with_masks, relevance_labels=relevance_labels, top_ks=top_ks_for_ndcg
         )
         for k, ndcg_metric in ndcg_metrics.items():
-            # Calculate average nDCG at each postion k.
+            # Calculate average nDCG at each position k.
             metrics.update(
                 calculate_mean_metrics(
                     metric_name=f"ndcg@{k}",

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -29,7 +29,7 @@ class MyModule(Module):
 `MyModule.__init__` will identify `MyModule.do_foo` as one of the methods to wrap through
 `Module._methods_to_wrap_for_auto_child_context` (which can be overridden by subclasses, e.g.,
 in RedirectToSharedModule). It will then wrap the method via
-`Modue._wrap_method_with_auto_child_context` and install the wrapped function as `self.do_foo`.
+`Module._wrap_method_with_auto_child_context` and install the wrapped function as `self.do_foo`.
 
 This allows MyModule's parents to invoke `do_foo` as `self.my_child.do_foo(...)` without having
 to create the child context explicitly.

--- a/axlearn/common/multi_stream_model.py
+++ b/axlearn/common/multi_stream_model.py
@@ -199,7 +199,7 @@ class MultiStreamModel(BaseModel):
                 A scalar Tensor representing the total loss.
                 A NestedTensor representing additional metrics (currently none).
         """
-        # Disentangling the foward and the predict is based on the following thoughts:
+        # Disentangling the forward and the predict is based on the following thoughts:
         # User might override the predict function for some specific tasks, the predict
         #       function could produce redundant outputs that might interfere the _fusion_network.
         input_batch = self._forward_all_stream_encoder(input_batch)

--- a/axlearn/common/multi_stream_model_test.py
+++ b/axlearn/common/multi_stream_model_test.py
@@ -185,7 +185,7 @@ class MultiStreamPipelineTest(TestCase):
         )
         assert_allclose(outputs["encoder"]["count_encoder"], 3)
 
-    def caluclate_loss(self, input_batch, loss_weights):
+    def calculate_loss(self, input_batch, loss_weights):
         encoder_name = "encoder"
         fusion_1_name = "fusion_1"
         fusion_2_name = "fusion_2"
@@ -219,9 +219,9 @@ class MultiStreamPipelineTest(TestCase):
         }
 
         # The input_batch is updated during feedforward. Therefore, copy.deepcopy is required.
-        loss_0 = self.caluclate_loss(copy.deepcopy(input_batch), {"fusion_1": 0, "fusion_2": 1})
-        loss_1 = self.caluclate_loss(copy.deepcopy(input_batch), {"fusion_1": 1, "fusion_2": 0})
-        loss_2 = self.caluclate_loss(copy.deepcopy(input_batch), {"fusion_1": 1, "fusion_2": 1})
+        loss_0 = self.calculate_loss(copy.deepcopy(input_batch), {"fusion_1": 0, "fusion_2": 1})
+        loss_1 = self.calculate_loss(copy.deepcopy(input_batch), {"fusion_1": 1, "fusion_2": 0})
+        loss_2 = self.calculate_loss(copy.deepcopy(input_batch), {"fusion_1": 1, "fusion_2": 1})
         assert_allclose(loss_0, loss_1)
         assert_allclose(loss_0 * 2, loss_2)
 

--- a/axlearn/common/multiway_transformer.py
+++ b/axlearn/common/multiway_transformer.py
@@ -265,7 +265,7 @@ class MultiModalEncoder(BaseLayer):
         visual_pos_emb: InstantiableConfig = LearnedPositionalEmbedding.default_config()
         # Text embedding.
         text_embed: TransformerTextEmbeddings.Config = TransformerTextEmbeddings.default_config()
-        # The modality type specifc embedding config.
+        # The modality type specific embedding config.
         modality_emb: InstantiableConfig = Embedding.default_config()
         # Input dropout config.
         input_dropout: InstantiableConfig = Dropout.default_config().set(rate=0.1)
@@ -345,7 +345,7 @@ class MultiModalEncoder(BaseLayer):
                 position for the pachified image.
 
         Returns:
-            A float Tensor of shape (batch, legnth, output_dim) representing the visual embedding.
+            A float Tensor of shape (batch, length, output_dim) representing the visual embedding.
         """
         cfg = self.config
         batch_size = data.shape[0]
@@ -382,7 +382,7 @@ class MultiModalEncoder(BaseLayer):
                 1 or IMAGE_MODALITY: representing images in shape [batch, height, width, channels].
                 2 or TEXT_IMAGE_MODALITY: a dict that contains text-image multimodal data with the
                     same format as monomodal data.
-            is_masked: a boolen Tensor in shape (batch, length), representing masked positions for
+            is_masked: a boolean Tensor in shape (batch, length), representing masked positions for
                 the patchifie input sequence.
 
         Returns:

--- a/axlearn/common/ops/_optimization_barrier_test.py
+++ b/axlearn/common/ops/_optimization_barrier_test.py
@@ -18,7 +18,7 @@ from axlearn.common.test_utils import TestCase
 class OptimizationBarrierTest(TestCase):
     """Tests ops.optimization_barrier"""
 
-    def test_foward_optimization_barrier(self):
+    def test_forward_optimization_barrier(self):
         """Test that constant folding happens without a barrier and does
         not happen with a barrier by inspecting the optimized HLO for the
         presence / absence of the original constants and folded constant.

--- a/axlearn/common/optimizers.py
+++ b/axlearn/common/optimizers.py
@@ -273,7 +273,7 @@ def per_param_scale_by_rms(*, min_scale: float = 1e-4) -> Callable[[NestedOptPar
     """Computes per-parameter scales with its Root-Mean-Square (RMS).
 
     Args:
-        min_scale: The minimum scale for each paramter.
+        min_scale: The minimum scale for each parameter.
 
     Returns:
         A function that computes per-parameter scales given a NestedOptParam tree. The returned
@@ -1202,7 +1202,7 @@ def skip_and_clip_by_global_norm(
     is that this version skips all updates while clip_by_global_norm() still performs parameter
     updates and optimizer state updates.
 
-    When drop_norm is a DropNormThreholdFn, the drop norm will be calculated based on the moving
+    When drop_norm is a DropNormThresholdFn, the drop norm will be calculated based on the moving
     stats of recent gradient norms. This is useful since the gradient norms can initially be large
     but reduce to a small value during training.
 
@@ -1226,12 +1226,12 @@ def skip_and_clip_by_global_norm(
     Args:
         inner: the PartitionedGradientTransformation we wrapped over, e.g. adamw_optimizer().
         drop_norm: the threshold to detect abnormal gradients and skip gradient and state updates.
-            When this is a DropNormThreholdFn, the actual drop norm will be calcuated dynamically
+            When this is a DropNormThresholdFn, the actual drop norm will be calculated dynamically
             based on recent gradient stats.
         max_norm: the maximum global gradient norm. If this is set, larger gradients will be scaled
             and clipped.
         gradient_norm_ema_decay: the decay factor used to compute EMA of gradient norms. This must
-            be set when `drop_norm` is a DropNormThreholdFn.
+            be set when `drop_norm` is a DropNormThresholdFn.
         eps: a small constant added to scaling factor, i.e. `1/(norm + eps)`.
 
     Returns:
@@ -1707,7 +1707,7 @@ def adastar_optimizer(
         # Stage 1.
         smoothed_gradients = ema(gradients, gradient_ema_decay, gradient_ema_debias)
         smoothed_gradient_squares = ema(
-            gradients ** 2 + eps_square, gradient_square_ema_decay, gradient_sqare_ema_debias)
+            gradients ** 2 + eps_square, gradient_square_ema_decay, gradient_square_ema_debias)
         # Normalized gradients.
         raw_updates = smoothed_gradients / ((smoothed_gradient_squares) ** 0.5 + eps)
         clipped_updates = clip(scaled_gradients, raw_update_clipping_threshold)

--- a/axlearn/common/param_converter.py
+++ b/axlearn/common/param_converter.py
@@ -798,8 +798,8 @@ def _parameters_from_deberta_for_sequence_classification(
 ) -> NestedTensor:
     model = _parameters_from_deberta_model(src.deberta, dst_layer=dst_layer)
     pooler = _parameters_from_deberta_context_pooler(src.pooler)
-    classifer = torch_to_axlearn(src.classifier)
-    return dict(encoder=model["encoder"], head=dict(pooler=pooler, output=classifer))
+    classifier = torch_to_axlearn(src.classifier)
+    return dict(encoder=model["encoder"], head=dict(pooler=pooler, output=classifier))
 
 
 def _parameters_from_deberta_embeddings(

--- a/axlearn/common/quantized_dot_general/layers.py
+++ b/axlearn/common/quantized_dot_general/layers.py
@@ -294,7 +294,7 @@ class DenseGeneralBaseLayer(BaseLayer):
         # QuantizedDotGeneral config. Replace jax.lax.dot_general with
         # dot_general_maybe_quantized from this layer to achieve
         # hardware accelerated quantized dot_general.
-        # TODO(jiarui): Siwtch to ConfigOr[Protocol] which defines the implementation of
+        # TODO(jiarui): Switch to ConfigOr[Protocol] which defines the implementation of
         #  dot_general(subscript, activation, kernel) (which can be a layer) to generalize the API.
         quantized_dot_general: Optional[QuantizedDotGeneral.Config] = None
 

--- a/axlearn/common/state_builder.py
+++ b/axlearn/common/state_builder.py
@@ -548,7 +548,7 @@ def traverse_and_set_target_state_parameters(
 class FlaxPretrainedBuilder(Builder):
     """Builds (partial) model state from supplied flax states.
 
-    The function reads model parameters from cofigured state supplier, and
+    The function reads model parameters from configured state supplier, and
     sets the corresponding model state to these parameters.
 
     In the following context, the target refers to the model state.

--- a/axlearn/common/summary_writer.py
+++ b/axlearn/common/summary_writer.py
@@ -246,7 +246,7 @@ class WandBWriter(BaseWriter):
 
     Note:
         This utility does not support restarts gracefully.
-        If the job is pre-empted, the logger will create a new run.
+        If the job is preempted, the logger will create a new run.
 
     TODO(adesai22): Add support for restarts.
     """

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -1,6 +1,6 @@
 # Copyright © 2023 Apple Inc.
 
-"""Utilites used for testing."""
+"""Utilities used for testing."""
 import contextlib
 import copy
 import dataclasses

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -410,7 +410,7 @@ class SpmdTrainer(Module):
                 last training step. If None or False, do not force run evalers and no evaler
                 summaries are returned; if True, force run all evalers at the last training step
                 and return summaries; if given as a set of strings, force run all the evalers
-                with the name in the set at teh last training step and return summaries.
+                with the name in the set at the last training step and return summaries.
 
         Returns:
             None if no training is run or a dict otherwise.

--- a/axlearn/common/utils_spmd.py
+++ b/axlearn/common/utils_spmd.py
@@ -107,7 +107,7 @@ def setup(
                         "Failed to recognize coordinator" in err_str
                         or "Barrier timed out" in err_str
                     ):
-                        continue  # Retry. Sleep is handled by jax.distributed.initialze.
+                        continue  # Retry. Sleep is handled by jax.distributed.initialize.
                     raise
             if not _jax_distributed_initialized:
                 raise RuntimeError(

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -1244,11 +1244,11 @@ class InferMeshShapeTest(TestCase):
         mesh_shape = infer_mesh_shape((4, 1, 8, 1))
         self.assertEqual(mesh_shape, (4, 1, 8, 1))
 
-        # When there is mutiple -1
+        # When there is multiple -1
         with self.assertRaises(ValueError):
             infer_mesh_shape((-1, 1, -1, 8))
 
-        # When num_devices is not a mutiple of products of mesh_shape
+        # When num_devices is not a multiple of products of mesh_shape
         with self.assertRaises(ValueError):
             infer_mesh_shape((-1, 1, 8, 1), num_devices=4)
 

--- a/axlearn/common/vision_transformer.py
+++ b/axlearn/common/vision_transformer.py
@@ -361,7 +361,7 @@ class VisionTransformer(BaseLayer):
 
         Args:
             image: The input image. Shape: (batch, height, width, channels).
-            is_masked: a boolen Tensor in shape (batch, length), representing masked positions
+            is_masked: a boolean Tensor in shape (batch, length), representing masked positions
                 for the patchifie input sequence.
 
         Returns:

--- a/axlearn/common/vocabulary_bpe.py
+++ b/axlearn/common/vocabulary_bpe.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2019 OpenAI.
 # Licensed under a modified MIT license.
 
-"""An implemention of GPT2 BPE as a seqio Vocabulary.
+"""An implementation of GPT2 BPE as a seqio Vocabulary.
 
 Reference:
 https://github.com/openai/gpt-2/blob/a74da5d99abaaba920de8131d64da2862a8f213b/src/encoder.py
@@ -181,7 +181,7 @@ class BPEVocabulary(seqio.SentencePieceVocabulary):
             A tf.Tensor of shape [num_tokens] and dtype tf.string.
         """
         # Simulate the lookahead by splitting in two stages.
-        # `(?s).*` tells us to keep all delimeters ( `.` does not by default include e.g. `\n`).
+        # `(?s).*` tells us to keep all delimiters ( `.` does not by default include e.g. `\n`).
         s = tft.regex_split(s, f"[{self._spc}][^{self._spc}]+", keep_delim_regex_pattern="(?s).*")
         tokens = tft.regex_split(s, self._pat, keep_delim_regex_pattern="(?s).*")
         return tokens.flat_values

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -60,7 +60,7 @@ def _compile_and_dump_programs(
         print(program.as_text())
         print(f"== Cost analysis {program_name} ==")
         print(program.cost_analysis())
-        print(f"== Memeory analysis {program_name} ==")
+        print(f"== Memory analysis {program_name} ==")
         print(program.memory_analysis())
 
         # Serialization does not work for CPU devices:

--- a/axlearn/experiments/text/gpt/common.py
+++ b/axlearn/experiments/text/gpt/common.py
@@ -137,7 +137,7 @@ def mesh_shape_from_axes(
     """Builds a 5D logical mesh from the provided spec.
 
     Args:
-        data: For data-paralellism. Expect model state to be fully replicated over this axis.
+        data: For data-parallelism. Expect model state to be fully replicated over this axis.
             Useful for e.g. multi-slice/granule partitioning with slow networking between granules.
         expert: Designed to be used for partitioning "experts" in mixture-of-expert models.
             E.g. <https://arxiv.org/abs/2006.16668>.

--- a/axlearn/huggingface/hf_text_encoder.py
+++ b/axlearn/huggingface/hf_text_encoder.py
@@ -48,8 +48,8 @@ class TextEmbeddingEncoder(nn.Module):
             attention_mask: Attention mask in shape of [batch_size, max_seq_len].
 
         Returns:
-            Output embeddings in shape of [batch_size, output_dim] where ouput_dim==hidden_size when
-                there is no linear projection, projection_dim otherwise.
+            Output embeddings in shape of [batch_size, output_dim] where output_dim==hidden_size
+                when there is no linear projection, projection_dim otherwise.
         """
         base_model_outputs = self.base_model(
             input_ids=input_ids, attention_mask=attention_mask, return_dict=True

--- a/axlearn/vision/clip.py
+++ b/axlearn/vision/clip.py
@@ -489,7 +489,7 @@ class CLIPFusionNetwork(FusionNetwork):
                     *"output_features": A Tensor with shape [batch_size, num_sentences, dim]
 
         Returns:
-            loss: A Tensor represnting the loss
+            loss: A Tensor representing the loss
             A dictionary containing:
                 *"similarity": A Tensor representing the similarity between
                     the text and image.
@@ -529,7 +529,7 @@ class CLIPFusionNetwork(FusionNetwork):
 class CLIPModel(MultiStreamModel):
     """A CLIP two stream model.
 
-    This class provides a customized predict funtion.
+    This class provides a customized predict function.
 
     The predict is called during the inference. As we only need to calculate the
         StreamEncoder outputs.

--- a/axlearn/vision/coca.py
+++ b/axlearn/vision/coca.py
@@ -259,7 +259,7 @@ class CoCaImageStreamEncoder(StreamEncoder):
             cfg.contrastive_pooler.set(input_dim=hidden_dim, output_dim=hidden_dim),
         )
         if cfg.pooler_mode != "bottleneck":
-            # allows pooler dimension to be overriden
+            # allows pooler dimension to be overridden
             output_dim = cfg.caption_pooler.output_dim or hidden_dim
             self._add_child(
                 "caption_pooler",
@@ -566,7 +566,7 @@ class CoCaCaptioningFusionNetwork(FusionNetwork):
                         [batch_size, num_sentences, seq_len]
 
         Returns:
-            loss: A Tensor represnting the loss
+            loss: A Tensor representing the loss
             A dictionary containing: TBA
 
         Raises:
@@ -759,7 +759,7 @@ def set_captioning_cfg(
     captioning_cfg.pad_token_id = pad_token_id
     captioning_cfg.use_cross_attention = use_cross_attention
 
-    # Deocder config
+    # Decoder config
     if remat:
         decoder_cfg = RepeatedTransformerLayer.default_config()
     else:
@@ -796,7 +796,7 @@ def set_captioning_cfg(
 class CoCaModel(MultiStreamModel, DecodingMixin):
     """A CoCa two stream model.
 
-    This class provides a customized predict funtion.
+    This class provides a customized predict function.
 
     The predict is called during the inference. As we only need to calculate the
         StreamEncoder outputs.
@@ -808,7 +808,7 @@ class CoCaModel(MultiStreamModel, DecodingMixin):
     class Config(MultiStreamModel.Config):
         """Configures CoCaModel."""
 
-        # Required when running beacm_seach_decode, see details in `DecodingMixin`
+        # Required when running beacm_search_decode, see details in `DecodingMixin`
         pad_token_id: Optional[int] = None
         eos_token_id: Optional[int] = None
 

--- a/axlearn/vision/coco_evaluator.py
+++ b/axlearn/vision/coco_evaluator.py
@@ -168,7 +168,7 @@ class COCOEvaluator:
         return metrics_dict
 
     def _retrieve_per_category_metrics(self, coco_eval, prefix="") -> Dict[str, Any]:
-        """Retrieves and per-category metrics and retuns them in a dict.
+        """Retrieves and per-category metrics and returns them in a dict.
 
         Args:
             coco_eval: a cocoeval.COCOeval object containing evaluation data.

--- a/axlearn/vision/coco_utils.py
+++ b/axlearn/vision/coco_utils.py
@@ -45,7 +45,7 @@ class COCOWrapper(coco.COCO):
             eval_type: either 'box' or 'mask'.
             annotation_file: a JSON file that stores annotations of the eval dataset.
                 This is required if `gt_dataset` is not provided.
-            gt_dataset: the groundtruth eval datatset in COCO API format.
+            gt_dataset: the groundtruth eval dataset in COCO API format.
 
         Raises:
             ValueError: If annotation_file and gt_dataset are both specified or both left
@@ -264,7 +264,7 @@ def convert_groundtruths_to_coco_dataset(
                 masks depending on which one is available.
             - masks: a list of numpy arrays of string of shape [batch_size, K],
         label_map: (optional) a dictionary that defines items from the category id to the category
-            name. If `None`, collect the category mappping from the `groundtruths`.
+            name. If `None`, collect the category mapping from the `groundtruths`.
 
     Returns:
         coco_groundtruths: the groundtruth dataset in COCO format.

--- a/axlearn/vision/fpn_test.py
+++ b/axlearn/vision/fpn_test.py
@@ -1,6 +1,6 @@
 # Copyright © 2023 Apple Inc.
 
-"""Tests feature pyramind network implementations."""
+"""Tests feature pyramid network implementations."""
 import jax.numpy as jnp
 import jax.random
 import numpy as np

--- a/axlearn/vision/imagenet_adversarial_text/add_attack_tfrecord.py
+++ b/axlearn/vision/imagenet_adversarial_text/add_attack_tfrecord.py
@@ -66,7 +66,7 @@ def _decode_record_and_attack(record: Dict[str, tf.Tensor], verbose: bool = Fals
     if verbose:
         print(f"image shape: {img.shape}")
 
-    new_category = sc.most_similiar_class(target)
+    new_category = sc.most_similar_class(target)
 
     new_text = imagenet_classes[new_category]
     new_img = util_im_process.write_text_to_image(img, new_text)

--- a/axlearn/vision/imagenet_adversarial_text/util_imagenet.py
+++ b/axlearn/vision/imagenet_adversarial_text/util_imagenet.py
@@ -19,7 +19,7 @@ class ImageNet_SimilarClass:
         self.target2esti = target2esti
         self.S = S
 
-    def most_similiar_class(self, c):
+    def most_similar_class(self, c):
         mylist = None
         if c in self.target2esti:
             mylist = [tmp for tmp in self.target2esti[c] if tmp != c]

--- a/axlearn/vision/input_image.py
+++ b/axlearn/vision/input_image.py
@@ -240,7 +240,7 @@ def random_erasing(
 
     Args:
         image: the input image of shape [H, W, C].
-        erasing_probability: the probablity of applying random erasing.
+        erasing_probability: the probability of applying random erasing.
 
     Returns:
         The augmented image.

--- a/axlearn/vision/mask_generator.py
+++ b/axlearn/vision/mask_generator.py
@@ -42,7 +42,7 @@ class MaskingGenerator:
 
         Args:
             input_size: an int tuple that represents (height, width) of the patchified target.
-            num_masking_patches: the number of paches to be masked.
+            num_masking_patches: the number of patches to be masked.
             num_attempts: the max number of attempts for one mask generation trial.
             min_mask_patches: the min number of patches for one masking area.
             max_mask_patches: the max number of patches for one masking area. If None, sets to
@@ -128,7 +128,7 @@ class MaskingGenerator:
         mask = np.zeros(shape=self.get_shape(), dtype=np.int32)
         mask_count = 0
         # pylint: disable=no-else-break,unbalanced-tuple-unpacking
-        # Keeps selecting one new random area if mask_count does not reach num_masking_pathces.
+        # Keeps selecting one new random area if mask_count does not reach num_masking_patches.
         # TODO(xianzhi): consider consolidating the while and the if/else logics.
         while mask_count < self.num_masking_patches:
             max_mask_patches = self.num_masking_patches - mask_count

--- a/axlearn/vision/masked_image_model.py
+++ b/axlearn/vision/masked_image_model.py
@@ -24,7 +24,7 @@ from axlearn.common.module import Module, NestedTensor, Tensor, child_context
 
 # pylint: disable=no-self-use
 class MaskedImageModel(BaseModel):
-    """An impelementation for masked image modeling."""
+    """An implementation for masked image modeling."""
 
     @config_class
     class Config(BaseModel.Config):
@@ -86,7 +86,7 @@ class MaskedImageModel(BaseModel):
         Args:
             logits: The prediction logits in shape (batch, length, num_classes).
             labels: The prediction labels in shape (batch, length), with int values.
-            is_masked: a boolen Tensor in shape (batch, length), representing the masked positions
+            is_masked: a boolean Tensor in shape (batch, length), representing the masked positions
                 for the logits.
 
         Returns:
@@ -106,7 +106,7 @@ class MaskedImageModel(BaseModel):
 
         Args:
             image: The input image. Shape: (batch, height_pixel, width_pixel, channels).
-            is_masked: a boolen Tensor in shape (batch, length), representing the masked positions
+            is_masked: a boolean Tensor in shape (batch, length), representing the masked positions
                 for the patchifie input image.
 
         Returns:
@@ -120,12 +120,12 @@ class MaskedImageModel(BaseModel):
 
     # pylint: disable-next=arguments-differ
     def forward(self, input_batch: Dict[str, Tensor]) -> Tuple[Tensor, NestedTensor]:
-        """Runs foward pass.
+        """Runs forward pass.
 
         Args:
             input_batch: a dictionary that contains:
             * image: The input image. Shape: (batch, height_pixel, width_pixel, channels).
-            * is_masked: a boolen Tensor in shape (batch, height_patch, width_patch),
+            * is_masked: a boolean Tensor in shape (batch, height_patch, width_patch),
                 representing the masked positions for the patchifie input image.
 
         Returns:

--- a/axlearn/vision/nms.py
+++ b/axlearn/vision/nms.py
@@ -150,7 +150,7 @@ def non_max_suppression_padded(
         are zero).
       * Boxes with higher scores can be used to suppress boxes with lower scores.
 
-    The overal design of the algorithm is to handle boxes tile-by-tile:
+    The overall design of the algorithm is to handle boxes tile-by-tile:
 
     boxes = boxes.pad_to_multiply_of(tile_size)
     num_tiles = len(boxes) // tile_size

--- a/axlearn/vision/utils_detection.py
+++ b/axlearn/vision/utils_detection.py
@@ -445,7 +445,7 @@ class IouSimilarity:
 
 
 class TargetGather:
-    """Targer gather for dense object detector."""
+    """Target gather for dense object detector."""
 
     def __call__(
         self,
@@ -759,7 +759,7 @@ class BoxList:
 
         Returns:
             Number of boxes held in collection (integer) or None if this is not
-            inferrable at graph construction time.
+            inferable at graph construction time.
         """
         return self.data["boxes"].get_shape().dims[0].value
 

--- a/axlearn/vision/virtex.py
+++ b/axlearn/vision/virtex.py
@@ -219,12 +219,12 @@ class VirTexModel(ImageBackboneModelMixin, BaseLayer):
                     should be +1 of the maximum sequence length.
                     Shape: [batch, max_sequence_length]. Values should be in the range
                     [0, vocab_size].
-            return_aux: Whether to return auxilliary outputs, which includes
+            return_aux: Whether to return auxiliary outputs, which includes
                 visual backbone features and text decoder logits (and hidden state
                 if the decoder is a transformer).
 
         Returns:
-            (loss, Dict): The loss and dictionary of auxilliary outputs (if `return_aux=True`).
+            (loss, Dict): The loss and dictionary of auxiliary outputs (if `return_aux=True`).
                 If `return_aux=False`, an empty dictionary will be returned.
         """
         image = input_batch["image"]

--- a/axlearn/vision/virtex_test.py
+++ b/axlearn/vision/virtex_test.py
@@ -54,11 +54,11 @@ class VirTexTest(parameterized.TestCase):
         cfg.textual.eos_token_id = eos_token_id
 
     def _base_aux_outputs_test(self, cfg):
-        """Verify that approriate auxilliary outputs are returned.
+        """Verify that appropriate auxiliary outputs are returned.
 
         Implicitly this also tests the forward pass executes without error.
 
-        The auxilliary outputs for VirTex include:
+        The auxiliary outputs for VirTex include:
             - 'visual_features': Outputs of the visual backbone.
         """
         model: VirTexModel = cfg.set(name="test_intermediate_features").instantiate(parent=None)

--- a/axlearn/vision/window_attention_test.py
+++ b/axlearn/vision/window_attention_test.py
@@ -228,7 +228,7 @@ class WindowAttentionTest(TestCase, tf.test.TestCase):
             ),  # (200, 1, 1, 3), (10, 10)
         ]
     )
-    def test_window_partiton_unpartion_with_num_windows(
+    def test_window_partition_unpartition_with_num_windows(
         self,
         inputs_shape,
         num_windows,


### PR DESCRIPTION
# Changes

## Typo fixes

Tool-assisted (via ` typos --format brief --write-changes **/*.py` via [typos-cli](https://github.com/crate-ci/typos)).  The rest of the effort is fine-tooth combing that output.

Aside: If you attempt this in the future in any way, do so carefully. This generated many false positives due to the nature of the library (e.g. `nd` -> `and`, `empted` -> `emptied`).

<details>

<summary>_typos.toml config used</summary>

```toml
[default]
extend-ignore-identifiers-re = [
    # *sigh* this just isn't worth the cost of fixing
    ".*nd.*",
    ".*ND.*",
    ".*preempt.*",
    ".*empt.*",
    ".*helpfull.*",
    ".*dout.*",
    ".*whos.*",
    ".*your.*",
    ".*stakeboard.*",
    ".*sur.*",
]

[files]
extend-exclude = ["*.vocab"]
```

</details>