### PR TITLE
Request memory for TPUGKEJob pod based on TPU machine type

### DIFF
--- a/axlearn/cloud/gcp/system_characteristics.py
+++ b/axlearn/cloud/gcp/system_characteristics.py
@@ -452,3 +452,10 @@ USER_FACING_NAME_TO_SYSTEM_CHARACTERISTICS = {
         "N/A", 2048, "N/A", "n2-standard-32", 1, AcceleratorType["CPU"], "n2-standard-32-2048"
     ),
 }
+
+# Reference doc https://cloud.google.com/tpu/docs/tpus-in-gke.
+GCE_MACHINE_TYPE_TO_REQUEST_MEMORY_CHARACTERISTICS = {
+    "ct5p-hightpu-4t": 448,
+    "ct4p-hightpu-4t": 407,
+    "ct5lp-hightpu-4t": 192,
+}


### PR DESCRIPTION
Set memory request for worker pod according to its TPU machine type. This can make the pod less vulnerable to eviction.

1. Create a <machine_type to memory> mapping
2. Set the memory using the mapping in _build_cotianiner()

Memory setting reference: https://cloud.google.com/tpu/docs/tpus-in-gke