### PR TITLE
Validate k8s name before launching BastionManagedGKEJob

### DIFF
--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -468,11 +468,6 @@ class BastionManagedGKEJob(BaseBastionManagedJob):
     def _execute(self):
         """Submits the command to bastion."""
         cfg: BastionManagedGKEJob.Config = self.config
-        super()._execute()
-        print(
-            "\nView running pods with:\nkubectl get pods\n"
-            "\nNote that the job may take a few minutes to start."
-        )
         try:
             num_workers = infer_tpu_workers(infer_tpu_type(cfg.instance_type))
         except ValueError:
@@ -489,6 +484,11 @@ class BastionManagedGKEJob(BaseBastionManagedJob):
                 "Replace `--worker=0` with `--worker={idx}` "
                 f"where idx is between [0, {num_workers})."
             )
+        super()._execute()
+        print(
+            "\nView running pods with:\nkubectl get pods\n"
+            "\nNote that the job may take a few minutes to start."
+        )
 
 
 # Launchers specified here will be tried (in the given order) when launching a given instance type.

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -614,6 +614,11 @@ class TestBastionManagedGKEJob(TestWithTemporaryCWD):
         else:
             ctx = contextlib.nullcontext()
 
-        with patch_kube_config, patch_execute, ctx:
+        with ctx, patch_kube_config, patch_execute as mock_execute:
             job: BastionManagedGKEJob = cfg.instantiate()
             job._execute()
+
+            if isinstance(expected, Exception):
+                mock_execute.assert_not_called()
+            else:
+                mock_execute.assert_called_once()


### PR DESCRIPTION
### Change
In launching BastionManagedGKEJob, we should validate the k8s job name before launching the job. 
