### PR TITLE
Add safe_serialization to MultiStreamTextEmbeddingModel.from_pretrained

### DIFF
--- a/axlearn/huggingface/hf_text_encoder.py
+++ b/axlearn/huggingface/hf_text_encoder.py
@@ -82,14 +82,16 @@ class MultiStreamTextEmbeddingModel(nn.Module):
         super().__init__()
         self.stream_encoders = stream_encoders
 
-    def save_pretrained(self, save_directory: str):
+    def save_pretrained(self, save_directory: str, *, safe_serialization: bool = True):
         """Save a model and its configuration file to a directory, so that it can be re-loaded
         using the `:func:`~transformers.PreTrainedModel.from_pretrained`` class method.
         """
         for encoder_name in self.stream_encoders:
             encoder_output_dir = os.path.join(save_directory, encoder_name)
             os.makedirs(encoder_output_dir, exist_ok=True)
-            self.stream_encoders[encoder_name].save_pretrained(encoder_output_dir)
+            self.stream_encoders[encoder_name].save_pretrained(
+                encoder_output_dir, safe_serialization=safe_serialization
+            )
 
     def forward(
         self, input_batch: Dict[str, Dict[str, torch.Tensor]]


### PR DESCRIPTION
Adds `safe_serialization` argument to `MultiStreamTextEmbeddingModel.from_pretrained`.

`safe_serialization` is an argument in the Huggingface `PreTrainedModel`'s [save_pretrained method](https://huggingface.co/docs/transformers/en/main_classes/model#transformers.PreTrainedModel.save_pretrained). This PR passes the `safe_serialization` argument from `MultiStreamTextEmbeddingModel.save_pretrained(...)` to its stream encoders.