### PR TITLE
Adds MultiheadAttention.causal.

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -1724,7 +1724,8 @@ class MultiheadAttention(BaseLayer):
         if cfg.causal:
             seq_len = q_proj.shape[1]
             attention_logit_biases = apply_attention_logit_biases(
-                attention_logit_biases, make_causal_mask(seq_len)
+                make_causal_mask(seq_len).astype(logits.dtype),
+                attention_logit_biases,
             )
         probs = softmax_with_biases(logits, attention_logit_biases=attention_logit_biases)
         probs = self.dropout(probs)

--- a/axlearn/common/causal_lm.py
+++ b/axlearn/common/causal_lm.py
@@ -417,6 +417,7 @@ def gpt_decoder_config(
     layer_cfg.feed_forward.hidden_dim = 4 * hidden_dim
     # Self attention transformer layer config.
     layer_cfg.self_attention.norm = LayerNorm.default_config().set(eps=layer_norm_epsilon)
+    layer_cfg.self_attention.attention.causal = True
     layer_cfg.self_attention.attention.num_heads = num_heads
     # Use residual initialization for output linear layer
     layer_cfg.self_attention.attention.output_linear.param_init = residual_initializer_cfg(
@@ -436,5 +437,6 @@ def gpt_decoder_config(
         ),
         output_norm=LayerNorm.default_config().set(eps=layer_norm_epsilon),
         dropout_rate=dropout_rate,
+        attention_mask=None,
     )
     return decoder

--- a/axlearn/common/decoder_test.py
+++ b/axlearn/common/decoder_test.py
@@ -4,7 +4,7 @@
 # pylint: disable=no-self-use,too-many-branches
 import contextlib
 import unittest
-from typing import Literal, Optional
+from typing import Callable, Literal, Optional
 from unittest import mock
 
 import chex
@@ -20,6 +20,7 @@ from axlearn.common import causal_lm, decoding, logit_modifiers, utils
 from axlearn.common.attention import (
     NEG_INF,
     ALiBiAttentionLogitBiasLayer,
+    CausalAttentionLogitBiasLayer,
     MultiheadAttention,
     RepeatedTransformerLayer,
     StackedTransformerLayer,
@@ -34,6 +35,14 @@ from axlearn.common.flash_attention.layer import FlashAttention
 from axlearn.common.layers import set_bias_recursively
 from axlearn.common.module import functional
 from axlearn.common.test_utils import TestCase, assert_allclose
+
+
+def _enable_causal_attention(cfg: Decoder.Config) -> Decoder.Config:
+    """Enables the causal mode of the MultiheadAttention layer."""
+    cfg.transformer.layer.self_attention.attention.causal = True
+    # We no longer need CausalAttentionLogitBiasLayer.
+    cfg.attention_mask = None
+    return cfg
 
 
 def _enable_flash_attention(cfg: Decoder.Config) -> Decoder.Config:
@@ -136,10 +145,19 @@ class TestDecoder(TestCase):
         untied_head_state["lm_head"]["weight"] = tied_head_state["emb"]["token_emb"]["weight"]
         check_grads(tied_head_state, untied_head_state)
 
-    def test_causal_flash_attention(self):
-        """Tests that FlashAttention with causal=True and attention_mask=None
+    @parameterized.parameters(
+        # MultiheadAttention with causal=True and attention_mask=None.
+        _enable_causal_attention,
+        # FlashAttention with causal=True and attention_mask=None.
+        _enable_flash_attention,
+    )
+    def test_causal_attention(
+        self, make_test_decoder_config: Callable[[Decoder.Config], Decoder.Config]
+    ):
+        """Tests that make_test_decoder_config(ref_cfg) is equivalent to ref_cfg.
 
-        ... is equivalent to a regular attention with CausalAttentionLogitBiasLayer.
+        ... where `ref_cfg` is a Decoder config with a regular attention and
+        CausalAttentionLogitBiasLayer.
         """
         mesh = [1, 1, 1]
         mesh_axis_names = ["data", "fsdp", "model"]
@@ -151,7 +169,7 @@ class TestDecoder(TestCase):
 
             # Similarities with encoder_decoder_test.
             # pylint: disable=duplicate-code
-            decoder_cfg = gpt_decoder_config(
+            ref_cfg = gpt_decoder_config(
                 stack_cfg=StackedTransformerLayer.default_config(),
                 num_layers=2,
                 hidden_dim=hidden_dim,
@@ -160,15 +178,18 @@ class TestDecoder(TestCase):
                 activation_function="nn.relu",
                 max_position_embeddings=source_length,
             ).set(name="decoder")
+            # Use CausalAttentionLogitBiasLayer for the ref layer.
+            ref_cfg.transformer.layer.self_attention.attention.causal = False
+            ref_cfg.attention_mask = CausalAttentionLogitBiasLayer.default_config()
             # Flash attention does not support bias.
-            set_bias_recursively(decoder_cfg, bias=False)
-            decoder = decoder_cfg.instantiate(parent=None)
+            set_bias_recursively(ref_cfg, bias=False)
+            ref_decoder = ref_cfg.instantiate(parent=None)
             # pylint: enable=duplicate-code
-            decoder_state = decoder.initialize_parameters_recursively(jax.random.PRNGKey(0))
+            ref_decoder_state = ref_decoder.initialize_parameters_recursively(jax.random.PRNGKey(0))
 
-            flash_decoder_cfg = _enable_flash_attention(decoder_cfg.clone())
-            flash_decoder = flash_decoder_cfg.instantiate(parent=None)
-            flash_decoder_state = decoder_state
+            test_decoder_cfg = make_test_decoder_config(ref_cfg.clone())
+            test_decoder = test_decoder_cfg.instantiate(parent=None)
+            test_decoder_state = ref_decoder_state
 
             input_ids = jax.random.randint(
                 jax.random.PRNGKey(1), minval=1, maxval=vocab_size, shape=(3, source_length)
@@ -184,9 +205,9 @@ class TestDecoder(TestCase):
                     prng_key=jax.random.PRNGKey(2),
                 )[0]["logits"]
 
-            decoder_logits = layer_output(decoder_state, decoder)
-            flash_decoder_logits = layer_output(flash_decoder_state, flash_decoder)
-            assert_allclose(decoder_logits, flash_decoder_logits)
+            ref_decoder_logits = layer_output(ref_decoder_state, ref_decoder)
+            test_decoder_logits = layer_output(test_decoder_state, test_decoder)
+            assert_allclose(ref_decoder_logits, test_decoder_logits)
 
             # Test decode.
             # Explicitly fill positions >= prefix_length with pad_token_id.
@@ -194,34 +215,33 @@ class TestDecoder(TestCase):
             # [batch_size, source_length].
             prefix_length = jnp.array([1, 3, 6])
             prefix_mask = jnp.arange(source_length) < prefix_length[:, None]
-            prefix = input_ids * prefix_mask + decoder_cfg.pad_token_id * (1 - prefix_mask)
+            prefix = input_ids * prefix_mask + ref_cfg.pad_token_id * (1 - prefix_mask)
             # Set last token to a non-pad token, to fix the prefix length.
             oh_indices = jax.nn.one_hot(prefix_length - 1, source_length, dtype=prefix.dtype)
-            prefix = prefix * (1 - oh_indices) + decoder_cfg.eos_token_id * oh_indices
+            prefix = prefix * (1 - oh_indices) + ref_cfg.eos_token_id * oh_indices
             inputs = dict(
                 prefix=prefix,
                 max_sequence_length=source_length,
                 num_decodes=2,
             )
-            flash_decoder_outputs, _ = functional(
-                flash_decoder,
+            test_decoder_outputs, _ = functional(
+                test_decoder,
                 inputs=inputs,
-                state=flash_decoder_state,
+                state=test_decoder_state,
                 is_training=False,
                 prng_key=jax.random.PRNGKey(2),
                 method="beam_search_decode",
             )
             with utils.numeric_checks(False):
-                decoder_outputs, _ = functional(
-                    decoder,
+                ref_decoder_outputs, _ = functional(
+                    ref_decoder,
                     inputs=inputs,
-                    state=decoder_state,
+                    state=ref_decoder_state,
                     is_training=False,
                     prng_key=jax.random.PRNGKey(2),
                     method="beam_search_decode",
                 )
-        np.testing.assert_array_equal(flash_decoder_outputs.sequences, decoder_outputs.sequences)
-        self.assertTrue(jnp.all(flash_decoder_outputs.sequences == decoder_outputs.sequences))
+        np.testing.assert_array_equal(test_decoder_outputs.sequences, ref_decoder_outputs.sequences)
 
     @parameterized.parameters(None, 0.0, 0.2)
     def test_dropout_rate(self, output_dropout_rate):

--- a/axlearn/common/encoder_decoder_test.py
+++ b/axlearn/common/encoder_decoder_test.py
@@ -484,6 +484,7 @@ class TestAgainstHF(TestCase):
                 output_hidden_states=True,
             ),
             parameters_from_ref_layer=parameters_from_torch_layer,
+            require_same_tree_structure=False,
         )
 
         # Compare outputs at non-padding positions.

--- a/axlearn/common/flash_attention/layer_test.py
+++ b/axlearn/common/flash_attention/layer_test.py
@@ -26,22 +26,25 @@ from axlearn.common.module import functional as F
 from axlearn.common.test_utils import TestCase, is_supported_mesh_shape
 
 
-def _fake_inputs(*, batch: int, num_heads: int, seq_len: int, hidden_dim: int):
+def _fake_inputs(*, batch: int, num_heads: int, seq_len: int, hidden_dim: int, causal: bool):
     query = jax.random.normal(
         jax.random.PRNGKey(0),
         [batch, seq_len, hidden_dim],
         dtype=jnp.bfloat16,
     )
-    key = jax.random.normal(
-        jax.random.PRNGKey(1),
-        [batch, seq_len, hidden_dim],
-        dtype=jnp.bfloat16,
-    )
-    value = jax.random.normal(
-        jax.random.PRNGKey(2),
-        [batch, seq_len, hidden_dim],
-        dtype=jnp.bfloat16,
-    )
+    if causal:
+        key = value = None
+    else:
+        key = jax.random.normal(
+            jax.random.PRNGKey(1),
+            [batch, seq_len, hidden_dim],
+            dtype=jnp.bfloat16,
+        )
+        value = jax.random.normal(
+            jax.random.PRNGKey(2),
+            [batch, seq_len, hidden_dim],
+            dtype=jnp.bfloat16,
+        )
     bias = jax.random.normal(
         jax.random.PRNGKey(3),
         [batch, num_heads, seq_len, seq_len],
@@ -207,6 +210,7 @@ class TestFlashAttention(TestCase):
                 num_heads=num_heads,
                 seq_len=seq_len,
                 hidden_dim=hidden_dim,
+                causal=causal,
             )
             ref_inputs = inputs
             if causal:
@@ -299,6 +303,7 @@ class TestFlashAttention(TestCase):
                 num_heads=num_heads,
                 seq_len=seq_len,
                 hidden_dim=hidden_dim,
+                causal=causal,
             )
             ref_inputs = inputs
             if causal:

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1.txt
@@ -130,7 +130,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 8192
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -200,6 +200,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2.txt
@@ -130,7 +130,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 8192
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -200,6 +200,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3.txt
@@ -130,7 +130,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 8192
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -200,6 +200,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1-single-host.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1-single-host.txt
@@ -142,7 +142,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 4096
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -212,6 +212,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1.txt
@@ -142,7 +142,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 4096
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -212,6 +212,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2-single-host.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2-single-host.txt
@@ -142,7 +142,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 4096
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -212,6 +212,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2.txt
@@ -142,7 +142,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 4096
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -212,6 +212,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3-single-host.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3-single-host.txt
@@ -142,7 +142,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 4096
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -212,6 +212,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3.txt
@@ -142,7 +142,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 4096
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -212,6 +212,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-golden-run-test-v1.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-golden-run-test-v1.txt
@@ -113,7 +113,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 8
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -183,6 +183,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-golden-run-test-v2.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-golden-run-test-v2.txt
@@ -113,7 +113,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 8
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -183,6 +183,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-golden-run-test-v3.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-golden-run-test-v3.txt
@@ -113,7 +113,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 8
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -183,6 +183,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-test-v1.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-test-v1.txt
@@ -118,7 +118,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 8
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -188,6 +188,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-test-v2.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-test-v2.txt
@@ -118,7 +118,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 8
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -188,6 +188,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-test-v3.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-test-v3.txt
@@ -118,7 +118,7 @@ mesh_shape[4]: 1
 model.batch_axis_names[0]: 'data'
 model.batch_axis_names[1]: 'expert'
 model.batch_axis_names[2]: 'fsdp'
-model.decoder.attention_mask.klass: 'axlearn.common.attention.CausalAttentionLogitBiasLayer'
+model.decoder.attention_mask: None
 model.decoder.dim: 8
 model.decoder.dropout_rate: 0.0
 model.decoder.emb.dropout.klass: 'axlearn.common.layers.Dropout'
@@ -188,6 +188,7 @@ model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[1]
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[2]: 'MultiheadAttention.v_proj'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[3]: 'MultiheadAttention.context'
 model.decoder.transformer.layer.remat_spec['policy'].names_which_can_be_saved[4]: 'MultiheadAttention.o_proj'
+model.decoder.transformer.layer.self_attention.attention.causal: True
 model.decoder.transformer.layer.self_attention.attention.dropout.klass: 'axlearn.common.layers.Dropout'
 model.decoder.transformer.layer.self_attention.attention.input_linear.cache_dtype: 'jax.numpy.bfloat16'
 model.decoder.transformer.layer.self_attention.attention.input_linear.input_linear.cache_dtype: 'jax.numpy.bfloat16'

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, Optional, Union
 
 from axlearn.common import causal_lm, config
 from axlearn.common.attention import (
-    CausalAttentionLogitBiasLayer,
     FusedGroupedQKVLinear,
     FusedQKVLinear,
     GroupedQueryAttention,
@@ -269,7 +268,6 @@ def model_config(
         normalization=RMSNorm.default_config().set(eps=1e-5, forward_dtype=None),
         dropout_rate=dropout_rate,
         emb_cfg=TransformerTextEmbeddings.default_config().set(pos_emb=None),
-        attention_mask=None if flash_attention else CausalAttentionLogitBiasLayer.default_config(),
         attention_cfg=flash_attention_config() if flash_attention else atten_cfg,
         attention_qkv_linear=atten_qkv_linear,
     )


### PR DESCRIPTION
This allows users not to pass an explicit `attention_logit_biases` in the common case of causal attention.