### PR TITLE
Upgrades jax from 0.4.25 to 0.4.28

### DIFF
--- a/axlearn/common/module_test.py
+++ b/axlearn/common/module_test.py
@@ -256,7 +256,7 @@ class NestedModule(Module):
         cfg = self.config
         # It is ok to call another method of 'self' directly, if it is invoked only once in the
         # current context.
-        self.vprint(1, "input={x} cfg.child=\n{child}", x=x, child=str(cfg.child))
+        self.vprint(1, "input={x}", x=x)
         x = self.inc(x)
         if cfg.child is not None:
             # Can also call children directly, if each child is invoked only once.

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -429,44 +429,49 @@ class TreeUtilsTest(TestCase):
         target["a"]["b"] = 10
         self.assertEqual(2, source["a"]["b"])
 
-    def test_split_prng_key(self):
-        original_key = jax.random.PRNGKey(1234)
+    @parameterized.parameters("threefry2x32", "rbg")
+    def test_split_prng_key(self, prng_impl_type: str):
+        with prng_impl(prng_impl_type):
+            original_key = jax.random.PRNGKey(1234)
 
-        def fn(key: Tensor):
-            return jax.random.normal(key, [3, 2])
+            def fn(key: Tensor):
+                return jax.random.normal(key, [3, 2])
 
-        base_results = []
-        key = original_key
-        for _ in range(10):
-            key, child_key = jax.random.split(key)
-            base_results.append(fn(child_key))
-        base_results = jnp.stack(base_results)
+            base_results = []
+            key = original_key
+            for _ in range(10):
+                key, child_key = jax.random.split(key)
+                base_results.append(fn(child_key))
+            base_results = jnp.stack(base_results)
 
-        def batch(fn):
-            return lambda split_keys: jax.vmap(fn)(split_keys.keys)
+            def batch(fn):
+                return lambda split_keys: jax.vmap(fn)(split_keys.keys)
 
-        split_keys = split_prng_key(original_key, 10)
-        self.assertIsInstance(split_keys, StackedKeyArray)
-        self.assertNestedAllClose(batch(fn)(split_keys), base_results)
+            split_keys = split_prng_key(original_key, 10)
+            self.assertIsInstance(split_keys, StackedKeyArray)
+            if prng_impl_type == "threefry2x32":
+                self.assertNestedAllClose(batch(fn)(split_keys), base_results)
 
-        # Splitting the keys again is a no-op.
-        resplit_keys = split_prng_key(split_keys, 10)
-        self.assertNestedAllClose(resplit_keys, split_keys)
-        self.assertNestedAllClose(batch(fn)(resplit_keys), base_results)
+            # Splitting the keys again is a no-op.
+            resplit_keys = split_prng_key(split_keys, 10)
+            self.assertNestedAllClose(resplit_keys, split_keys)
+            if prng_impl_type == "threefry2x32":
+                self.assertNestedAllClose(batch(fn)(resplit_keys), base_results)
 
-        # Splitting the keys again with the wrong number of keys.
-        with self.assertRaisesRegex(AssertionError, "9"):
-            split_prng_key(split_keys, 9)
+            # Splitting the keys again with the wrong number of keys.
+            with self.assertRaisesRegex(AssertionError, "9"):
+                split_prng_key(split_keys, 9)
 
-        # Split keys by multiple dims.
-        split_keys = split_prng_key(original_key, (2, 5))
-        batch_results = batch(batch(fn))(split_keys)
-        self.assertSequenceEqual(batch_results.shape, [2, 5, 3, 2])
-        self.assertNestedAllClose(batch_results.reshape(base_results.shape), base_results)
+            # Split keys by multiple dims.
+            split_keys = split_prng_key(original_key, (2, 5))
+            batch_results = batch(batch(fn))(split_keys)
+            self.assertSequenceEqual(batch_results.shape, [2, 5, 3, 2])
+            if prng_impl_type == "threefry2x32":
+                self.assertNestedAllClose(batch_results.reshape(base_results.shape), base_results)
 
-        # Splitting the keys again is a no-op.
-        resplit_keys = split_prng_key(split_keys, (2, 5))
-        self.assertNestedAllClose(resplit_keys, split_keys)
+            # Splitting the keys again is a no-op.
+            resplit_keys = split_prng_key(split_keys, (2, 5))
+            self.assertNestedAllClose(resplit_keys, split_keys)
 
     @parameterized.parameters(
         ((1, 1), ("data", "model")),

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -450,6 +450,8 @@ class TreeUtilsTest(TestCase):
             split_keys = split_prng_key(original_key, 10)
             self.assertIsInstance(split_keys, StackedKeyArray)
             if prng_impl_type == "threefry2x32":
+                # Only the "threefry" implementation ensures invariance under "vmap".
+                # See https://github.com/google/jax/pull/20094.
                 self.assertNestedAllClose(batch(fn)(split_keys), base_results)
 
             # Splitting the keys again is a no-op.

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -2,7 +2,7 @@
 
 """AoT (ahead-of-time) compilation config tests.
 
-pip install 'jax[tpu]==0.4.25' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+pip install 'jax[tpu]==0.4.27' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 
 export TPU_SKIP_MDS_QUERY=1
 python axlearn/experiments/aot_test.py

--- a/axlearn/experiments/aot_test.py
+++ b/axlearn/experiments/aot_test.py
@@ -2,7 +2,7 @@
 
 """AoT (ahead-of-time) compilation config tests.
 
-pip install 'jax[tpu]==0.4.27' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+pip install 'jax[tpu]==0.4.28' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 
 export TPU_SKIP_MDS_QUERY=1
 python axlearn/experiments/aot_test.py

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -2,7 +2,7 @@
 
 """A command-line tool to perform AoT (ahead-of-time) compilation.
 
-pip install 'jax[tpu]==0.4.27' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+pip install 'jax[tpu]==0.4.28' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 
 XLA_FLAGS=--xla_dump_to=/tmp/aot_xla_dump \
 python -m axlearn.experiments.run_aot_compilation \

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -2,7 +2,7 @@
 
 """A command-line tool to perform AoT (ahead-of-time) compilation.
 
-pip install 'jax[tpu]==0.4.25' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+pip install 'jax[tpu]==0.4.27' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 
 XLA_FLAGS=--xla_dump_to=/tmp/aot_xla_dump \
 python -m axlearn.experiments.run_aot_compilation \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ dependencies = [
     "absl-py==2.1.0",
     "chex==0.1.86",  # chex 0.1.86 is required for jax 0.4.25.
     "importlab==0.7",  # breaks pytype on 0.8
-    "jax==0.4.27",
-    "jaxlib==0.4.27",
+    "jax==0.4.28",
+    "jaxlib==0.4.28",
     "nltk==3.7",  # for text preprocessing
     "numpy==1.26.4",  # verified with tensorflow 2.14 RaggedTensor
     "optax==0.1.7",  # optimizers (0.1.0 has known bugs).
@@ -90,7 +90,7 @@ gcp = [
 # Note: Specify -f https://storage.googleapis.com/jax-releases/libtpu_releases.html during install.
 tpu = [
     "axlearn[gcp]",
-    "jax[tpu]==0.4.27",  # must be >=0.4.19 for compat with v5p.
+    "jax[tpu]==0.4.28",  # must be >=0.4.19 for compat with v5p.
 ]
 # Vertex AI tensorboard.
 vertexai_tensorboard = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ dependencies = [
     "absl-py==2.1.0",
     "chex==0.1.86",  # chex 0.1.86 is required for jax 0.4.25.
     "importlab==0.7",  # breaks pytype on 0.8
-    "jax==0.4.25",
-    "jaxlib==0.4.25",
+    "jax==0.4.27",
+    "jaxlib==0.4.27",
     "nltk==3.7",  # for text preprocessing
     "numpy==1.26.4",  # verified with tensorflow 2.14 RaggedTensor
     "optax==0.1.7",  # optimizers (0.1.0 has known bugs).
@@ -90,7 +90,7 @@ gcp = [
 # Note: Specify -f https://storage.googleapis.com/jax-releases/libtpu_releases.html during install.
 tpu = [
     "axlearn[gcp]",
-    "jax[tpu]==0.4.25",  # must be >=0.4.19 for compat with v5p.
+    "jax[tpu]==0.4.27",  # must be >=0.4.19 for compat with v5p.
 ]
 # Vertex AI tensorboard.
 vertexai_tensorboard = [


### PR DESCRIPTION
https://github.com/google/jax/pull/20094 changes the behavior of RNG in vmap, so we can no longer rely on identical layer param initialization when using vmap vs. not. This affects repeated layers and fused QKV layers.

The fix is to convert layer params from the reference layer to the test layer instead of relying on identical initialization.