### PR TITLE
Adds BaseLayer.Config.tensor_stats

### DIFF
--- a/axlearn/common/base_layer.py
+++ b/axlearn/common/base_layer.py
@@ -218,6 +218,14 @@ class BaseLayer(Module):
         param_noise: Optional[ParameterNoise.Config] = None
 
         # If not None, adds stats about the tensors given in the `_add_tensor_stats` calls.
+        #
+        # The tensor_stats abstraction allows users to compute stats (e.g., mean, RMS norm, max abs)
+        # on tensors such as layer inputs/outputs and add them to summaries.
+        #
+        # The abstraction decouples which tensors to collect stats on, which will be controlled by
+        # the layer implementation via `_add_tensor_stats(name, value)` calls, vs. how to compute
+        # and report the stats, which will be controlled by `Config.tensor_stats` and configured
+        # on a per-experiment basis.
         tensor_stats: Optional[TensorStats.Config] = None
 
     def __init__(self, cfg: Config, *, parent: Optional["Module"]):

--- a/axlearn/common/base_layer.py
+++ b/axlearn/common/base_layer.py
@@ -136,7 +136,7 @@ class TensorStats(Module):
 
 
 class CompositeTensorStats(TensorStats):
-    """A TensorStats consists of multiple child TensorStats."""
+    """A TensorStats consisting of multiple child TensorStats."""
 
     @config_class
     class Config(TensorStats.Config):
@@ -366,6 +366,8 @@ class BaseLayer(Module):
                 )
         for name, child in self._children.items():
             if not isinstance(child, BaseLayer):
+                # `child` is not a BaseLayer and does not have parameters, e.g., it can be an
+                # instance of TensorStats.
                 continue
             assert name not in params
             prng_key, child_key = jax.random.split(prng_key)


### PR DESCRIPTION
The `tensor_stats` abstraction allows users to compute stats (e.g., mean, RMS norm, max abs) on tensors such as layer inputs/outputs and add them to summaries.

The abstraction decouple which tensors to collect stats on, which will be controlled by the layer implementation via `_add_tensor_stats(name, value)` calls, vs. how to compute and report the stats, which will be controlled by `Config.tensor_stats` and configured on a per-experiment basis.

Inspired by the discussion between @taolei87 and @apghml on an internal PR.