### PR TITLE
Add labels for vm tier

### DIFF
--- a/axlearn/cloud/gcp/tpu.py
+++ b/axlearn/cloud/gcp/tpu.py
@@ -572,14 +572,14 @@ def _tpu_body(
     vm_tier_labels = {}
     # Create labels for vm tier that can be used to group tpu metrics.
     # TPUs are created via QRM. In QRM, vm tier can be one of guaranteed, spot, or, bestEffort.
-    # guaranteeded is mapped to label value reserved. bestEffort is implemented to create spot instance. 
-    # Hence, both spot and bestEffort are mapped to lable value spot. 
-    # See [`_qrm_body()`](#L651) for details on the tiers. 
+    # guaranteeded is mapped to label value reserved. bestEffort is implemented to create
+    # spot instance. Hence, both spot and bestEffort are mapped to lable value spot.
+    # See [`_qrm_body()`](#L651) for details on the tiers.
     if reserved or gcp_settings("reserved_tpu", default=False):
         vm_tier_labels["vmtier"] = "reserved"
     else:
         vm_tier_labels["vmtier"] = "spot"
-        
+
     body.update(
         {
             "acceleratorType": tpu_type,

--- a/axlearn/cloud/gcp/tpu_test.py
+++ b/axlearn/cloud/gcp/tpu_test.py
@@ -14,6 +14,7 @@ from axlearn.cloud.gcp.tpu import (
     QueuedResourceInfo,
     TPUCreationError,
     TpuInfo,
+    _tpu_body,
     create_queued_tpu,
     infer_tpu_cores,
     infer_tpu_resources,
@@ -22,7 +23,6 @@ from axlearn.cloud.gcp.tpu import (
     infer_tpu_workers,
     queued_resource_info_table,
     tpu_info_table,
-    _tpu_body,
 )
 
 
@@ -254,26 +254,27 @@ class TpuUtilsTest(parameterized.TestCase):
                     tpu_type="v4-16",  # 2 workers.
                     bundler_type="test-bundler",
                 )
-                
+
     @parameterized.parameters(
         #(reserved, reserved_tpu_gcp_setting, expected_vmtier_label)
-        (True, False, "reserved"), 
+        (True, False, "reserved"),
         (False, False, "spot"),
         (None, True, "reserved"),
         (None, False, "spot"),
     )
-    
+
     @mock.patch("pathlib.Path")
     @mock.patch("builtins.open")
-    
-    def test_tpu_body_reserved_param(self, reserved, reserved_tpu_setting, expected_vmtier, mock_open, mock_path):
+
+    def test_tpu_body_reserved_param(self, reserved, reserved_tpu_setting,
+                                     expected_vmtier, mock_open, mock_path):
         module = tpu.__name__
         mock_settings = mock_gcp_settings(
             module,
             settings={
-                "project": "project", 
-                "zone": "zone", 
-                "ttl_bucket": "ttl_bucket", 
+                "project": "project",
+                "zone": "zone",
+                "ttl_bucket": "ttl_bucket",
                 "reserved_tpu": reserved_tpu_setting,
                 "network": "network",
                 "subnetwork": "subnetwork",
@@ -283,5 +284,6 @@ class TpuUtilsTest(parameterized.TestCase):
         mock_path.return_value = mock.MagicMock()
 
         with mock_settings:
-            tpu_body = _tpu_body("test-tpu", tpu_type="v4-8", bundler_type="test", reserved=reserved)
+            tpu_body = _tpu_body("test-tpu", tpu_type="v4-8",
+                                 bundler_type="test", reserved=reserved)
             self.assertEqual(tpu_body["labels"]["vmtier"], expected_vmtier)

--- a/axlearn/cloud/gcp/tpu_test.py
+++ b/axlearn/cloud/gcp/tpu_test.py
@@ -22,6 +22,7 @@ from axlearn.cloud.gcp.tpu import (
     infer_tpu_workers,
     queued_resource_info_table,
     tpu_info_table,
+    _tpu_body,
 )
 
 
@@ -253,3 +254,34 @@ class TpuUtilsTest(parameterized.TestCase):
                     tpu_type="v4-16",  # 2 workers.
                     bundler_type="test-bundler",
                 )
+                
+    @parameterized.parameters(
+        #(reserved, reserved_tpu_gcp_setting, expected_vmtier_label)
+        (True, False, "reserved"), 
+        (False, False, "spot"),
+        (None, True, "reserved"),
+        (None, False, "spot"),
+    )
+    
+    @mock.patch("pathlib.Path")
+    @mock.patch("builtins.open")
+    
+    def test_tpu_body_reserved_param(self, reserved, reserved_tpu_setting, expected_vmtier, mock_open, mock_path):
+        module = tpu.__name__
+        mock_settings = mock_gcp_settings(
+            module,
+            settings={
+                "project": "project", 
+                "zone": "zone", 
+                "ttl_bucket": "ttl_bucket", 
+                "reserved_tpu": reserved_tpu_setting,
+                "network": "network",
+                "subnetwork": "subnetwork",
+                "service_account_email":"sa@exmaple.com"},
+        )
+        mock_open.return_value = mock.MagicMock()
+        mock_path.return_value = mock.MagicMock()
+
+        with mock_settings:
+            tpu_body = _tpu_body("test-tpu", tpu_type="v4-8", bundler_type="test", reserved=reserved)
+            self.assertEqual(tpu_body["labels"]["vmtier"], expected_vmtier)


### PR DESCRIPTION
# Overview
When using [tpu.googleapis.com/accelerator/tensorcore_utilization](https://cloud.google.com/monitoring/api/metrics_gcp) metric, there is no way to break down by VM tiers(i.e. reserved vs spot) as the information is not captured in the existing filtering labels. However the tier information can be injected with VM custom labels, which show up as user labels in the filtering and can be used for grouping by the tiers. The code changes in this PR injects a custom label, vmtier, for TPU VM provisioned via [QRM](https://cloud.google.com/tpu/docs/queued-resources). The custom label supports two values: reserved and spot. 
# Testing
## Unit Testing
```
(axlearn) ➜  gcp git:(vm-tier-label) ✗ pytest tpu_test.py -v
=========================================================== test session starts ===========================================================
platform darwin -- Python 3.9.19, pytest-8.2.2, pluggy-1.5.0 -- /Users/ericshen/miniforge3/envs/axlearn/bin/python3.9
cachedir: .pytest_cache
rootdir: /Users/ericshen/my-git/apple/axlearn
configfile: pyproject.toml
collected 22 items                                                                                                                        

tpu_test.py::TpuUtilsTest::test_create_queued_tpu0 PASSED
tpu_test.py::TpuUtilsTest::test_create_queued_tpu1 PASSED
tpu_test.py::TpuUtilsTest::test_create_queued_tpu2 PASSED
tpu_test.py::TpuUtilsTest::test_create_queued_tpu3 PASSED
tpu_test.py::TpuUtilsTest::test_infer_resources0 PASSED
tpu_test.py::TpuUtilsTest::test_infer_resources1 PASSED
tpu_test.py::TpuUtilsTest::test_infer_resources2 PASSED
tpu_test.py::TpuUtilsTest::test_infer_resources3 PASSED
tpu_test.py::TpuUtilsTest::test_infer_tpu_type0 PASSED
tpu_test.py::TpuUtilsTest::test_infer_tpu_type1 PASSED
tpu_test.py::TpuUtilsTest::test_infer_tpu_type2 PASSED
tpu_test.py::TpuUtilsTest::test_infer_tpu_type3 PASSED
tpu_test.py::TpuUtilsTest::test_infer_utils0 PASSED
tpu_test.py::TpuUtilsTest::test_infer_utils1 PASSED
tpu_test.py::TpuUtilsTest::test_infer_utils2 PASSED
tpu_test.py::TpuUtilsTest::test_queued_resource_info_table PASSED
tpu_test.py::TpuUtilsTest::test_tpu_body_reserved_param0 PASSED
tpu_test.py::TpuUtilsTest::test_tpu_body_reserved_param1 PASSED
tpu_test.py::TpuUtilsTest::test_tpu_body_reserved_param2 PASSED
tpu_test.py::TpuUtilsTest::test_tpu_body_reserved_param3 PASSED
tpu_test.py::TpuUtilsTest::test_tpu_info_table PASSED
tpu_test.py::TpuUtilsTest::test_unknown_tpu_version PASSED

------------------- generated xml file: /Users/ericshen/my-git/apple/axlearn/axlearn/cloud/gcp/test-results/testing.xml -------------------
=========================================================== 22 passed in 0.28s ============================================================

```

## e2e Testing (manual)

1. run ```BASTION_TIER=1 axlearn gcp tpu start --name=$USER-test --tpu_type=v4-8 -- python3 -c "'import jax; print(jax.devices())'"``` to start axlearn job on TPU that is provisioned through [queue resource](https://cloud.google.com/tpu/docs/queued-resources).
2. Once the queued resource state is active and run ```gcloud alpha compute tpus tpu-vm describe ericshen-test --zone us-central2-b``` to check the TPU VM info which should have lines as below:
```
labels:
  vmtier: spot 
schedulingConfig:
  spot: true
```
