### PR TITLE
Fixes a bug in the interaction of causal mask and FlashAttention.

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -1750,6 +1750,8 @@ class MultiheadAttention(BaseLayer):
         """Returns a causal mask that can be broadcasted to [batch, num_heads, seq_len, seq_len].
 
         ... or None if the implementation of _compute_attention supports the causal mode natively.
+
+        Only used for (ForwardMode.FORWARD, ForwardMode.INIT_STATES).
         """
         return make_causal_mask(seq_len)[None, None, :, :]
 

--- a/axlearn/common/deberta_test.py
+++ b/axlearn/common/deberta_test.py
@@ -537,7 +537,10 @@ class DeBERTaEncoderTest(TestCase):
         )
         output_mask = padding_mask[:, :, None]
         self.assertNestedAllClose(
-            ref_out.hidden_states[-1] * as_torch_tensor(output_mask), test_out * output_mask
+            ref_out.hidden_states[-1] * as_torch_tensor(output_mask),
+            test_out * output_mask,
+            atol=1e-5,
+            rtol=1e-2,
         )
 
     def test_encoder(self, query_len: int, **kwargs):

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -95,7 +95,7 @@ class FlashAttention(GroupedQueryAttention):
         return cfg
 
     def _causal_mask(self, seq_len: int) -> Optional[Tensor]:
-        return None  # No need for causal mask.
+        return None  # No need for mask because flash attention supports the causal mode natively.
 
     def _compute_attention(
         self,
@@ -162,6 +162,11 @@ class FlashAttention(GroupedQueryAttention):
         k_proj = with_sharding_constraint(k_proj, cfg.mha_dim_to_partition_spec["bsnh"])
         v_proj = with_sharding_constraint(v_proj, cfg.mha_dim_to_partition_spec["bsnh"])
         if attention_logit_biases is not None:
+            if attention_logit_biases.shape[0] != q_proj.shape[0]:
+                raise ValueError(
+                    "attention_logit_biases must have matching batch dim: "
+                    f"{attention_logit_biases.shape} vs. {q_proj.shape[0]}"
+                )
             attention_logit_biases = with_sharding_constraint(
                 attention_logit_biases, cfg.mha_dim_to_partition_spec["bnts"]
             )

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -94,6 +94,9 @@ class FlashAttention(GroupedQueryAttention):
         }
         return cfg
 
+    def _causal_mask(self, seq_len: int) -> Optional[Tensor]:
+        return None  # No need for causal mask.
+
     def _compute_attention(
         self,
         *,

--- a/axlearn/common/launch_trainer_main.py
+++ b/axlearn/common/launch_trainer_main.py
@@ -2,16 +2,13 @@
 
 """Main function for launching the trainer."""
 
-import sys
-
-from absl import app, flags, logging
+from absl import app, flags
 
 from axlearn.common import launch, launch_trainer, measurement
 from axlearn.common.config import config_for_function
 
 
 def main(_):
-    logging.info("Command line: %s", " ".join(sys.argv))
     measurement.initialize(flags.FLAGS)
     launch.setup()
     trainer_config = launch_trainer.get_trainer_config()

--- a/axlearn/common/launch_trainer_main.py
+++ b/axlearn/common/launch_trainer_main.py
@@ -2,13 +2,16 @@
 
 """Main function for launching the trainer."""
 
-from absl import app, flags
+import sys
+
+from absl import app, flags, logging
 
 from axlearn.common import launch, launch_trainer, measurement
 from axlearn.common.config import config_for_function
 
 
 def main(_):
+    logging.info("Command line: %s", " ".join(sys.argv))
     measurement.initialize(flags.FLAGS)
     launch.setup()
     trainer_config = launch_trainer.get_trainer_config()


### PR DESCRIPTION
Fixes a problem with https://github.com/apple/axlearn/pull/529 and FlashAttention.

With https://github.com/apple/axlearn/pull/529, we construct a causal mask of shape `[1, 1, seq_len, seq_len]` and pass it as `attention_logit_biases` to `FlashAttention._compute_attention` (previously `FlashAttention._compute_attention` gets `attention_logit_biases=None`). This leads to errors when FlashAttention tries to shard the biases by `PartitionSpec(('data', 'expert', 'fsdp'), None, None, None)` since the batch dim of 1 is not divisible by the mesh axes.

The fix is to allow subclasses of `MultiheadAttention` to override the generation of the causal mask. Specifically, FlashAttention will override it to None since it supports the causal mode natively.
