### PR TITLE
Makes the remat logic in BaseLayer support static kwargs.

### DIFF
--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -4043,6 +4043,9 @@ class StackedTransformerTest(BaseTransformerTest):
             output_self_attention_kv_state=True,
         )
         cfg.stack.repeat.carry = repeat_carry
+        cfg.stack.layer.remat_spec = build_remat_spec(
+            cfg.stack, self_attention=True, feed_forward=True
+        )
         if precomputed_kv_state:
             kv_shape = (batch_size, seq_len, num_heads, head_dim)
             kv_state = KVState(

--- a/axlearn/common/t5_test.py
+++ b/axlearn/common/t5_test.py
@@ -335,7 +335,7 @@ class T5EncoderDecoderModelTest(TestCase):
         self.assertNestedAllClose(
             test_aux["logits"] * target_label_mask[:, :, None],
             as_tensor(ref_outputs.logits) * target_label_mask[:, :, None],
-            atol=5e-6,
+            atol=1e-4,
         )
         self.assertNestedAllClose(test_loss, as_tensor(ref_outputs.loss))
 


### PR DESCRIPTION
Sets `remat_spec` in `test_repeated_layer_with_custom_carry` to show the problem of using `return_aux` with `remat_spec`.