### PR TITLE
Improves bastion log sync logic

### DIFF
--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -69,7 +69,7 @@ Examples:
 To test changes to bastion:
 
     # 1. Build a custom image.
-    axlearn gcp bundle --bundler_type=docker \
+    axlearn gcp bundle --bundler_type=artifactregistry \
         --name=$USER-bastion \
         --bundler_spec=image=base \
         --bundler_spec=dockerfile=Dockerfile \

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -251,7 +251,7 @@ def _gcloud_storage_rsync(
             text=True,
             # Avoid "No space left on device":
             # https://cloud.google.com/knowledge/kb/error-message-while-running-the-command-gsutil-rsync-000004577
-            env={"TMPDIR": src},
+            env={"TMPDIR": f"{_LOG_DIR}/rsync"},
         )
         if proc.returncode == 0:
             return
@@ -324,7 +324,7 @@ class RemoteBastionJob(CPUJob):
         # idempotent. Setup outputs are piped to setup_log.
         setup_log = os.path.join(_LOG_DIR, "setup.log")
         start_cmd = f"""set -o pipefail;
-            mkdir -p {_LOG_DIR};
+            mkdir -p {_LOG_DIR}/rsync;
             if [[ -z "$(docker ps -f "name={cfg.name}" -f "status=running" -q )" ]]; then
                 {self._bundler.install_command(image)} 2>&1 | tee -a {setup_log} && \
                 echo "Starting command..." >> {setup_log} && {run_cmd} && \

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -249,6 +249,9 @@ def _gcloud_storage_rsync(
             timeout=timeout_s,
             capture_output=True,
             text=True,
+            # Avoid "No space left on device":
+            # https://cloud.google.com/knowledge/kb/error-message-while-running-the-command-gsutil-rsync-000004577
+            env={"TMPDIR": src},
         )
         if proc.returncode == 0:
             return

--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -196,7 +196,7 @@ class TPURunnerJob(TPUQRMJob):
 
     def _sync_outputs(self, *, session: str, src: str, dst: str, interval_s: int):
         """Starts a screen session to sync outputs to gs."""
-        logging.info("Starting log sync...")
+        logging.info("Starting log sync %s -> %s...", src, dst)
         self._execute_remote_cmd(
             f"while true; do gsutil -m rsync -r {src} {dst}; sleep {interval_s}; done",
             detached_session=session,

--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -333,10 +333,6 @@ class TPURunnerJob(TPUQRMJob):
     def _run_command(self):
         """Launches the command on the TPU-VMs."""
         cfg: TPURunnerJob.Config = self.config
-        # Install the bundle.
-        self._install_bundle()
-        # Prepare command environment variables.
-        env_vars = self._prepare_env()
         # Start syncing run log to GS.
         # TODO(markblee): Sync XLA logs.
         self._sync_outputs(
@@ -345,6 +341,10 @@ class TPURunnerJob(TPUQRMJob):
             dst=f"{cfg.output_dir}/output/$HOSTNAME/",
             interval_s=60,
         )
+        # Install the bundle.
+        self._install_bundle()
+        # Prepare command environment variables.
+        env_vars = self._prepare_env()
         # Possibly wrap with docker run.
         cmd = self._wrap(cfg.command, env=env_vars)
         # Set env vars, run the command and pipe outputs to run log.

--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -259,8 +259,8 @@ class TPURunnerJob(TPUQRMJob):
         pip_freeze_cmd = self._wrap("python3 -m pip freeze")
         self._execute_remote_cmd(
             f"set -o pipefail; mkdir -p {self._output_dir}; "
-            f"sleep $((1 + $RANDOM % 30)) && {install_cmd} && {pip_freeze_cmd} | "
-            f"tee -a {self._run_log}",
+            f"sleep $((1 + $RANDOM % 30)) && "
+            f"({install_cmd} && {pip_freeze_cmd}) 2>&1 | tee -a {self._run_log}",
             shell=True,
         )
         logging.info("Done installing bundle.")


### PR DESCRIPTION
- Adds TMPDIR to avoid `No space left on device`.
- Makes tpu_runner.py start log sync before installing the bundle. 
- Pipes bundle installation stderr and stdout to run.log. This allows us to see the bundle installation process in the GCS logs.
