### PR TITLE
Fixes for when using external KVState

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -1906,7 +1906,7 @@ class GroupedQueryAttention(MultiheadAttention):
 
     def _repeat_kv_heads(self, key_or_value: Tensor) -> Tensor:
         """Repeats key or value heads dim to match the query."""
-        num_head_repeats = self.config.num_heads // self.num_kv_heads
+        num_head_repeats = self.config.num_heads // key_or_value.shape[2]
         if num_head_repeats == 1:
             return key_or_value
         # Repeat along the num_heads dim: [batch, source_length, num_heads, per_head_dim].
@@ -3426,7 +3426,10 @@ class _TransformerRepeat(Repeat):
             v = ys.pop(k, None)
             if v is not None:
                 # Take the output from the last layer.
-                v = v[-1]
+                if isinstance(v, KVState):
+                    v = KVState(k_proj=v.k_proj[-1], v_proj=v.v_proj[-1])
+                else:
+                    v = v[-1]
             carry[k] = v
         return updated_states, TransformerLayer.Output(**carry, **ys)
 


### PR DESCRIPTION
1. If i_proj is set as QLinear, it has no `num_kv_head` property and we have to infer it from the KV tensor shape.
2. If outputting KVState from a repeated setup, indexing by v[-1] would return the v_proj at all layers, as opposed to the k_proj and v_proj at the final layer (what we want). 