### PR TITLE
Adds `return_aux` to Transformer layer APIs.

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -125,7 +125,7 @@ class KVState(NamedTuple):
 
 
 def _return_aux(return_aux: Optional[Set[str]], aux: str) -> bool:
-    return return_aux and aux in return_aux
+    return return_aux is not None and aux in return_aux
 
 
 class BaseTransformerLayer(BaseLayer):

--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -124,10 +124,6 @@ class KVState(NamedTuple):
     v_proj: Tensor
 
 
-def _return_aux(return_aux: Optional[Set[str]], aux: str) -> bool:
-    return return_aux is not None and aux in return_aux
-
-
 class BaseTransformerLayer(BaseLayer):
     """An abstract class to define the common interface of all *TransformerLayer classes, including:
 
@@ -1731,10 +1727,11 @@ class MultiheadAttention(BaseLayer):
         o_proj = self.o_proj(context)
         outputs = self._remat_name(o_proj, "o_proj")
         self._add_tensor_stats("o_proj_outputs", outputs)
+        return_aux = return_aux or set()
         output = self.Output(
             data=outputs,
-            probs=probs if _return_aux(return_aux, "probs") else None,
-            kv_state=kv_state if _return_aux(return_aux, "kv_state") else None,
+            probs=probs if "probs" in return_aux else None,
+            kv_state=kv_state if "kv_state" in return_aux else None,
         )
         return dict(i_proj=i_proj_state), output
 

--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -2469,7 +2469,7 @@ class MultiheadAttentionTest(TestCase):
             state=layer_params,
             is_training=False,
             prng_key=jax.random.PRNGKey(456),
-            inputs=dict(query=query, return_aux={"probs"}),
+            inputs=dict(query=query),
         )
         return kwargs
 
@@ -2480,6 +2480,7 @@ class MultiheadAttentionTest(TestCase):
         kwargs = self._scale_query_kwargs(
             query_scale_factor=query_scale_factor, key_scale_factor=key_scale_factor
         )
+        kwargs["inputs"]["return_aux"] = {"probs"}
         forward_outputs, _ = F(**kwargs)
         if query_scale_factor is None:
             query_scale_factor = kwargs["module"].per_head_dim() ** -0.5
@@ -2503,6 +2504,7 @@ class MultiheadAttentionTest(TestCase):
         kwargs = self._scale_query_kwargs(
             query_scale_factor=query_scale_factor, key_scale_factor=key_scale_factor
         )
+        kwargs["inputs"]["return_aux"] = {"probs"}
         forward_outputs, _ = F(**kwargs)
         self.assertNestedAllClose(
             forward_outputs.probs[0, 0, 0, 0],
@@ -2523,7 +2525,6 @@ class MultiheadAttentionTest(TestCase):
         kwargs = self._scale_query_kwargs(
             query_scale_factor=query_scale_factor, key_scale_factor=key_scale_factor
         )
-        kwargs["return_aux"] = None
 
         # Check optimized HLO scales by query_scale_factor and key_scale_factor as separate
         # multiplications. This only checks the default backend, so it doesn't check

--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -2111,12 +2111,14 @@ class MultiheadAttentionTest(TestCase):
         else:
             key = value = query
         attention_logit_biases = attention.make_causal_mask(tgt_len)
+        return_aux = {"probs"}
         inputs = dict(
             query=query,
             key=key,
             value=value,
             kv_state=kv_state,
             attention_logit_biases=attention_logit_biases,
+            return_aux=return_aux,
         )
         forward_outputs, _ = F(
             layer,
@@ -2136,7 +2138,7 @@ class MultiheadAttentionTest(TestCase):
         else:
             self.assertNotIn("key", initial_state["i_proj"])
             self.assertNotIn("value", initial_state["i_proj"])
-        inputs = dict(cached_states=initial_state, kv_state=kv_state)
+        inputs = dict(cached_states=initial_state, kv_state=kv_state, return_aux=return_aux)
         decoder_output = jnp.zeros(shape=[tgt_len, batch_size, model_dim])
         decoder_probs = jnp.zeros(shape=[tgt_len, batch_size, num_heads, tgt_len])
         for t in range(tgt_len):
@@ -2257,13 +2259,16 @@ class MultiheadAttentionTest(TestCase):
             jax.random.PRNGKey(123), [batch_size, tgt_len, model_dim], dtype=dtype
         )
         attention_logit_biases = attention.make_causal_mask(tgt_len)
+        return_aux = {"probs"}
 
         forward_outputs, _ = F(
             layer,
             state=layer_params,
             is_training=False,
             prng_key=jax.random.PRNGKey(456),
-            inputs=dict(query=query, attention_logit_biases=attention_logit_biases),
+            inputs=dict(
+                query=query, attention_logit_biases=attention_logit_biases, return_aux=return_aux
+            ),
         )
 
         time_step = jnp.arange(batch_size)
@@ -2273,7 +2278,10 @@ class MultiheadAttentionTest(TestCase):
             is_training=False,
             prng_key=jax.random.PRNGKey(456),
             inputs=dict(
-                time_step=time_step, query=query, attention_logit_biases=attention_logit_biases
+                time_step=time_step,
+                query=query,
+                attention_logit_biases=attention_logit_biases,
+                return_aux=return_aux,
             ),
             method="prefill_states",
         )
@@ -2297,16 +2305,19 @@ class MultiheadAttentionTest(TestCase):
         time_step_mask = jnp.arange(tgt_len) < time_step[:, None]
         # [batch, tgt_len, model_dim].
         decoder_output = initial_output.data * time_step_mask[..., None]
-        # [batch, num_heads, tgt_len, src_len].
-        decoder_probs = initial_output.probs * time_step_mask[:, None, :, None]
-
         # [batch, tgt_len, model_dim] --> [batch, model_dim, tgt_len].
         decoder_output = jnp.moveaxis(decoder_output, -2, -1)
-        # [batch, num_heads, tgt_len, src_len] --> [batch, num_heads, src_len, tgt_len].
-        decoder_probs = jnp.moveaxis(decoder_probs, -2, -1)
+
+        # [batch, num_heads, tgt_len, src_len].
+        if initial_output.probs is None:
+            decoder_probs = None
+        else:
+            decoder_probs = initial_output.probs * time_step_mask[:, None, :, None]
+            # [batch, num_heads, tgt_len, src_len] --> [batch, num_heads, src_len, tgt_len].
+            decoder_probs = jnp.moveaxis(decoder_probs, -2, -1)
 
         # Call extend_step from time_step, ensuring that outputs match.
-        inputs = dict(cached_states=initial_states)
+        inputs = dict(cached_states=initial_states, return_aux=return_aux)
         while jnp.any(time_step < tgt_len):
             # [batch, tgt_len=1, model_dim].
             inputs["query"] = jnp.take_along_axis(
@@ -2458,7 +2469,7 @@ class MultiheadAttentionTest(TestCase):
             state=layer_params,
             is_training=False,
             prng_key=jax.random.PRNGKey(456),
-            inputs=dict(query=query),
+            inputs=dict(query=query, return_aux={"probs"}),
         )
         return kwargs
 
@@ -2512,6 +2523,7 @@ class MultiheadAttentionTest(TestCase):
         kwargs = self._scale_query_kwargs(
             query_scale_factor=query_scale_factor, key_scale_factor=key_scale_factor
         )
+        kwargs["return_aux"] = None
 
         # Check optimized HLO scales by query_scale_factor and key_scale_factor as separate
         # multiplications. This only checks the default backend, so it doesn't check
@@ -3127,7 +3139,7 @@ class TransformerTest(BaseTransformerTest):
         target = rng.random([batch_size, tgt_len, model_dim], dtype=np.float32)
         base_layer_outputs, _ = F(
             base_layer,
-            inputs=dict(data=jnp.asarray(target)),
+            inputs=dict(data=jnp.asarray(target), return_aux={"self_attention_kv_state"}),
             state=base_layer_params,
             is_training=True,
             prng_key=jax.random.PRNGKey(0),
@@ -3139,6 +3151,7 @@ class TransformerTest(BaseTransformerTest):
             inputs=dict(
                 data=jnp.asarray(target),
                 self_attention_kv_state=base_layer_outputs.self_attention_kv_state,
+                return_aux={"self_attention_kv_state"},
             ),
             state=test_layer_params,
             is_training=True,
@@ -3376,6 +3389,7 @@ class StackedTransformerTest(BaseTransformerTest):
         cross_attention_logit_biases = (
             jnp.array(np.random.randint(0, 2, [tgt_len, src_len])) * NEG_INF
         )
+        return_aux = {"self_attention_probs", "cross_attention_probs"}
 
         forward_outputs, _ = F(
             layer,
@@ -3384,13 +3398,16 @@ class StackedTransformerTest(BaseTransformerTest):
                 self_attention_logit_biases=self_attention_logit_biases,
                 cross_attention_data=source,
                 cross_attention_logit_biases=cross_attention_logit_biases,
+                return_aux=return_aux,
             ),
             state=layer_params,
             is_training=False,
             prng_key=jax.random.PRNGKey(0),
         )
         initial_state = layer.init_states(target_batch_size=batch_size, target_max_len=tgt_len)
-        inputs = dict(cached_states=initial_state, cross_attention_data=source)
+        inputs = dict(
+            cached_states=initial_state, cross_attention_data=source, return_aux=return_aux
+        )
         decoder_output = jnp.zeros(shape=[tgt_len, batch_size, model_dim])
 
         # [num_dec_layers, [num_stacked_layers,] batch_size, num_heads, tgt_len, tgt_len] -->
@@ -3496,6 +3513,7 @@ class StackedTransformerTest(BaseTransformerTest):
         cross_attention_logit_biases = (
             jnp.array(np.random.randint(0, 2, [tgt_len, src_len])) * NEG_INF
         )
+        return_aux = {"self_attention_probs", "cross_attention_probs"}
 
         forward_outputs, _ = F(
             layer,
@@ -3504,6 +3522,7 @@ class StackedTransformerTest(BaseTransformerTest):
                 self_attention_logit_biases=self_attention_logit_biases,
                 cross_attention_data=source,
                 cross_attention_logit_biases=cross_attention_logit_biases,
+                return_aux=return_aux,
             ),
             state=layer_params,
             is_training=False,
@@ -3522,6 +3541,7 @@ class StackedTransformerTest(BaseTransformerTest):
                 self_attention_logit_biases=self_attention_logit_biases,
                 cross_attention_data=source,
                 cross_attention_logit_biases=cross_attention_logit_biases,
+                return_aux=return_aux,
             ),
             method="prefill_states",
         )
@@ -3548,7 +3568,9 @@ class StackedTransformerTest(BaseTransformerTest):
         decoder_cross_attention_probs = jnp.moveaxis(decoder_cross_attention_probs, -2, -1)
 
         # Call extend_step from time_step, ensuring that outputs match.
-        inputs = dict(cached_states=initial_states, cross_attention_data=source)
+        inputs = dict(
+            cached_states=initial_states, cross_attention_data=source, return_aux=return_aux
+        )
         while jnp.any(time_step < tgt_len):
             # [batch, tgt_len=1, model_dim].
             inputs["data"] = jnp.take_along_axis(
@@ -3983,7 +4005,7 @@ class StackedTransformerTest(BaseTransformerTest):
             is_training=is_training,
             prng_key=jax.random.PRNGKey(123),
             state=state,
-            inputs=dict(data=inputs),
+            inputs=dict(data=inputs, return_aux={"self_attention_kv_state"}),
         )
         self.assertEqual(
             BaseTransformerLayer.Output(
@@ -4041,7 +4063,11 @@ class StackedTransformerTest(BaseTransformerTest):
             is_training=True,
             prng_key=jax.random.PRNGKey(123),
             state=state,
-            inputs=dict(data=inputs, self_attention_kv_state=kv_state),
+            inputs=dict(
+                data=inputs,
+                self_attention_kv_state=kv_state,
+                return_aux={"self_attention_kv_state"},
+            ),
         )
         print(outputs)
         self.assertNestedAllClose(expected_output, outputs[0])

--- a/axlearn/common/deberta_test.py
+++ b/axlearn/common/deberta_test.py
@@ -535,7 +535,10 @@ class DeBERTaEncoderTest(TestCase):
             output_hidden_states=True,
             return_dict=True,
         )
-        self.assertNestedAllClose(ref_out.hidden_states[-1], test_out)
+        output_mask = padding_mask[:, :, None]
+        self.assertNestedAllClose(
+            ref_out.hidden_states[-1] * as_torch_tensor(output_mask), test_out * output_mask
+        )
 
     def test_encoder(self, query_len: int, **kwargs):
         torch.use_deterministic_algorithms(True)

--- a/axlearn/common/deberta_test.py
+++ b/axlearn/common/deberta_test.py
@@ -9,7 +9,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import torch
-from absl import logging
 from absl.testing import parameterized
 from transformers import DebertaV2Config, DebertaV2ForSequenceClassification
 from transformers.models.deberta_v2 import modeling_deberta_v2 as hf_deberta_v2
@@ -35,7 +34,6 @@ from axlearn.common.module import functional as F
 from axlearn.common.param_converter import as_torch_tensor
 from axlearn.common.test_utils import TestCase, assert_allclose
 from axlearn.common.torch_utils import parameters_from_torch_layer
-from axlearn.common.utils import shapes
 
 
 class RelativePositionTest(TestCase):
@@ -401,6 +399,7 @@ class DisentangledSelfAttentionTest(TestCase):
             jax.random.PRNGKey(333),
             [cfg.pos_emb.num_embeddings, cfg.pos_emb.dim],
         )
+        return_aux = {"probs"}
 
         # Patch in the pos_emb weights.
         layer_params["pos_emb"] = dict(weight=relative_pos_emb)
@@ -409,7 +408,11 @@ class DisentangledSelfAttentionTest(TestCase):
         layer_outputs, _ = F(
             layer,
             inputs=dict(
-                query=query, key=key, value=key, attention_logit_biases=attention_logit_biases
+                query=query,
+                key=key,
+                value=key,
+                attention_logit_biases=attention_logit_biases,
+                return_aux=return_aux,
             ),
             state=layer_params,
             is_training=False,
@@ -517,7 +520,7 @@ class DeBERTaEncoderTest(TestCase):
             jax.random.PRNGKey(111), [batch_size, query_len], minval=0, maxval=test_cfg.vocab_size
         )
         padding_mask = input_ids != cfg.pad_token_id
-        _, test_out = F(
+        test_out, _ = F(
             layer,
             jax.random.PRNGKey(0),
             layer_params["encoder"],
@@ -525,29 +528,14 @@ class DeBERTaEncoderTest(TestCase):
             is_training=False,
             drop_output_collections=[],
         )
-        logging.info("test_out=%s", shapes(test_out))
-        ref_outputs = hf_layer(
+        ref_out = hf_layer(
             as_torch_tensor(input_ids),
             attention_mask=as_torch_tensor(padding_mask),
             output_attentions=True,
             output_hidden_states=True,
             return_dict=True,
         )
-
-        # [batch, seq_len, seq_len]
-        attention_probs_mask = jnp.logical_and(padding_mask[:, :, None], padding_mask[:, None, :])
-        attention_probs_mask = attention_probs_mask[:, None, :, :]
-        hf_attention_probs_mask = as_torch_tensor(attention_probs_mask)
-
-        for i in range(ref_cfg.num_hidden_layers):
-            logging.info("Comparing layer %s attentions.", i)
-            test_attention_probs = test_out.module_outputs[
-                "transformer_outputs"
-            ].self_attention_probs[i]
-            self.assertNestedAllClose(
-                test_attention_probs * attention_probs_mask,
-                ref_outputs.attentions[i] * hf_attention_probs_mask,
-            )
+        self.assertNestedAllClose(ref_out.hidden_states[-1], test_out)
 
     def test_encoder(self, query_len: int, **kwargs):
         torch.use_deterministic_algorithms(True)

--- a/axlearn/vision/attention.py
+++ b/axlearn/vision/attention.py
@@ -8,7 +8,7 @@
 
 """Attention layers for ViT variant vision transformers."""
 import math
-from typing import Dict, NamedTuple, Optional, Sequence, Tuple
+from typing import Dict, NamedTuple, Optional, Sequence, Set, Tuple
 
 import jax.nn
 from jax import numpy as jnp
@@ -30,6 +30,10 @@ from axlearn.vision.window_attention import (
     window_partition_with_window_size,
     window_unpartition_with_window_size,
 )
+
+
+def _return_aux(return_aux: Optional[Set[str]], aux: str) -> bool:
+    return return_aux is not None and aux in return_aux
 
 
 def get_rel_pos_emb(
@@ -166,6 +170,7 @@ class WindowedAttention(MultiheadAttention):
         key: Optional[Tensor] = None,
         value: Optional[Tensor] = None,
         attention_logit_biases: Optional[Tensor] = None,
+        return_aux: Optional[Set[str]] = None,
     ) -> MultiheadAttention.Output:
         """Computes self-windowed attention for the given query and attention logit biases.
 
@@ -176,6 +181,7 @@ class WindowedAttention(MultiheadAttention):
             key:   an optional Tensor of shape [batch, source_length, source_dim].
             value: an optional Tensor of shape [batch, source_length, source_dim].
             attention_logit_biases:  See ``On attention logit biases`` in the file comments.
+            return_aux: See comments in MultiheadAttention.Output.
 
         Returns:
             An Output instance, where .data is of the same shape as query and .probs is of shape
@@ -224,8 +230,11 @@ class WindowedAttention(MultiheadAttention):
         # [batch, target_length, output_dim].
         o_proj = self.o_proj(context)
         outputs = self._remat_name(o_proj, "o_proj")
+        kv_state = KVState(k_proj=k_proj, v_proj=v_proj)
         return self.Output(
-            data=outputs, probs=probs, kv_state=KVState(k_proj=k_proj, v_proj=v_proj)
+            data=outputs,
+            probs=probs if _return_aux(return_aux, "probs") else None,
+            kv_state=kv_state if _return_aux(return_aux, "kv_state") else None,
         )
 
 
@@ -248,6 +257,7 @@ class WindowedSelfAttentionLayer(TransformerAttentionLayer):
         target: Tensor,
         source: Optional[Tensor] = None,
         attention_logit_biases: Optional[Tensor] = None,
+        return_aux: Optional[Set[str]] = None,
     ) -> TransformerAttentionLayer.Output:
         """Computes attention with target as query and source as key and value.
 
@@ -255,6 +265,7 @@ class WindowedSelfAttentionLayer(TransformerAttentionLayer):
             target: a Tensor of shape [batch, target_length, target_dim].
             source: None, uses norm(target) as source for self-attention
             attention_logit_biases: See ``On attention logit biases`` in the file comments.
+            return_aux: See comments in TransformerAttentionLayer.Output.
 
         Returns:
             An Output instance, where .data is of the same shape as target and .probs is of shape
@@ -279,6 +290,7 @@ class WindowedSelfAttentionLayer(TransformerAttentionLayer):
                 key=source,
                 value=source,
                 attention_logit_biases=attention_logit_biases,
+                return_aux=return_aux,
             )
             x = atten_output.data
 

--- a/axlearn/vision/attention.py
+++ b/axlearn/vision/attention.py
@@ -32,10 +32,6 @@ from axlearn.vision.window_attention import (
 )
 
 
-def _return_aux(return_aux: Optional[Set[str]], aux: str) -> bool:
-    return return_aux is not None and aux in return_aux
-
-
 def get_rel_pos_emb(
     q_size: int,
     k_size: int,
@@ -231,10 +227,11 @@ class WindowedAttention(MultiheadAttention):
         o_proj = self.o_proj(context)
         outputs = self._remat_name(o_proj, "o_proj")
         kv_state = KVState(k_proj=k_proj, v_proj=v_proj)
+        return_aux = return_aux or set()
         return self.Output(
             data=outputs,
-            probs=probs if _return_aux(return_aux, "probs") else None,
-            kv_state=kv_state if _return_aux(return_aux, "kv_state") else None,
+            probs=probs if "probs" in return_aux else None,
+            kv_state=kv_state if "kv_state" in return_aux else None,
         )
 
 

--- a/axlearn/vision/attention_test.py
+++ b/axlearn/vision/attention_test.py
@@ -113,7 +113,7 @@ class WindowedAttentionTest(TestCase, tf.test.TestCase):
             is_training=False,
             prng_key=jax.random.PRNGKey(123),
             state=attention_state,
-            inputs=dict(query=query),
+            inputs=dict(query=query, return_aux={"probs"}),
         )
         ref_data_shape = (batch_size, height * width, model_dim)
         ref_probs_shape = (batch_size, num_heads, height * width, height * width)


### PR DESCRIPTION
WARNING: This is a change that breaks backwards-compatibility, since it changes the default behavior not to return attention probs and kv state.