### PR TITLE
Fix a missing check on FFN remat spec

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -3684,15 +3684,15 @@ def build_remat_spec(
     # TODO(markblee): Switch to using isinstance everywhere.
     if stack_cfg.klass is PipelinedTransformerLayer:
         return None
-    attention_name = stack_cfg.layer.self_attention.attention.klass.__name__
-    ffn_name = stack_cfg.layer.feed_forward.klass.__name__
 
     checkpoints = []
     if self_attention:
+        attention_name = stack_cfg.layer.self_attention.attention.klass.__name__
         checkpoints.extend(
             [f"{attention_name}.{el}" for el in ["q_proj", "k_proj", "v_proj", "context", "o_proj"]]
         )
-    if feed_forward:
+    if feed_forward and hasattr(stack_cfg.layer, "feed_forward"):
+        ffn_name = stack_cfg.layer.feed_forward.klass.__name__
         checkpoints.extend([f"{ffn_name}.{el}" for el in ["activation", "linear2"]])
 
     return RematSpec(


### PR DESCRIPTION
This PR includes 2 changes, 
1. Add a attribution check in build_remat_spec for FFN, due to potential missing of FFN.
2. Add remat_specs to a few UTs where variance of transformers are used but lack remat coverage.