### PR TITLE
Adds `InputDispatcher`.

### DIFF
--- a/axlearn/common/evaler.py
+++ b/axlearn/common/evaler.py
@@ -234,7 +234,7 @@ class BaseMetricCalculator(Module):
             self._model.method(...).
         """
         # Shard and (possibly) dispatch the input batch.
-        input_batch = utils.dispatch_input_batch(input_batch)
+        input_batch = self.input.dispatch_global_batch(input_batch)
         model_inputs = dict(
             input_batch=self._eval_cast(input_batch),
             **kwargs,

--- a/axlearn/common/evaler.py
+++ b/axlearn/common/evaler.py
@@ -234,7 +234,6 @@ class BaseMetricCalculator(Module):
             self._model.method(...).
         """
         # Shard and (possibly) dispatch the input batch.
-        input_batch = self.input.dispatch_global_batch(input_batch)
         model_inputs = dict(
             input_batch=self._eval_cast(input_batch),
             **kwargs,
@@ -686,6 +685,8 @@ class SpmdEvaler(Module):
             with jax.profiler.StepTraceAnnotation(cfg.name, step_num=step):
                 with jax.profiler.TraceAnnotation(f"{cfg.name}.forward"):
                     global_input_batch = utils.host_to_global_device_array(input_batch)
+                    if hasattr(self.input, "dispatch_global_batch"):
+                        global_input_batch = self.input.dispatch_global_batch(global_input_batch)
                     forward_outputs = self.metric_calculator.forward(
                         global_input_batch,
                         model_params=model_params,

--- a/axlearn/common/input_dispatch.py
+++ b/axlearn/common/input_dispatch.py
@@ -1,0 +1,180 @@
+# Copyright © 2024 Apple Inc.
+"""Utility to help dispatching input batches from hosts to devices."""
+
+import copy
+from typing import Dict, Optional, Sequence, Union
+
+import jax
+from jax import numpy as jnp
+
+from axlearn.common.config import REQUIRED, Required, config_class
+from axlearn.common.module import Module
+from axlearn.common.utils import PHYSICAL_TO_LOGICAL_DISPATCH_KEY, Nested, Tensor
+
+
+class InputDispatcher(Module):
+    """A Module to dispatch per-feed logical input batches to global logical batches on device.
+
+    The dispatch process consists of three steps:
+    - Convert each logical feed batch to a physical feed batch (logical_to_physical_batch);
+    - Assemble a global physical batch from per-feed batches (utils.host_to_global_device_array);
+    - Convert a global physical batch to a global logical batch (physical_to_logical_batch).
+
+    This process is needed because utils.host_to_global_device_array requires that global batch
+    size be divisible by number of devices.
+    """
+
+    @config_class
+    class Config(Module.Config):
+        """Configuration for InputDispatcher."""
+
+        global_logical_batch_size: Required[int] = REQUIRED
+
+        # If None, defaults to max(global_logical_batch_size, jax.device_count()).
+        global_physical_batch_size: Optional[int] = None
+
+        # The total number of physical feeds across all hosts. Defaults to jax.process_count().
+        num_physical_feeds: Optional[int] = None
+
+        # The local physical feed index. Must be in [0, num_physical_feeds).
+        # Defaults to jax.process_index().
+        physical_feed_index: Optional[int] = None
+
+        # If not None, a list of length num_logical_feeds. logical_feed_indices[i] is an integer in
+        # [0, num_physical_feeds), representing the physical feed index for the i'th logical feed.
+        logical_feed_indices: Optional[Sequence[int]] = None
+
+        batch_axis_names: Union[str, Sequence[str]] = "data"
+
+    def __init__(self, cfg: Config, *, parent: Optional[Module]):
+        if cfg.global_physical_batch_size is None:
+            cfg.global_physical_batch_size = max(cfg.global_logical_batch_size, jax.device_count())
+        cfg.num_physical_feeds = cfg.num_physical_feeds or jax.process_count()
+        cfg.physical_feed_index = cfg.physical_feed_index or jax.process_index()
+        cfg.logical_feed_indices = cfg.logical_feed_indices or list(range(cfg.num_physical_feeds))
+        super().__init__(cfg, parent=parent)
+        cfg = self.config
+        if cfg.global_logical_batch_size % self.num_logical_feeds != 0:
+            raise ValueError(
+                f"global_logical_batch_size {cfg.global_logical_batch_size} must be "
+                f"divisible by num_logical_feeds {self.num_logical_feeds}"
+            )
+        if cfg.global_physical_batch_size % cfg.num_physical_feeds != 0:
+            raise ValueError(
+                f"global_logical_batch_size {cfg.global_physical_batch_size} must be "
+                f"divisible by num_logical_feeds {self.num_physical_feeds}"
+            )
+        if not 0 <= cfg.physical_feed_index < cfg.num_physical_feeds:
+            raise ValueError(
+                f"physical_feed_index {cfg.physical_feed_index} must be "
+                f"in range [0, {cfg.num_physical_feeds})"
+            )
+        if not all(0 <= ix < cfg.num_physical_feeds for ix in cfg.logical_feed_indices):
+            raise ValueError(
+                f"Invalid physical feed index in {cfg.logical_feed_indices}: must be "
+                f"in range [0, {cfg.num_physical_feeds})"
+            )
+        if len(set(cfg.logical_feed_indices)) != len(cfg.logical_feed_indices):
+            raise ValueError(f"logical_feed_indices must be unique: {cfg.logical_feed_indices}")
+
+    @property
+    def num_logical_feeds(self):
+        return len(self.config.logical_feed_indices)
+
+    @property
+    def logical_feed_index(self) -> Optional[int]:
+        cfg = self.config
+        try:
+            return cfg.logical_feed_indices.index(cfg.physical_feed_index)
+        except ValueError:
+            return None
+
+    def physical_feed_read_config(self) -> Dict[str, int]:
+        """Generates the read configuration for the physical feed.
+
+        Returns:
+            A dict containing:
+            - "num_shards": The total number of logical shards to split the source by;
+            - "shard_index": The logical shard index to read for the local physical feed.
+        """
+        cfg = self.config
+        # Set the read config to draw unique data for num logical feed indices only.
+        num_shards = self.num_logical_feeds
+        shard_index = self.logical_feed_index
+        if shard_index is None:
+            # Read an arbitrary shard. It doesn't matter which shard we read, since the results are
+            # not included by the result of `physical_to_logical_batch`.
+            # Here we try to distribute the logical shards evenly.
+            non_logical_feed_indices = [
+                ix for ix in range(cfg.num_physical_feeds) if ix not in cfg.logical_feed_indices
+            ]
+            shard_index = non_logical_feed_indices.index(cfg.physical_feed_index) % num_shards
+        return dict(num_shards=num_shards, shard_index=shard_index)
+
+    def logical_to_physical_batch(self, logical_feed_batch: Nested[Tensor]) -> Nested[Tensor]:
+        cfg = self.config
+        if cfg.global_logical_batch_size == cfg.global_physical_batch_size:
+            return copy.deepcopy(logical_feed_batch)
+        feed_physical_batch_size = cfg.global_physical_batch_size // cfg.num_physical_feeds
+        feed_logical_batch_size = cfg.global_logical_batch_size // self.num_logical_feeds
+
+        def pad_to_physical_batch_size(x: Tensor):
+            if x.ndim < 1 or x.shape[0] != feed_logical_batch_size:
+                raise NotImplementedError(
+                    "Shape does not match logical batch size: "
+                    f"{x.shape} vs. {feed_logical_batch_size}"
+                )
+            if feed_logical_batch_size == feed_physical_batch_size:
+                return x
+            padding = jnp.zeros(
+                [feed_physical_batch_size - feed_logical_batch_size] + list(x.shape[1:]),
+                dtype=x.dtype,
+            )
+            return jnp.concatenate([x, padding], axis=0)
+
+        physical_feed_batch = jax.tree_util.tree_map(pad_to_physical_batch_size, logical_feed_batch)
+
+        if cfg.physical_feed_index in cfg.logical_feed_indices:
+            logical_example_indices = -1 + jnp.zeros([feed_physical_batch_size], dtype=jnp.int32)
+        else:
+            dispatch_start_ix = self.logical_feed_index * feed_logical_batch_size
+            logical_example_indices = jnp.concatenate(
+                # dispatch_start_ix + [0, feed_logical_batch_size).
+                dispatch_start_ix + jnp.arange(feed_logical_batch_size),
+                # Padded with -1's.
+                -1
+                + jnp.zeros([feed_physical_batch_size - feed_logical_batch_size], dtype=jnp.int32),
+            )
+        dispatch = jax.nn.one_hot(
+            logical_example_indices, cfg.global_logical_batch_size, dtype=jnp.bool
+        )
+        assert dispatch.shape == (
+            feed_physical_batch_size,
+            cfg.global_logical_batch_size,
+        ), f"{dispatch.shape} vs. {(feed_physical_batch_size, cfg.global_logical_batch_size)}"
+
+        if PHYSICAL_TO_LOGICAL_DISPATCH_KEY in physical_feed_batch:
+            raise ValueError(f"{PHYSICAL_TO_LOGICAL_DISPATCH_KEY} already exists")
+        physical_feed_batch[PHYSICAL_TO_LOGICAL_DISPATCH_KEY] = dispatch
+        return physical_feed_batch
+
+    def physical_to_logical_batch(self, global_physical_batch: Nested[Tensor]) -> Nested[Tensor]:
+        cfg = self.config
+
+        def traverse_and_dispatch(data: Nested[Tensor]) -> Nested[Tensor]:
+            if isinstance(data, dict):
+                # Dispatch from physical batch dimensions to logical batch.
+                if PHYSICAL_TO_LOGICAL_DISPATCH_KEY in data:
+                    dispatch = data.pop(PHYSICAL_TO_LOGICAL_DISPATCH_KEY)
+                    assert dispatch.shape == (
+                        cfg.global_physical_batch_size,
+                        cfg.global_logical_batch_size,
+                    )
+                    return jax.tree_util.tree_map(
+                        lambda x: jnp.einsum("p...,pl->l...", x, dispatch), data
+                    )
+                for key, value in data.items():
+                    data[key] = traverse_and_dispatch(value)
+            return data
+
+        return traverse_and_dispatch(global_physical_batch)

--- a/axlearn/common/input_dispatch.py
+++ b/axlearn/common/input_dispatch.py
@@ -223,7 +223,7 @@ class InputDispatcher(Module):
             if isinstance(data, dict):
                 # Dispatch from physical batch dimensions to logical batch.
                 if PHYSICAL_TO_LOGICAL_DISPATCH_KEY in data:
-                    dispatch = data.pop(PHYSICAL_TO_LOGICAL_DISPATCH_KEY)
+                    dispatch: Tensor = data.pop(PHYSICAL_TO_LOGICAL_DISPATCH_KEY)
                     assert dispatch.shape == (
                         cfg.global_physical_batch_size,
                         cfg.global_logical_batch_size,

--- a/axlearn/common/input_dispatch.py
+++ b/axlearn/common/input_dispatch.py
@@ -165,6 +165,8 @@ class InputDispatcher(Module):
                     "Shape does not match logical batch size: "
                     f"{x.shape} vs. {feed_logical_batch_size}"
                 )
+            if cfg.physical_feed_index not in cfg.logical_feed_indices:
+                x = jnp.zeros_like(as_numpy_array(x))
             if feed_logical_batch_size == feed_physical_batch_size:
                 return x
             pad_size = feed_physical_batch_size - feed_logical_batch_size

--- a/axlearn/common/input_dispatch.py
+++ b/axlearn/common/input_dispatch.py
@@ -122,6 +122,19 @@ class InputDispatcher(Module):
         return dict(num_shards=num_shards, shard_index=shard_index)
 
     def logical_to_physical_batch(self, logical_feed_batch: Nested[Tensor]) -> Nested[Tensor]:
+        """Converts a per-feed logical batch to a per-feed physical batch.
+
+        Specifically, pads the batch to feed_physical_batch_size and adds a dispatch Tensor under
+        key PHYSICAL_TO_LOGICAL_DISPATCH_KEY, which will be used by physical_to_logical_batch later.
+
+        Args:
+            logical_feed_batch: A per-feed logical batch, where every leaf Tensor should be of
+                shape [feed_logical_batch_size, ...].
+
+        Returns:
+            A per-feed physical batch, where every leaf Tensor should be of shape
+            [feed_physical_batch_size, ...].
+        """
         cfg = self.config
         if (
             cfg.global_logical_batch_size == cfg.global_physical_batch_size
@@ -172,6 +185,16 @@ class InputDispatcher(Module):
         return physical_feed_batch
 
     def physical_to_logical_batch(self, global_physical_batch: Nested[Tensor]) -> Nested[Tensor]:
+        """Converts a global physical batch to a global logical batch.
+
+        Args:
+            global_physical_batch: A global physical batch, where every leaf Tensor should be of
+                shape [global_physical_batch_size, ...].
+
+        Returns:
+            A global logical batch, where every leaf Tensor should be of shape
+            [global_logical_batch_size, ...].
+        """
         cfg = self.config
 
         def traverse_and_dispatch(data: Nested[Tensor]) -> Nested[Tensor]:

--- a/axlearn/common/input_dispatch.py
+++ b/axlearn/common/input_dispatch.py
@@ -101,10 +101,9 @@ class InputDispatcher(Module):
     @property
     def logical_feed_index(self) -> Optional[int]:
         cfg = self.config
-        try:
+        if cfg.physical_feed_index in cfg.logical_feed_indices:
             return cfg.logical_feed_indices.index(cfg.physical_feed_index)
-        except ValueError:
-            return None
+        return None
 
     @property
     def feed_logical_batch_size(self) -> int:

--- a/axlearn/common/input_dispatch.py
+++ b/axlearn/common/input_dispatch.py
@@ -36,7 +36,8 @@ class InputDispatcher(Module):
 
         global_logical_batch_size: Required[int] = REQUIRED
 
-        # If None, defaults to max(global_logical_batch_size, jax.device_count()).
+        # Usually left unset. Defaults to
+        # max(feed_logical_batch_size * num_physical_feeds, jax.device_count()).
         global_physical_batch_size: Optional[int] = None
 
         # The total number of physical feeds across all hosts. Defaults to jax.process_count().
@@ -46,6 +47,7 @@ class InputDispatcher(Module):
         # Defaults to jax.process_index().
         physical_feed_index: Optional[int] = None
 
+        # Usually left unset.
         # If not None, a list of length num_logical_feeds. logical_feed_indices[i] is an integer in
         # [0, num_physical_feeds), representing the physical feed index for the i'th logical feed.
         logical_feed_indices: Optional[Sequence[int]] = None

--- a/axlearn/common/input_dispatch_test.py
+++ b/axlearn/common/input_dispatch_test.py
@@ -3,7 +3,6 @@
 """Tests input dispatcher."""
 
 import random
-from typing import Optional
 
 import jax
 from absl.testing import parameterized
@@ -36,7 +35,7 @@ class DispatcherTest(TestCase):
         logical_feed_indices,
     ):
         all_physical_batches = []
-        dispatcher: Optional[InputDispatcher] = None
+        dispatcher: InputDispatcher = None
         for physical_feed_index in range(num_physical_feeds):
             cfg = InputDispatcher.default_config().set(
                 global_logical_batch_size=global_logical_batch_size,
@@ -82,13 +81,11 @@ class DispatcherTest(TestCase):
             lambda *xs: jnp.concatenate(xs, axis=0),
             *all_physical_batches,
         )
-        print(global_physical_batch)
         self.assertEqual(
             (dispatcher.config.global_physical_batch_size,),
             global_physical_batch["example_index"].shape,
         )
         global_logical_batch = dispatcher.physical_to_logical_batch(global_physical_batch)
-        print(global_logical_batch)
         self.assertEqual(
             {"example_index": (global_logical_batch_size,)}, shapes(global_logical_batch)
         )

--- a/axlearn/common/input_dispatch_test.py
+++ b/axlearn/common/input_dispatch_test.py
@@ -20,6 +20,7 @@ class DispatcherTest(TestCase):
         (8, 16, 2, None),
         (8, 16, 2, (0,)),
         (8, 16, 4, (1, 3)),
+        (2, 16, 16, (7, 11)),
     )
     def test_input_dispatcher(
         self,
@@ -87,6 +88,6 @@ class DispatcherTest(TestCase):
         self.assertEqual(
             {"example_index": (global_logical_batch_size,)}, shapes(global_logical_batch)
         )
-        self.assertCountEqual(
+        self.assertSequenceEqual(
             global_logical_batch["example_index"].tolist(), range(global_logical_batch_size)
         )

--- a/axlearn/common/input_dispatch_test.py
+++ b/axlearn/common/input_dispatch_test.py
@@ -16,12 +16,17 @@ from axlearn.common.utils import shapes
 
 class DispatcherTest(TestCase):
     @parameterized.parameters(
+        # In the most common use cases, users only specify `global_logical_batch_size` and
+        # `num_physical_feeds` and let InputDispatcher figure out `global_physical_batch_size`
+        # and `logical_feed_indices` automatically.
         (8, None, 2, None),
+        (2, None, 16, None),
+        # With explicit `global_physical_batch_size`.
         (8, 16, 2, None),
+        # With explicit `logical_feed_indices`.
         (8, 16, 2, (0,)),
         (8, 16, 4, (1, 3)),
         (2, 16, 16, (7, 11)),
-        (2, None, 16, None),
     )
     def test_input_dispatcher(
         self,

--- a/axlearn/common/input_dispatch_test.py
+++ b/axlearn/common/input_dispatch_test.py
@@ -21,6 +21,7 @@ class DispatcherTest(TestCase):
         (8, 16, 2, (0,)),
         (8, 16, 4, (1, 3)),
         (2, 16, 16, (7, 11)),
+        (2, None, 16, None),
     )
     def test_input_dispatcher(
         self,
@@ -42,10 +43,8 @@ class DispatcherTest(TestCase):
             dispatcher: InputDispatcher = cfg.set(name="dispatcher").instantiate(parent=None)
             if logical_feed_indices is not None:
                 self.assertEqual(len(logical_feed_indices), dispatcher.num_logical_feeds)
-            else:
-                self.assertEqual(num_physical_feeds, dispatcher.num_logical_feeds)
             feed_read_config = dispatcher.feed_read_config()
-            if logical_feed_indices is None or physical_feed_index in logical_feed_indices:
+            if physical_feed_index in dispatcher.config.logical_feed_indices:
                 self.assertIsNotNone(dispatcher.logical_feed_index)
                 self.assertEqual(
                     {
@@ -80,7 +79,7 @@ class DispatcherTest(TestCase):
         )
         print(global_physical_batch)
         self.assertEqual(
-            (global_physical_batch_size or global_logical_batch_size,),
+            (dispatcher.config.global_physical_batch_size,),
             global_physical_batch["example_index"].shape,
         )
         global_logical_batch = dispatcher.physical_to_logical_batch(global_physical_batch)
@@ -88,6 +87,6 @@ class DispatcherTest(TestCase):
         self.assertEqual(
             {"example_index": (global_logical_batch_size,)}, shapes(global_logical_batch)
         )
-        self.assertSequenceEqual(
+        self.assertCountEqual(
             global_logical_batch["example_index"].tolist(), range(global_logical_batch_size)
         )

--- a/axlearn/common/input_dispatch_test.py
+++ b/axlearn/common/input_dispatch_test.py
@@ -1,0 +1,92 @@
+# Copyright © 2024 Apple Inc.
+
+"""Tests input dispatcher."""
+
+import random
+from typing import Optional
+
+import jax
+from absl.testing import parameterized
+from jax import numpy as jnp
+
+from axlearn.common.input_dispatch import InputDispatcher
+from axlearn.common.test_utils import TestCase
+from axlearn.common.utils import shapes
+
+
+class DispatcherTest(TestCase):
+    @parameterized.parameters(
+        (8, None, 2, None),
+        (8, 16, 2, None),
+        (8, 16, 2, (0,)),
+        (8, 16, 4, (1, 3)),
+    )
+    def test_input_dispatcher(
+        self,
+        global_logical_batch_size,
+        global_physical_batch_size,
+        num_physical_feeds,
+        logical_feed_indices,
+    ):
+        all_physical_batches = []
+        dispatcher: Optional[InputDispatcher] = None
+        for physical_feed_index in range(num_physical_feeds):
+            cfg = InputDispatcher.default_config().set(
+                global_logical_batch_size=global_logical_batch_size,
+                global_physical_batch_size=global_physical_batch_size,
+                num_physical_feeds=num_physical_feeds,
+                physical_feed_index=physical_feed_index,
+                logical_feed_indices=logical_feed_indices,
+            )
+            dispatcher: InputDispatcher = cfg.set(name="dispatcher").instantiate(parent=None)
+            if logical_feed_indices is not None:
+                self.assertEqual(len(logical_feed_indices), dispatcher.num_logical_feeds)
+            else:
+                self.assertEqual(num_physical_feeds, dispatcher.num_logical_feeds)
+            feed_read_config = dispatcher.feed_read_config()
+            if logical_feed_indices is None or physical_feed_index in logical_feed_indices:
+                self.assertIsNotNone(dispatcher.logical_feed_index)
+                self.assertEqual(
+                    {
+                        "shard_index": dispatcher.logical_feed_index,
+                        "num_shards": dispatcher.num_logical_feeds,
+                    },
+                    feed_read_config,
+                )
+            else:
+                self.assertIsNone(dispatcher.logical_feed_index)
+                self.assertEqual(dispatcher.num_logical_feeds, feed_read_config["num_shards"])
+            feed_example_start_index = (
+                feed_read_config["shard_index"] * dispatcher.feed_logical_batch_size
+            )
+            feed_logical_batch = {
+                "example_index": feed_example_start_index
+                + jnp.arange(dispatcher.feed_logical_batch_size),
+            }
+            feed_physical_batch = dispatcher.logical_to_physical_batch(feed_logical_batch)
+            self.assertEqual(
+                (dispatcher.feed_physical_batch_size,), feed_physical_batch["example_index"].shape
+            )
+            all_physical_batches.append(feed_physical_batch)
+
+        # Shuffle the feed batches.
+        random.shuffle(all_physical_batches)
+        # Form the global batch by concatenating the tensors.
+        # pylint: disable-next=no-value-for-parameter
+        global_physical_batch = jax.tree_util.tree_map(
+            lambda *xs: jnp.concatenate(xs, axis=0),
+            *all_physical_batches,
+        )
+        print(global_physical_batch)
+        self.assertEqual(
+            (global_physical_batch_size or global_logical_batch_size,),
+            global_physical_batch["example_index"].shape,
+        )
+        global_logical_batch = dispatcher.physical_to_logical_batch(global_physical_batch)
+        print(global_logical_batch)
+        self.assertEqual(
+            {"example_index": (global_logical_batch_size,)}, shapes(global_logical_batch)
+        )
+        self.assertCountEqual(
+            global_logical_batch["example_index"].tolist(), range(global_logical_batch_size)
+        )

--- a/axlearn/common/input_tf_data.py
+++ b/axlearn/common/input_tf_data.py
@@ -1171,11 +1171,12 @@ class Input(Module):
             # Let input_dispatcher determine num_shards and shard_index for tfds_read_config.
             feed_read_config = self.input_dispatcher.feed_read_config()
             set_read_config_recursively(cfg.source, **feed_read_config)
-            logging.info("feed_read_config=%s, source=%s", feed_read_config, cfg.source)
             if cfg.batcher.fn is per_feed_batch:
                 # If using `per_feed_batch`, set feed_batch_size according to `input_batcher`.
                 # If not, we rely on user to set up batcher correctly.
                 cfg.batcher.feed_batch_size = self.input_batcher.feed_logical_batch_size
+            logging.info("feed_read_config=%s", feed_read_config)
+            logging.info("Modified Input.config according to input_batcher:\n%s", cfg)
         self._source = maybe_set_config(cfg.source, is_training=cfg.is_training).instantiate()
         self._processor = maybe_set_config(cfg.processor, is_training=cfg.is_training).instantiate()
         self._batcher = maybe_set_config(cfg.batcher, is_training=cfg.is_training).instantiate()

--- a/axlearn/common/input_tf_data.py
+++ b/axlearn/common/input_tf_data.py
@@ -1174,7 +1174,7 @@ class Input(Module):
             if cfg.batcher.fn is per_feed_batch:
                 # If using `per_feed_batch`, set feed_batch_size according to `input_batcher`.
                 # If not, we rely on user to set up batcher correctly.
-                cfg.batcher.feed_batch_size = self.input_batcher.feed_logical_batch_size
+                cfg.batcher.feed_batch_size = self.input_dispatcher.feed_logical_batch_size
             logging.info("feed_read_config=%s", feed_read_config)
             logging.info("Modified Input.config according to input_batcher:\n%s", cfg)
         self._source = maybe_set_config(cfg.source, is_training=cfg.is_training).instantiate()

--- a/axlearn/common/input_tf_data_test.py
+++ b/axlearn/common/input_tf_data_test.py
@@ -657,11 +657,10 @@ class PadTest(test_utils.TestCase):
             print(f"input_batch={input_batches[0]}")
             self.assertLen(input_batches, num_logical_batches_per_feed)
 
-            if physical_feed_index in logical_feed_indices:
-                for manual_batch, input_batch in zip(manual_feed_batches, input_batches):
-                    print(f"manual_batch={manual_batch}")
-                    print(f"input_batch={input_batch}")
-                    self.assertNestedEqual(manual_batch, input_batch)
+            for manual_batch, input_batch in zip(manual_feed_batches, input_batches):
+                print(f"manual_batch={manual_batch}")
+                print(f"input_batch={input_batch}")
+                self.assertNestedEqual(manual_batch, input_batch)
 
             manual_feeds[physical_feed_index] = manual_feed_batches
             input_feeds[physical_feed_index] = input_batches

--- a/axlearn/common/input_tf_data_test.py
+++ b/axlearn/common/input_tf_data_test.py
@@ -587,7 +587,6 @@ class PadTest(test_utils.TestCase):
         `dispatch_input_batch`.
         """
         text_examples = [[1, 2], [3, 4], [5, 6], [7, 8]]
-        per_feed_physcal_batch_size = physical_batch_size // num_physical_feeds
         feed_logical_batch_size = 2
         feed_physical_batch_size = physical_batch_size // num_physical_feeds
         if feed_physical_batch_size < feed_logical_batch_size:
@@ -617,7 +616,7 @@ class PadTest(test_utils.TestCase):
                         logical_feed_index=logical_feed_index,
                         pad_example_fn=default_pad_example_fn,
                     )
-            physical_feed_ds = physical_feed_ds.batch(per_feed_physcal_batch_size)
+            physical_feed_ds = physical_feed_ds.batch(feed_physical_batch_size)
             manual_feed_batches = list(iter(physical_feed_ds))
             self.assertLen(manual_feed_batches, num_logical_batches_per_feed)
 

--- a/axlearn/common/input_tf_data_test.py
+++ b/axlearn/common/input_tf_data_test.py
@@ -19,6 +19,7 @@ from jax.sharding import Mesh
 from axlearn.common import test_utils, utils
 from axlearn.common.checkpointer import Checkpointer
 from axlearn.common.config import config_for_function
+from axlearn.common.input_dispatch import InputDispatcher
 from axlearn.common.input_fake import fake_serialized_json_source, fake_source, fake_text_source
 from axlearn.common.input_tf_data import (
     BuildDatasetFn,
@@ -369,6 +370,21 @@ def _text_ds(texts: List[str], *, repeat=1) -> tf.data.Dataset:
     return tf.data.Dataset.from_tensor_slices(dataset).repeat(repeat)
 
 
+def _tokens_ds(tokens: List[List[int]], *, repeat=1) -> tf.data.Dataset:
+    dataset = {
+        "tokens": [],
+        "index": [],
+        "is_valid": [],
+    }
+
+    for index, tok in enumerate(tokens):
+        dataset["index"].append(tf.constant(index, dtype=tf.int32))
+        dataset["tokens"].append(tf.constant(tok, dtype=tf.int32))
+        dataset["is_valid"].append(tf.constant(True, dtype=tf.bool))
+
+    return tf.data.Dataset.from_tensor_slices(dataset).repeat(repeat)
+
+
 class PadTest(test_utils.TestCase):
     @parameterized.parameters(None, 1, 5)
     def test_infer_cardinality(self, num_repeats: Optional[int]):
@@ -552,6 +568,83 @@ class PadTest(test_utils.TestCase):
                 ckptr.save(step=step, state={"iterator": iterator}, evaler_summaries=None)
                 ckptr.wait_until_finished()
             self.assertTrue(os.path.exists(os.path.join(save_dir, f"step_{step:08d}", "index")))
+
+    @parameterized.product(
+        num_physical_feeds=(2, 4),
+        physical_batch_size=(4, 8, 16),
+    )
+    def test_input_dispatcher(
+        self,
+        num_physical_feeds: int,
+        physical_batch_size: int,
+    ):
+        text_examples = [[1, 2], [3, 4], [5, 6], [7, 8]]
+        per_feed_physcal_batch_size = physical_batch_size // num_physical_feeds
+        feed_logical_batch_size = 2
+        feed_physical_batch_size = physical_batch_size // num_physical_feeds
+        if feed_physical_batch_size < feed_logical_batch_size:
+            return  # skip invalid cases
+        num_logical_batches_per_feed = len(text_examples) // feed_logical_batch_size
+        logical_feed_indices = [num_physical_feeds - 1]
+        global_logical_batch_size = feed_logical_batch_size * len(logical_feed_indices)
+        for physical_feed_index in range(num_physical_feeds):
+            if physical_feed_index in logical_feed_indices:
+                logical_feed_index = logical_feed_indices.index(physical_feed_index)
+            else:
+                logical_feed_index = None
+            with mock.patch("jax.process_count", return_value=num_physical_feeds):
+                physical_feed_ds = _pad_logical_to_physical(
+                    _tokens_ds(text_examples),
+                    global_batch_size=physical_batch_size,
+                    global_logical_batch_size=global_logical_batch_size,
+                    num_logical_feeds=len(logical_feed_indices),
+                    logical_feed_index=logical_feed_index,
+                    pad_example_fn=default_pad_example_fn,
+                ).batch(per_feed_physcal_batch_size)
+            manual_feed_batches = list(iter(physical_feed_ds))
+            self.assertLen(manual_feed_batches, num_logical_batches_per_feed)
+
+            def source_fn() -> BuildDatasetFn:
+                def fn() -> tf.data.Dataset:
+                    return _tokens_ds(text_examples)
+
+                return fn
+
+            input_generator = (
+                Input.default_config()
+                .set(
+                    name="input",
+                    is_training=True,
+                    source=config_for_function(source_fn),
+                    processor=config_for_function(identity),
+                    batcher=config_for_function(batch).set(
+                        global_batch_size=feed_logical_batch_size,
+                        pad_example_fn=default_pad_example_fn,
+                        repeat=1,
+                    ),
+                    input_dispatcher=InputDispatcher.default_config().set(
+                        global_logical_batch_size=global_logical_batch_size,
+                        global_physical_batch_size=physical_batch_size,
+                        logical_feed_indices=logical_feed_indices,
+                        num_physical_feeds=num_physical_feeds,
+                        physical_feed_index=physical_feed_index,
+                    ),
+                )
+                .instantiate(parent=None)
+            )
+
+            input_it = iter(input_generator.dataset())
+            self.assertIsInstance(input_it, tf.data.Iterator)
+            self._check_iterator_saveable(input_it)
+
+            input_batches = list(input_generator.batches(input_it))
+            self.assertLen(input_batches, num_logical_batches_per_feed)
+
+            if physical_feed_index in logical_feed_indices:
+                for manual_batch, input_batch in zip(manual_feed_batches, input_batches):
+                    print(f"manual_batch={manual_batch}")
+                    print(f"input_batch={input_batch}")
+                    self.assertNestedEqual(manual_batch, input_batch)
 
 
 class BatchTest(test_utils.TestCase):

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -425,7 +425,7 @@ class SpmdTrainer(Module):
                 output = None
                 stop_trace_step = None
 
-                for input_batch in self._input_iter:
+                for input_batch in self.input.batches(self._input_iter):
                     self._maybe_record_event(measurement.Event.START_STEP, self._step)
                     logging.log_first_n(
                         logging.INFO, "input_batch=%s", 3, utils.shapes(input_batch)
@@ -877,9 +877,10 @@ class SpmdTrainer(Module):
         state: TrainerState,
         input_batch: Dict[str, Any],
     ) -> Tuple[TrainerState, NestedTensor]:
+        cfg = self.config
         # Shard and (possibly) dispatch the input batch.
-        input_batch = utils.dispatch_input_batch(
-            input_batch, batch_axis_names=self.config.batch_axis_names
+        input_batch = self.input.dispatch_global_batch(
+            input_batch, batch_axis_names=cfg.batch_axis_names
         )
 
         new_prng_key, param_noise_key, forward_key, learner_key = jax.random.split(
@@ -887,7 +888,7 @@ class SpmdTrainer(Module):
         )
 
         def train_cast(in_tree):
-            return utils.cast_floats(in_tree, to_dtype=self.config.train_dtype)
+            return utils.cast_floats(in_tree, to_dtype=cfg.train_dtype)
 
         # A nested tree of booleans.
         should_compute_gradients = self.learner.should_update_with_optimizers(state.model)

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -8,7 +8,7 @@ import os.path
 import shutil
 import tempfile
 import unittest
-from typing import Any, Callable, Dict, Literal, Optional, Sequence
+from typing import Any, Callable, Dict, Iterable, Literal, Optional, Sequence, Union
 
 import chex
 import jax
@@ -35,7 +35,14 @@ from axlearn.common.learner import UpdateType, should_update_with_optimizers
 from axlearn.common.module import Module
 from axlearn.common.state_builder import Builder as TrainerStateBuilder
 from axlearn.common.trainer import SpmdTrainer, TrainerState, select_mesh_config
-from axlearn.common.utils import NestedTensor, Tensor, as_tensor, flatten_items, match_regex_rules
+from axlearn.common.utils import (
+    NestedTensor,
+    Tensor,
+    as_tensor,
+    dispatch_input_batch,
+    flatten_items,
+    match_regex_rules,
+)
 
 FLAGS = flags.FLAGS
 
@@ -124,6 +131,18 @@ class DummyInput(Module):
         if cfg.total_num_batches is None:
             ds = ds.repeat()
         return ds
+
+    def batches(self, it: tf.data.Iterator) -> Iterable[NestedTensor]:
+        for input_batch in it:
+            yield input_batch
+
+    def dispatch_global_batch(
+        self,
+        global_physical_batch: NestedTensor,
+        *,
+        batch_axis_names: Union[str, Sequence[str]] = "data",
+    ) -> NestedTensor:
+        return dispatch_input_batch(global_physical_batch, batch_axis_names=batch_axis_names)
 
     def __iter__(self):
         # Use a different __iter__ than iter(self.dataset()), to test that input iter can be


### PR DESCRIPTION
A Module to dispatch per-feed logical input batches to global logical batches on device.

    The dispatch process consists of three steps:
    - Convert each logical feed batch to a physical feed batch (logical_to_physical_batch);
    - Assemble a global physical batch from per-feed batches (utils.host_to_global_device_array);
    - Convert a global physical batch to a global logical batch (physical_to_logical_batch).

    This process is needed because `utils.host_to_global_device_array` requires that global batch
    size be divisible by number of devices.

    One should set up the local input generator to read the logical shard as specified by
    `feed_read_config` and batch the examples by `feed_logical_batch_size`.
    One should then call `logical_to_physical_batch` on each per-feed batch, followed by
    `utils.host_to_global_device_array` to generate the input array for pjit, then finally
    `physical_to_logical_batch` inside pjit.

Unlike the current logic, InputDispatcher does not affect tf.data.Iterator, so it also allows us to migrate TF iterator checkpoints from models that do not use InputDispatcher to ones that use InputDispatcher. This is useful for moving training to a larger slice with more input hosts.