### PR TITLE
An implementation of concurrency-bounded array serialization.

### DIFF
--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -1,0 +1,175 @@
+# Copyright © 2024 Apple Inc.
+#
+# Some of the code in this file is adapted from:
+#
+# google/jax:
+# Copyright 2021 The JAX Authors.
+# Licensed under the Apache License, Version 2.0 (the "License").
+
+"""Array serialization utilities.
+
+Reference:
+https://github.com/google/jax/blob/595a620804e810335a870e93975a78504b2e95e5/jax/experimental/array_serialization/serialization.py
+"""
+
+import asyncio
+import functools
+from typing import Callable, Dict, List
+
+import jax
+from absl import logging
+from jax._src.array import Shard
+from jax.experimental.array_serialization import serialization
+
+from axlearn.common.utils import Tensor
+
+
+def _proxy(fut: asyncio.Future) -> asyncio.Future:
+    """Returns a proxy that can be used to await (but does not cancel) `fut`."""
+    proxy = asyncio.Future()
+
+    def callback(_):
+        proxy.set_result(None)
+
+    fut.add_done_callback(callback)
+    return proxy
+
+
+async def _release(limiter: asyncio.BoundedSemaphore, commit: asyncio.Future):
+    """Releases resources when `commit` completes."""
+    await _proxy(commit)
+    limiter.release()
+
+
+async def _open_and_write(
+    *,
+    limiter: asyncio.BoundedSemaphore,
+    tensorstore_spec: Dict,
+    shard: Shard,
+):
+    """Initiates a write for the given shard.
+
+    This waits until `limiter` admits the shard, and blocks until the device-host copy is complete
+    before returning. The shard may be committed in an async fashion, with the commit future
+    appended to `commit_futures`.
+    """
+    await limiter.acquire()
+
+    # Opening with assume_metadata=True should incur no IO ops.
+    t = await serialization.ts.open(
+        serialization.ts.Spec(tensorstore_spec),
+        open=True,
+        assume_metadata=True,
+        context=serialization.TS_CONTEXT,
+    )
+
+    # TODO(markblee): investigate can_reference_source_data_indefinitely after updating tensorstore.
+    write_future = t[shard.index].write(shard.data)
+    await write_future.copy
+
+    # Release without blocking the event loop (commits can complete asynchronously).
+    asyncio.create_task(_release(limiter, write_future.commit))
+    return write_future.commit
+
+
+async def async_serialize(
+    array: Tensor,
+    tensorstore_spec: Dict,
+    *,
+    limiter: asyncio.BoundedSemaphore,
+) -> List[asyncio.Future]:
+    """Similar to `serialization.async_serialize`, but limiting peak host memory usage.
+
+    Specifically, TensorStores are opened on a per-shard basis, only for shards which correspond
+    to the current host, and only if the current in-flight writes are below a user-supplied limit.
+
+    We also simplify the API slightly by assuming replica_id=0 and primary_host=0.
+
+    Reference:
+    https://github.com/google/jax/blob/595a620804e810335a870e93975a78504b2e95e5/jax/experimental/array_serialization/serialization.py#L188
+    """
+    # pylint: disable=protected-access
+
+    # Fully addressable arrays lead to races between multiple writing hosts.
+    assert not (
+        isinstance(array, serialization.array.ArrayImpl)
+        and jax.process_count() > 1
+        and array.is_fully_addressable
+    )
+    if not serialization._spec_has_metadata(tensorstore_spec):
+        tensorstore_spec["metadata"] = serialization._get_metadata(array)
+    if "dtype" not in tensorstore_spec:
+        tensorstore_spec["dtype"] = jax.numpy.dtype(array.dtype).name
+
+    commit_futures = []
+
+    if jax.process_index() == 0:
+        await serialization.ts.open(
+            serialization.ts.Spec(tensorstore_spec),
+            create=True,
+            open=True,
+        )
+
+    local_shards = [shard for shard in array.addressable_shards if shard.replica_id == 0]
+    if not local_shards:
+        return commit_futures
+
+    commit_futures.extend(
+        await asyncio.gather(
+            *(
+                _open_and_write(
+                    limiter=limiter,
+                    tensorstore_spec=tensorstore_spec,
+                    shard=shard,
+                )
+                for shard in local_shards
+            )
+        )
+    )
+    return commit_futures
+
+
+class BoundedAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
+    """A concurrency-bounded implementation of JAX array serialization.
+
+    The main difference is that we write at most `max_concurrency` shards concurrently.
+    """
+
+    def __init__(self, *, max_concurrency: int, timeout_secs: int = 300):
+        super().__init__(timeout_secs)
+        if max_concurrency <= 0:
+            raise ValueError("max_concurrency must be strictly positive.")
+        self._max_concurrency = max_concurrency
+
+    def serialize(
+        self,
+        arrays: List[Tensor],
+        tensorstore_specs: List[Dict],
+        *,
+        on_commit_callback: Callable[[], None],
+    ):
+        """See JAX `GlobalAsyncCheckpointManager` docstring."""
+
+        logging.info("Waiting for previous serialization to finish.")
+        self.wait_until_finished()
+
+        async def _run_serializer(*, arrays, tensorstore_specs, max_concurrency):
+            limiter = asyncio.BoundedSemaphore(value=max_concurrency)
+            future_writer = jax.tree_util.tree_map(
+                functools.partial(async_serialize, limiter=limiter),
+                arrays,
+                tensorstore_specs,
+            )
+            return await asyncio.gather(*future_writer)
+
+        commit_futures = asyncio.run(
+            _run_serializer(
+                arrays=arrays,
+                tensorstore_specs=tensorstore_specs,
+                max_concurrency=self._max_concurrency,
+            )
+        )
+        commit_futures = jax.tree_util.tree_flatten(commit_futures)[0]
+        self._add_futures(commit_futures)
+        logging.info("Starting async commit.")
+        self._start_async_commit(on_commit_callback)

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -14,7 +14,7 @@ https://github.com/google/jax/blob/595a620804e810335a870e93975a78504b2e95e5/jax/
 
 import asyncio
 import functools
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Set
 
 import jax
 from absl import logging
@@ -26,64 +26,71 @@ from axlearn.common.utils import Tensor
 
 def _proxy(fut: asyncio.Future) -> asyncio.Future:
     """Returns a proxy that can be used to await (but does not cancel) `fut`."""
-    proxy = asyncio.Future()
+    loop = asyncio.get_event_loop()
+    proxy = loop.create_future()
 
     def callback(_):
-        proxy.set_result(None)
+        # Callback may be invoked from a separate event loop.
+        if not loop.is_closed():
+            loop.call_soon_threadsafe(proxy.set_result, None)
 
     fut.add_done_callback(callback)
     return proxy
 
 
-async def _release(limiter: asyncio.BoundedSemaphore, commit: asyncio.Future):
+async def _release(
+    limiter: serialization._LimitInFlightBytes,
+    commit: asyncio.Future,
+    nbytes: int,
+):
     """Releases resources when `commit` completes."""
     await _proxy(commit)
-    limiter.release()
+    await limiter.release_bytes(nbytes)
 
 
-async def _open_and_write(
+async def _acquire_and_write(
+    t,
     *,
-    limiter: asyncio.BoundedSemaphore,
-    tensorstore_spec: Dict,
+    limiter: serialization._LimitInFlightBytes,
     shard: Shard,
+    nbytes: int,
+    release_tasks: Set,
 ):
     """Initiates a write for the given shard.
 
     This waits until `limiter` admits the shard, and blocks until the device-host copy is complete
-    before returning. The shard may be committed in an async fashion, with the commit future
-    appended to `commit_futures`.
+    before returning. The shard may be committed in an async fashion; the commit future is returned
+    so that the caller can await it at a later point in time.
     """
-    await limiter.acquire()
-
-    # Opening with assume_metadata=True should incur no IO ops.
-    t = await serialization.ts.open(
-        serialization.ts.Spec(tensorstore_spec),
-        open=True,
-        assume_metadata=True,
-        context=serialization.TS_CONTEXT,
-    )
-
-    # TODO(markblee): investigate can_reference_source_data_indefinitely after updating tensorstore.
+    await limiter.wait_for_bytes(nbytes)
+    # TODO(markblee): Investigate can_reference_source_data_indefinitely after updating tensorstore.
     write_future = t[shard.index].write(shard.data)
     await write_future.copy
-
     # Release without blocking the event loop (commits can complete asynchronously).
-    asyncio.create_task(_release(limiter, write_future.commit))
+    release_task = asyncio.create_task(_release(limiter, write_future.commit, nbytes))
+    release_tasks.add(release_task)
+    release_task.add_done_callback(release_tasks.discard)
     return write_future.commit
+
+
+def _local_shards(array: Tensor) -> List[Shard]:
+    """Returns addressable shards with replica_id=0."""
+    return [shard for shard in array.addressable_shards if shard.replica_id == 0]
 
 
 async def async_serialize(
     array: Tensor,
     tensorstore_spec: Dict,
     *,
-    limiter: asyncio.BoundedSemaphore,
+    limiter: serialization._LimitInFlightBytes,
 ) -> List[asyncio.Future]:
     """Similar to `serialization.async_serialize`, but limiting peak host memory usage.
 
-    Specifically, TensorStores are opened on a per-shard basis, only for shards which correspond
-    to the current host, and only if the current in-flight writes are below a user-supplied limit.
+    Specifically, TensorStores are opened only for shards which correspond to the current host, and
+    only if the current in-flight writes are below a user-supplied limit.
 
-    We also simplify the API slightly by assuming replica_id=0 and primary_host=0.
+    We also simplify the API slightly by assuming replica_id=0 and primary_host=0, and by returning
+    commit futures rather than mutating an input array.
 
     Reference:
     https://github.com/google/jax/blob/595a620804e810335a870e93975a78504b2e95e5/jax/experimental/array_serialization/serialization.py#L188
@@ -101,8 +108,6 @@ async def async_serialize(
     if "dtype" not in tensorstore_spec:
         tensorstore_spec["dtype"] = jax.numpy.dtype(array.dtype).name
 
-    commit_futures = []
-
     if jax.process_index() == 0:
         await serialization.ts.open(
             serialization.ts.Spec(tensorstore_spec),
@@ -110,36 +115,43 @@ async def async_serialize(
             open=True,
         )
 
-    local_shards = [shard for shard in array.addressable_shards if shard.replica_id == 0]
+    local_shards = _local_shards(array)
     if not local_shards:
-        return commit_futures
+        return []
 
-    commit_futures.extend(
-        await asyncio.gather(
-            *(
-                _open_and_write(
-                    limiter=limiter,
-                    tensorstore_spec=tensorstore_spec,
-                    shard=shard,
-                )
-                for shard in local_shards
+    # Opening with assume_metadata=True should incur no IO ops.
+    t = await serialization.ts.open(
+        serialization.ts.Spec(tensorstore_spec),
+        open=True,
+        assume_metadata=True,
+        context=serialization.TS_CONTEXT,
+    )
+    # Keep references to release() calls, since asyncio only keeps weak references to tasks:
+    # https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+    release_tasks = set()
+    return await asyncio.gather(
+        *(
+            # Memory usage seems to be proportional to the array size rather than shard sizes.
+            # TODO(markblee): Investigate why this is the case.
+            _acquire_and_write(
+                t, limiter=limiter, shard=shard, nbytes=array.nbytes, release_tasks=release_tasks
             )
+            for shard in local_shards
         )
     )
-    return commit_futures
 
 
 class BoundedAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
     """A concurrency-bounded implementation of JAX array serialization.
 
-    The main difference is that we write at most `max_concurrency` shards concurrently.
+    The main difference is that we attempt to keep at most `max_concurrent_gb` bytes in memory.
     """
 
-    def __init__(self, *, max_concurrency: int, timeout_secs: int = 300):
+    def __init__(self, *, max_concurrent_gb: int, timeout_secs: int = 300):
         super().__init__(timeout_secs)
-        if max_concurrency <= 0:
-            raise ValueError("max_concurrency must be strictly positive.")
-        self._max_concurrency = max_concurrency
+        if max_concurrent_gb <= 0:
+            raise ValueError("max_concurrent_gb must be strictly positive.")
+        self._max_concurrent_bytes = int(max_concurrent_gb * 10**9)
 
     def serialize(
         self,
@@ -153,8 +165,21 @@ class BoundedAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
         logging.info("Waiting for previous serialization to finish.")
         self.wait_until_finished()
 
-        async def _run_serializer(*, arrays, tensorstore_specs, max_concurrency):
-            limiter = asyncio.BoundedSemaphore(value=max_concurrency)
+        max_shard_bytes = max((0, *(array.nbytes for array in arrays)))
+        max_concurrent_bytes = self._max_concurrent_bytes
+        if max_shard_bytes > max_concurrent_bytes:
+            logging.warning(
+                "Max shard size %s exceeds max_concurrent_bytes %s. "
+                "Will adjust max_concurrent_bytes to fit.",
+                max_shard_bytes,
+                max_concurrent_bytes,
+            )
+            max_concurrent_bytes = max_shard_bytes
+
+        async def _run_serializer(*, arrays, tensorstore_specs, max_concurrent_bytes):
+            # We add 1 because LimitInFlightBytes expects a limit strictly greater than any request.
+            # pylint: disable-next=protected-access
+            limiter = serialization._LimitInFlightBytes(max_concurrent_bytes + 1)
             future_writer = jax.tree_util.tree_map(
                 functools.partial(async_serialize, limiter=limiter),
                 arrays,
@@ -166,8 +191,8 @@ class BoundedAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
             _run_serializer(
                 arrays=arrays,
                 tensorstore_specs=tensorstore_specs,
-                max_concurrency=self._max_concurrency,
-            )
+                max_concurrent_bytes=max_concurrent_bytes,
+            ),
         )
         commit_futures = jax.tree_util.tree_flatten(commit_futures)[0]
         self._add_futures(commit_futures)

--- a/axlearn/common/array_serialization_test.py
+++ b/axlearn/common/array_serialization_test.py
@@ -1,0 +1,252 @@
+# Copyright © 2024 Apple Inc.
+
+"""Tests array serialization utils."""
+# pylint: disable=protected-access
+
+import asyncio
+import contextlib
+import functools
+from typing import List, Optional
+from unittest import mock
+
+import jax.numpy as jnp
+from absl.testing import parameterized
+from jax import Shard
+
+from axlearn.common import array_serialization
+from axlearn.common.array_serialization import (
+    BoundedAsyncCheckpointManager,
+    _open_and_write,
+    _proxy,
+    async_serialize,
+    serialization,
+)
+
+
+class SerializerTest(parameterized.TestCase):
+    """Tests serialization utils."""
+
+    def test_fully_addressable(self):
+        """Tests that we don't attempt to serialize fully addressable arrays across multiple hosts,
+        which can lead to races.
+        """
+        with mock.patch("jax.process_count", return_value=2), self.assertRaises(Exception):
+            asyncio.run(async_serialize(jnp.array(1), {}, limiter=asyncio.BoundedSemaphore()))
+
+    @parameterized.parameters(
+        dict(process_index=0),
+        dict(process_index=1),
+        dict(process_index=0, addressable_shards=[]),
+    )
+    def test_async_serialize(self, process_index: int, addressable_shards: Optional[List] = None):
+        """Tests async_serialize.
+
+        We should only open_and_write shards which belong to the current process.
+        """
+        mock_open_fut = mock.AsyncMock()()
+        mock_open = mock.Mock(return_value=mock_open_fut)
+        ts_spec = {"dummy_key": "dummy_value"}
+        if addressable_shards is None:
+            addressable_shards = [
+                mock.MagicMock(id=0, replica_id=0),
+                mock.MagicMock(id=1, replica_id=0),
+                mock.MagicMock(id=2, replica_id=1),
+            ]
+        array = mock.MagicMock(
+            dtype=jnp.bfloat16,
+            addressable_shards=addressable_shards,
+        )
+
+        patch_ts = mock.patch.multiple(
+            f"{serialization.__name__}.ts",
+            open=mock_open,
+            Spec=mock.DEFAULT,
+        )
+        patch_process_id = mock.patch("jax.process_index", return_value=process_index)
+        patch_write = mock.patch(f"{array_serialization.__name__}._open_and_write")
+
+        async def serialize(array, spec):
+            limiter = asyncio.BoundedSemaphore()
+            return await async_serialize(array, spec, limiter=limiter)
+
+        with patch_process_id, patch_write as mock_write, patch_ts as mock_ts:
+            asyncio.run(serialize(array, ts_spec))
+            # Check that open is only invoked for process 0.
+            self.assertEqual(mock_open.called, process_index == 0)
+            # Check that open is invoked with the right spec.
+            if process_index == 0:
+                self.assertIn(ts_spec, mock_ts["Spec"].call_args[0])
+            else:
+                self.assertIsNone(mock_ts["Spec"].call_args)
+
+            # Check that open_and_write is only invoked for local shards.
+            # If no local shards, open_and_write should not be invoked.
+            if addressable_shards:
+                expected_shard_ids = [
+                    shard.id for shard in addressable_shards if shard.replica_id == 0
+                ]
+                opened_shards = [call_args[1]["shard"] for call_args in mock_write.call_args_list]
+                self.assertCountEqual(expected_shard_ids, [shard.id for shard in opened_shards])
+            else:
+                self.assertFalse(mock_write.called)
+
+    def test_proxy_cancel(self):
+        """Tests that cancelling a proxy does not cancel the original future."""
+
+        async def call():
+            fut = asyncio.Future()
+            proxy_fut = _proxy(fut)
+            proxy_fut.cancel()
+            self.assertFalse(fut.cancelled())
+
+        asyncio.run(call())
+
+    def test_proxy_await(self):
+        """Tests that awaiting a proxy awaits the original future."""
+
+        async def set_result(f):
+            await asyncio.sleep(0.1)
+            f.set_result(None)
+
+        async def call():
+            fut = asyncio.Future()
+            asyncio.create_task(set_result(fut))
+            await _proxy(fut)
+            self.assertTrue(fut.done())
+
+        asyncio.run(call())
+
+    @parameterized.parameters(
+        # Test a case where we process shards one-by-one.
+        dict(num_shards=3, max_concurrency=1),
+        # Test a case where we process shards all at once.
+        dict(num_shards=3, max_concurrency=3),
+        # Test a case where copy fails, which should surface immediately.
+        dict(
+            num_shards=2,
+            max_concurrency=1,
+            copies=[None, RuntimeError("copy_fail")],
+            expect_error=RuntimeError("copy_fail"),
+        ),
+        # Test a case where commit fails, but we don't wait for it.
+        dict(num_shards=1, max_concurrency=3, commits=[RuntimeError("commit_fail")]),
+    )
+    def test_open_and_write(
+        self,
+        num_shards: int,
+        max_concurrency: int,
+        commits: Optional[List[RuntimeError]] = None,
+        copies: Optional[List[RuntimeError]] = None,
+        expect_error: Optional[RuntimeError] = None,
+    ):
+        """Tests open_and_write.
+
+        Specifically, it should respect max_concurrency, and block on copies but not commits.
+        """
+        written = []
+        concurrent_copy = 0
+        max_concurrency_actual = 0
+        commits = commits or [None] * num_shards
+        copies = copies or [None] * num_shards
+
+        async def mock_commit(i):
+            if commits[i] is not None:
+                raise commits[i]
+            await asyncio.sleep(1)
+            return i
+
+        async def mock_copy(i):
+            nonlocal concurrent_copy
+            await asyncio.sleep(0)  # Yield to event loop.
+            concurrent_copy -= 1
+            if copies[i] is not None:
+                raise copies[i]
+
+        expected_commit_futures = [
+            mock.AsyncMock(wraps=functools.partial(mock_commit, i=i))() for i in range(num_shards)
+        ]
+
+        def mock_write(i):
+            nonlocal concurrent_copy, max_concurrency_actual
+            concurrent_copy += 1
+            max_concurrency_actual = max(max_concurrency_actual, concurrent_copy)
+            written.append(i)
+            return mock.AsyncMock(
+                copy=mock.AsyncMock(wraps=functools.partial(mock_copy, i=i))(),
+                commit=expected_commit_futures[i],
+            )
+
+        mock_write_futs = [
+            mock.Mock(**{"write.side_effect": mock_write}) for _ in range(num_shards)
+        ]
+
+        def mock_ts_index(self, idx):
+            del self
+            return mock_write_futs[idx]
+
+        class MockTs(mock.AsyncMock):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.__getitem__ = mock_ts_index
+
+        mock_ts = mock.AsyncMock(return_value=MockTs())
+
+        async def open_and_write(*, shards: List[Shard]):
+            limiter = asyncio.BoundedSemaphore(max_concurrency)
+            return await asyncio.gather(
+                *(
+                    _open_and_write(
+                        limiter=limiter,
+                        tensorstore_spec={"idx": i},
+                        shard=shard,
+                    )
+                    for i, shard in enumerate(shards)
+                )
+            )
+
+        if expect_error:
+            ctx = self.assertRaisesRegex(type(expect_error), str(expect_error))
+        else:
+            ctx = contextlib.nullcontext()
+
+        with (
+            ctx,
+            # Mock out _proxy since the commit futures aren't actually futures.
+            mock.patch(f"{array_serialization.__name__}._proxy", side_effect=lambda fut: fut),
+            mock.patch.multiple(
+                f"{serialization.__name__}.ts",
+                open=mock_ts,
+                Spec=mock.DEFAULT,
+            ) as mocks,
+        ):
+            shards = [mock.Mock(index=i, data=i) for i in range(num_shards)]
+            commit_futures = asyncio.run(open_and_write(shards=shards))
+
+            # Check that open is called with the right spec.
+            self.assertCountEqual(
+                [({"idx": i},) for i in range(num_shards)],
+                [call_args[0] for call_args in mocks["Spec"].call_args_list],
+            )
+
+            # Check that open is awaited once per shard.
+            self.assertEqual(num_shards, mock_ts.await_count)
+            # Check that max_concurrency is respected.
+            self.assertLessEqual(max_concurrency_actual, max_concurrency)
+            # Check that all shards written once.
+            self.assertCountEqual([shard.data for shard in shards], written)
+            # Check that commit futures are tracked.
+            self.assertCountEqual(expected_commit_futures, commit_futures)
+
+    def test_max_concurrency(self):
+        with self.assertRaisesRegex(ValueError, "strictly positive"):
+            BoundedAsyncCheckpointManager(max_concurrency=0)
+
+    def test_serialize_consecutive(self):
+        """Tests that serialize waits for prior serialization to finish."""
+        manager = BoundedAsyncCheckpointManager(max_concurrency=1)
+        mock_serialize = mock.patch(
+            f"{array_serialization.__name__}.async_serialize", return_value=mock.AsyncMock()
+        )
+        with mock_serialize, mock.patch.object(manager, "wait_until_finished") as mock_wait:
+            manager.serialize([], [], on_commit_callback=lambda *args: None)
+            self.assertTrue(mock_wait.called)

--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -29,6 +29,7 @@ from jax.experimental import maps, multihost_utils
 from jax.experimental.array_serialization import serialization as array_serialization
 
 from axlearn.common import utils
+from axlearn.common.array_serialization import BoundedAsyncCheckpointManager
 from axlearn.common.config import (
     REQUIRED,
     Configurable,
@@ -303,14 +304,29 @@ class TensorStoreStateStorage(StateStorage):
 
     @config_class
     class Config(StateStorage.Config):
-        """Configures TensorStoreStateStorage."""
+        """Configures TensorStoreStateStorage.
+
+        Attributes:
+            timeout_secs: Barrier timeout in seconds.
+            max_concurrency: Max concurrent shards to write.
+        """
 
         timeout_secs: float = 3600
+        max_concurrency: Optional[int] = None
 
     def __init__(self, cfg: Config):
         super().__init__(cfg)
         cfg = self.config
-        self._manager = array_serialization.GlobalAsyncCheckpointManager(cfg.timeout_secs)
+        # TODO(markblee): Consider making BoundedAsyncCheckpointManager the default once stable.
+        if cfg.max_concurrency is not None:
+            self._manager = BoundedAsyncCheckpointManager(
+                max_concurrency=cfg.max_concurrency,
+                timeout_secs=cfg.timeout_secs,
+            )
+        else:
+            self._manager = array_serialization.GlobalAsyncCheckpointManager(
+                timeout_secs=cfg.timeout_secs
+            )
 
     @dataclasses.dataclass
     class CheckpointSpec:  # pylint: disable=too-many-instance-attributes
@@ -324,6 +340,7 @@ class TensorStoreStateStorage(StateStorage):
         tf_ckpt_map: Dict[str, Any]
 
     def _spec_from_path(self, ckpt_path: str):
+        # TODO(markblee): Enable ocdbt driver.
         return array_serialization.get_tensorstore_spec(ckpt_path)
 
     def _get_spec(self, step: int, state: NestedTensor, ckpt_dir: str) -> CheckpointSpec:
@@ -378,6 +395,7 @@ class TensorStoreStateStorage(StateStorage):
         ckpt_dir: str,
         on_commit_callback: StateStorageCommitCallback = write_index_file,
     ):
+        start_time = time.perf_counter()
         # We write data files directly to `ckpt_dir`. `index` is written into `ckpt_dir` in
         # `on_commit_callback` to finalize the checkpoint.
         spec = self._get_spec(step, state, ckpt_dir)
@@ -394,16 +412,20 @@ class TensorStoreStateStorage(StateStorage):
         multihost_utils.sync_global_devices(ckpt_dir)
         # Each worker writes its tf checkpoints under a different path.
         save_tf_savables(spec.tf_ckpt_map, dir=os.path.join(ckpt_dir, f"tf_{jax.process_index()}"))
+
+        def commit():
+            on_commit_callback(ckpt_dir=ckpt_dir, index=spec.index)
+            logging.info(
+                "Serialization of %s completed in %s seconds.",
+                ckpt_dir,
+                time.perf_counter() - start_time,
+            )
+
         # Run serialization of GDA values in parallel.
         logging.info(
             "array_values=%s tensorstore=%s", utils.shapes(spec.gda_values), spec.tensorstore_specs
         )
-        self._manager.serialize(
-            spec.gda_values,
-            spec.tensorstore_specs,
-            on_commit_callback=lambda: on_commit_callback(ckpt_dir=ckpt_dir, index=spec.index),
-        )
-        logging.info("GlobalAsyncCheckpointManager.serialize done")
+        self._manager.serialize(spec.gda_values, spec.tensorstore_specs, on_commit_callback=commit)
 
     def wait_until_finished(self):
         self._manager.wait_until_finished()
@@ -428,7 +450,7 @@ class TensorStoreStateStorage(StateStorage):
             spec.tf_ckpt_map, dir=os.path.join(ckpt_dir, f"tf_{jax.process_index()}")
         )
 
-        restored_gda_values = array_serialization.run_deserialization(
+        restored_gda_values = self._manager.deserialize(
             shardings=spec.shardings,
             tensorstore_specs=spec.tensorstore_specs,
             global_shapes=spec.shapes,
@@ -673,12 +695,10 @@ class Checkpointer(Module):
         if step < 0 or step >= 10**8:
             raise ValueError(f"Out-of-range: {step}")
         ckpt_dir = self.ckpt_dir(step)
-        start_time = time.perf_counter()
         _cleanup_checkpoint(ckpt_dir)
         self._storage.save_to_dir(
             step=step, state=state, ckpt_dir=ckpt_dir, on_commit_callback=write_index_file
         )
-        end_time = time.perf_counter()
         if "summary_writer" in self.children:
             self.summary_writer.log_checkpoint(
                 step=step,
@@ -686,9 +706,6 @@ class Checkpointer(Module):
                 ckpt_dir=ckpt_dir,
                 action=CheckpointerAction.SAVE,
             )
-        logging.info(
-            "Saved checkpoint with %s in %s seconds", type(self._storage), end_time - start_time
-        )
 
     def run_garbage_collection(self):
         """Runs one round of garbage collection of past checkpoints.

--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -308,19 +308,20 @@ class TensorStoreStateStorage(StateStorage):
 
         Attributes:
             timeout_secs: Barrier timeout in seconds.
-            max_concurrency: Max concurrent shards to write.
+            max_concurrent_gb: Max concurrent shards (in GB) to write.
         """
 
         timeout_secs: float = 3600
-        max_concurrency: Optional[int] = None
+        max_concurrent_gb: Optional[int] = None
 
     def __init__(self, cfg: Config):
         super().__init__(cfg)
         cfg = self.config
+
         # TODO(markblee): Consider making BoundedAsyncCheckpointManager the default once stable.
-        if cfg.max_concurrency is not None:
+        if cfg.max_concurrent_gb is not None:
             self._manager = BoundedAsyncCheckpointManager(
-                max_concurrency=cfg.max_concurrency,
+                max_concurrent_gb=cfg.max_concurrent_gb,
                 timeout_secs=cfg.timeout_secs,
             )
         else:

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -656,10 +656,10 @@ class CheckpointerTest(test_utils.TestCase):
 
 class TensorStoreStateStorageTest(test_utils.TestCase):
     @parameterized.parameters(None, 1)
-    def test_max_concurrency(self, max_concurrency: Optional[int]):
-        cfg = TensorStoreStateStorage.default_config().set(max_concurrency=max_concurrency)
+    def test_max_concurrent_gb(self, max_concurrent_gb: Optional[int]):
+        cfg = TensorStoreStateStorage.default_config().set(max_concurrent_gb=max_concurrent_gb)
         storage = cfg.instantiate()
-        if max_concurrency is not None:
+        if max_concurrent_gb is not None:
             self.assertIsInstance(storage._manager, BoundedAsyncCheckpointManager)
         else:
             self.assertIsInstance(

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -5,11 +5,13 @@
 Some tests are intended to be run on TPU.
 """
 
-# pylint: disable=no-self-use,protected-access
 import os
+import queue
 import re
 import tempfile
 import threading
+
+# pylint: disable=no-self-use,protected-access
 from typing import Iterable, List, Optional, Sequence
 from unittest import mock
 
@@ -20,8 +22,10 @@ from absl import logging
 from absl.testing import absltest, parameterized
 from jax import numpy as jnp
 from jax.experimental import mesh_utils
+from jax.experimental.array_serialization import serialization as array_serialization
 
 from axlearn.common import checkpointer, test_utils, utils
+from axlearn.common.array_serialization import BoundedAsyncCheckpointManager
 from axlearn.common.checkpointer import (
     BestMetricPolicy,
     Checkpointer,
@@ -651,6 +655,17 @@ class CheckpointerTest(test_utils.TestCase):
 
 
 class TensorStoreStateStorageTest(test_utils.TestCase):
+    @parameterized.parameters(None, 1)
+    def test_max_concurrency(self, max_concurrency: Optional[int]):
+        cfg = TensorStoreStateStorage.default_config().set(max_concurrency=max_concurrency)
+        storage = cfg.instantiate()
+        if max_concurrency is not None:
+            self.assertIsInstance(storage._manager, BoundedAsyncCheckpointManager)
+        else:
+            self.assertIsInstance(
+                storage._manager, array_serialization.GlobalAsyncCheckpointManager
+            )
+
     @parameterized.parameters(jnp.float32, jnp.bfloat16, jnp.int32, jnp.int16)
     def test_save_and_restore_from_dir(self, restore_floats_as: jnp.dtype):
         mesh_shape = (1, 1)
@@ -670,17 +685,13 @@ class TensorStoreStateStorageTest(test_utils.TestCase):
                 storage.save_to_dir(step=step, state=state, ckpt_dir=final_dir)
                 storage.wait_until_finished()
 
-                # Restore.
-                def restore_state():
-                    return storage.restore_from_dir(
-                        step,
-                        state=make_state(float_dtype=restore_floats_as),
-                        ckpt_dir=final_dir,
-                        validation=CheckpointValidationType.EXACT_UP_TO_DTYPE,
-                    )
-
                 # Successfully restores with different dtypes.
-                restored_state = restore_state()
+                restored_state = storage.restore_from_dir(
+                    step,
+                    state=make_state(float_dtype=restore_floats_as),
+                    ckpt_dir=final_dir,
+                    validation=CheckpointValidationType.EXACT_UP_TO_DTYPE,
+                )
                 self.assertNestedEqual(
                     restored_state,
                     (
@@ -689,6 +700,33 @@ class TensorStoreStateStorageTest(test_utils.TestCase):
                         else make_state(float_dtype=restore_floats_as)
                     ),
                 )
+
+    def test_save_to_dir_async(self):
+        """Tests that serialization happens async."""
+        mesh_shape = (1, 1)
+        if not test_utils.is_supported_mesh_shape(mesh_shape):
+            return
+        with _mesh(mesh_shape):
+            storage = TensorStoreStateStorage.default_config().instantiate()
+            with tempfile.TemporaryDirectory() as temp_dir:
+                # We do a blocking set on the main thread and a blocking get on commit.
+                q = queue.Queue()
+                committed_value = None
+
+                def on_commit_callback(**kwargs):
+                    del kwargs
+                    nonlocal committed_value
+                    committed_value = q.get(block=True)
+
+                storage.save_to_dir(
+                    step=1,
+                    state=dict(x=jnp.zeros([], dtype=jnp.int32)),
+                    ckpt_dir=temp_dir,
+                    on_commit_callback=on_commit_callback,
+                )
+                q.put("test", block=True)
+                storage.wait_until_finished()
+                self.assertEqual("test", committed_value)
 
 
 def _write_shards(lines: Iterable[str], *, path_prefix, num_shards) -> List[str]:

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -710,14 +710,14 @@ class TrainerTest(test_utils.TestCase):
     @parameterized.product(
         save_input_iterator=[False, True],
         restore_input_iterator=[False, True],
-        max_concurrency=[None, 1],
+        max_concurrent_gb=[None, 1],
     )
     def test_checkpoint_policy(
         self,
         *,
         save_input_iterator: bool,
         restore_input_iterator: bool,
-        max_concurrency: Optional[int],
+        max_concurrent_gb: Optional[int],
     ):
         """Test checkpoint policy when evaler and checkpointer run at different cadences."""
         model_cfg = DummyModel.default_config().set(dtype=jnp.float32)
@@ -762,7 +762,7 @@ class TrainerTest(test_utils.TestCase):
             ),
             save_input_iterator=save_input_iterator,
         )
-        cfg.checkpointer.storage.max_concurrency = max_concurrency
+        cfg.checkpointer.storage.max_concurrent_gb = max_concurrent_gb
 
         # Run trainer.
         trainer: SpmdTrainer = cfg.instantiate(parent=None)

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 """Tests SpmdTrainer."""
+
 # pylint: disable=no-self-use
 import copy
 import dataclasses
@@ -709,8 +710,15 @@ class TrainerTest(test_utils.TestCase):
     @parameterized.product(
         save_input_iterator=[False, True],
         restore_input_iterator=[False, True],
+        max_concurrency=[None, 1],
     )
-    def test_checkpoint_policy(self, *, save_input_iterator: bool, restore_input_iterator: bool):
+    def test_checkpoint_policy(
+        self,
+        *,
+        save_input_iterator: bool,
+        restore_input_iterator: bool,
+        max_concurrency: Optional[int],
+    ):
         """Test checkpoint policy when evaler and checkpointer run at different cadences."""
         model_cfg = DummyModel.default_config().set(dtype=jnp.float32)
 
@@ -724,7 +732,7 @@ class TrainerTest(test_utils.TestCase):
 
             return fn
 
-        cfg = SpmdTrainer.default_config().set(
+        cfg: SpmdTrainer.Config = SpmdTrainer.default_config().set(
             name="test_trainer",
             dir=tempfile.mkdtemp(),
             mesh_axis_names=("data", "model"),
@@ -754,6 +762,7 @@ class TrainerTest(test_utils.TestCase):
             ),
             save_input_iterator=save_input_iterator,
         )
+        cfg.checkpointer.storage.max_concurrency = max_concurrency
 
         # Run trainer.
         trainer: SpmdTrainer = cfg.instantiate(parent=None)


### PR DESCRIPTION
This PR implements an array serializer that blocks until all device-host copies are completed, while allowing some commits/writes to happen asynchronously. The implementation is concurrency limited, s.t. the in-flight shards are capped at max_concurrent_gb -- this means that we may have to block on some commits, but significantly reduces the peak host memory util when writing large checkpoints.

By default, this is disabled (which also avoids a large number of golden config updates).