### PR TITLE
Add bastion_tier label in bastion code

### DIFF
--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -299,10 +299,11 @@ class TPURunnerJob(TPUQRMJob):
         if tier is not None:
             reserved = str(tier) == "0"
             logging.info("Found tier=%s in env. Using reserved=%s", tier, reserved)
-        
+
         # Create labels for vm tier that can be used to group tpu metrics.
         # In QRM, vm tier can be one of guaranteed, spot, or, bestEffort.
-        # The "reserved" label is used for guaranteed instances and "spot" for other instances (e.g. best-effort or spot instances).
+        # The "reserved" label is used for guaranteed instances and
+        # "spot" for other instances (e.g. best-effort or spot instances).
         # BASTION_TIER env has presendence over the reserved_tpu.
         if reserved is None:
             reserved = gcp_settings("reserved_tpu", default=False, required=False)

--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -302,8 +302,7 @@ class TPURunnerJob(TPUQRMJob):
         
         # Create labels for vm tier that can be used to group tpu metrics.
         # In QRM, vm tier can be one of guaranteed, spot, or, bestEffort.
-        # bestEffort is implemented to create spot instance. Hence,
-        # guaranteeded -> reserved and bestEffort|spot -> spot 
+        # The "reserved" label is used for guaranteed instances and "spot" for other instances (e.g. best-effort or spot instances).
         # BASTION_TIER env has presendence over the reserved_tpu.
         if reserved is None:
             reserved = gcp_settings("reserved_tpu", default=False, required=False)

--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -304,7 +304,7 @@ class TPURunnerJob(TPUQRMJob):
         # In QRM, vm tier can be one of guaranteed, spot, or, bestEffort.
         # bestEffort is implemented to create spot instance. Hence,
         # guaranteeded -> reserved and bestEffort|spot -> spot 
-        # BASTION_TIER env has presendence over the reserved_tpu
+        # BASTION_TIER env has presendence over the reserved_tpu.
         if reserved is None:
             reserved = gcp_settings("reserved_tpu", default=False, required=False)
         labels = {"bastion_tier": "reserved" if reserved else "spot"}

--- a/axlearn/cloud/gcp/jobs/tpu_runner.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner.py
@@ -305,15 +305,9 @@ class TPURunnerJob(TPUQRMJob):
         # bestEffort is implemented to create spot instance. Hence,
         # guaranteeded -> reserved and bestEffort|spot -> spot 
         # BASTION_TIER env has presendence over the reserved_tpu
-        labels = {}
         if reserved is None:
-            reserved_tier = gcp_settings("reserved_tpu", default=False, required=False)
-        else:
-            reserved_tier = reserved 
-        if reserved_tier:
-            labels["vmtier"] = "reserved"
-        else:
-            labels["vmtier"] = "spot"
+            reserved = gcp_settings("reserved_tpu", default=False, required=False)
+        labels = {"bastion_tier": "reserved" if reserved else "spot"}
 
         self._call_qrm_api(
             create_queued_tpu,

--- a/axlearn/cloud/gcp/jobs/tpu_runner_test.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner_test.py
@@ -181,15 +181,66 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
 
     @parameterized.parameters(
         [
-            dict(running_from_vm=True, env={"BASTION_TIER": "0"}, reserved_tpu_gcp_setting=None, expect_reserved=True, expected_label="reserved"),
-            dict(running_from_vm=True, env={"BASTION_TIER": "0"}, reserved_tpu_gcp_setting=True, expect_reserved=True, expected_label="reserved"),
-            dict(running_from_vm=True, env={"BASTION_TIER": "0"}, reserved_tpu_gcp_setting=False, expect_reserved=True, expected_label="reserved"),
-            dict(running_from_vm=True, env={"BASTION_TIER": "1"}, reserved_tpu_gcp_setting=None, expect_reserved=False, expected_label="spot"),
-            dict(running_from_vm=True, env={"BASTION_TIER": "1"}, reserved_tpu_gcp_setting=True, expect_reserved=False, expected_label="spot"),
-            dict(running_from_vm=True, env={"BASTION_TIER": "1"}, reserved_tpu_gcp_setting=False, expect_reserved=False, expected_label="spot"),
-            dict(running_from_vm=False, reserved_tpu_gcp_setting=None, expect_reserved=None, expected_label="spot"),
-            dict(running_from_vm=False, reserved_tpu_gcp_setting=True, expect_reserved=True, expected_label="reserved"),
-            dict(running_from_vm=False, reserved_tpu_gcp_setting=False, expect_reserved=False, expected_label="spot"),
+            dict(
+                running_from_vm=True,
+                env={"BASTION_TIER": "0"},
+                reserved_tpu_gcp_setting=None,
+                expect_reserved=True,
+                expected_label="reserved",
+            ),
+            dict(
+                running_from_vm=True,
+                env={"BASTION_TIER": "0"},
+                reserved_tpu_gcp_setting=True,
+                expect_reserved=True,
+                expected_label="reserved",
+            ),
+            dict(
+                running_from_vm=True,
+                env={"BASTION_TIER": "0"},
+                reserved_tpu_gcp_setting=False,
+                expect_reserved=True,
+                expected_label="reserved",
+            ),
+            dict(
+                running_from_vm=True,
+                env={"BASTION_TIER": "1"},
+                reserved_tpu_gcp_setting=None,
+                expect_reserved=False,
+                expected_label="spot",
+            ),
+            dict(
+                running_from_vm=True,
+                env={"BASTION_TIER": "1"},
+                reserved_tpu_gcp_setting=True,
+                expect_reserved=False,
+                expected_label="spot",
+            ),
+            dict(
+                running_from_vm=True,
+                env={"BASTION_TIER": "1"},
+                reserved_tpu_gcp_setting=False,
+                expect_reserved=False,
+                expected_label="spot",
+            ),
+            dict(
+                running_from_vm=False,
+                reserved_tpu_gcp_setting=None,
+                expect_reserved=None,
+                expected_label="spot",
+            ),
+            dict(
+                running_from_vm=False,
+                reserved_tpu_gcp_setting=True,
+                expect_reserved=True,
+                expected_label="reserved",
+            ),
+            dict(
+                running_from_vm=False,
+                reserved_tpu_gcp_setting=False,
+                expect_reserved=False,
+                expected_label="spot",
+            ),
         ]
     )
     def test_start(
@@ -198,7 +249,7 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
         expect_reserved: bool,
         expected_label: str,
         env: Optional[dict] = None,
-        reserved_tpu_gcp_setting: Optional[bool] = None
+        reserved_tpu_gcp_setting: Optional[bool] = None,
     ):
         cfg = _mock_config()
         job = cfg.set(command="").instantiate()
@@ -211,7 +262,9 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
             mock_env,
             mock_execute,
             mock_credentials,
-            mock_gcp_settings(tpu_runner.__name__, settings={"reserved_tpu": reserved_tpu_gcp_setting}),
+            mock_gcp_settings(
+                tpu_runner.__name__, settings={"reserved_tpu": reserved_tpu_gcp_setting}
+            ),
             mock_tpu(tpu_runner.__name__, running_from_vm) as mocks,
         ):
             # Create a dummy TPU.
@@ -222,7 +275,9 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
             mocks["create_queued_tpu"].assert_called()
             # TPU should be created with the right reservation.
             self.assertEqual(expect_reserved, mocks["create_queued_tpu"].call_args[1]["reserved"])
-            self.assertEqual(expected_label, mocks["create_queued_tpu"].call_args[1]["labels"]['bastion_tier'])
+            self.assertEqual(
+                expected_label, mocks["create_queued_tpu"].call_args[1]["labels"]["bastion_tier"]
+            )
             # Bundling should happen if not on VM.
             self.assertEqual(not running_from_vm, job._bundler.bundle.called)
 

--- a/axlearn/cloud/gcp/jobs/tpu_runner_test.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner_test.py
@@ -181,13 +181,15 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
 
     @parameterized.parameters(
         [
-            dict(running_from_vm=True, env={"BASTION_TIER": "0"}, expect_reserved=True, expected_label="reserved"),
-            dict(running_from_vm=True, env={"BASTION_TIER": "1"}, expect_reserved=False, expected_label="spot"),
+            dict(running_from_vm=True, env={"BASTION_TIER": "0"}, reserved_tpu_gcp_setting=None, expect_reserved=True, expected_label="reserved"),
+            dict(running_from_vm=True, env={"BASTION_TIER": "0"}, reserved_tpu_gcp_setting=True, expect_reserved=True, expected_label="reserved"),
+            dict(running_from_vm=True, env={"BASTION_TIER": "0"}, reserved_tpu_gcp_setting=False, expect_reserved=True, expected_label="reserved"),
+            dict(running_from_vm=True, env={"BASTION_TIER": "1"}, reserved_tpu_gcp_setting=None, expect_reserved=False, expected_label="spot"),
             dict(running_from_vm=True, env={"BASTION_TIER": "1"}, reserved_tpu_gcp_setting=True, expect_reserved=False, expected_label="spot"),
             dict(running_from_vm=True, env={"BASTION_TIER": "1"}, reserved_tpu_gcp_setting=False, expect_reserved=False, expected_label="spot"),
-            dict(running_from_vm=False, expect_reserved=None, expected_label="spot"),
-            dict(running_from_vm=False, reserved_tpu_gcp_setting=True, expect_reserved=None, expected_label="reserved"),
-            dict(running_from_vm=False, reserved_tpu_gcp_setting=False, expect_reserved=None, expected_label="spot"),
+            dict(running_from_vm=False, reserved_tpu_gcp_setting=None, expect_reserved=None, expected_label="spot"),
+            dict(running_from_vm=False, reserved_tpu_gcp_setting=True, expect_reserved=True, expected_label="reserved"),
+            dict(running_from_vm=False, reserved_tpu_gcp_setting=False, expect_reserved=False, expected_label="spot"),
         ]
     )
     def test_start(
@@ -220,7 +222,7 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
             mocks["create_queued_tpu"].assert_called()
             # TPU should be created with the right reservation.
             self.assertEqual(expect_reserved, mocks["create_queued_tpu"].call_args[1]["reserved"])
-            self.assertEqual(expected_label, mocks["create_queued_tpu"].call_args[1]["labels"]['vmtier'])
+            self.assertEqual(expected_label, mocks["create_queued_tpu"].call_args[1]["labels"]['bastion_tier'])
             # Bundling should happen if not on VM.
             self.assertEqual(not running_from_vm, job._bundler.bundle.called)
 

--- a/axlearn/cloud/gcp/jobs/tpu_runner_test.py
+++ b/axlearn/cloud/gcp/jobs/tpu_runner_test.py
@@ -181,16 +181,22 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
 
     @parameterized.parameters(
         [
-            dict(running_from_vm=True, env={"BASTION_TIER": "0"}, expect_reserved=True),
-            dict(running_from_vm=True, env={"BASTION_TIER": "1"}, expect_reserved=False),
-            dict(running_from_vm=False, expect_reserved=None),
+            dict(running_from_vm=True, env={"BASTION_TIER": "0"}, expect_reserved=True, expected_label="reserved"),
+            dict(running_from_vm=True, env={"BASTION_TIER": "1"}, expect_reserved=False, expected_label="spot"),
+            dict(running_from_vm=True, env={"BASTION_TIER": "1"}, reserved_tpu_gcp_setting=True, expect_reserved=False, expected_label="spot"),
+            dict(running_from_vm=True, env={"BASTION_TIER": "1"}, reserved_tpu_gcp_setting=False, expect_reserved=False, expected_label="spot"),
+            dict(running_from_vm=False, expect_reserved=None, expected_label="spot"),
+            dict(running_from_vm=False, reserved_tpu_gcp_setting=True, expect_reserved=None, expected_label="reserved"),
+            dict(running_from_vm=False, reserved_tpu_gcp_setting=False, expect_reserved=None, expected_label="spot"),
         ]
     )
     def test_start(
         self,
         running_from_vm: bool,
         expect_reserved: bool,
+        expected_label: str,
         env: Optional[dict] = None,
+        reserved_tpu_gcp_setting: Optional[bool] = None
     ):
         cfg = _mock_config()
         job = cfg.set(command="").instantiate()
@@ -203,6 +209,7 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
             mock_env,
             mock_execute,
             mock_credentials,
+            mock_gcp_settings(tpu_runner.__name__, settings={"reserved_tpu": reserved_tpu_gcp_setting}),
             mock_tpu(tpu_runner.__name__, running_from_vm) as mocks,
         ):
             # Create a dummy TPU.
@@ -213,6 +220,7 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
             mocks["create_queued_tpu"].assert_called()
             # TPU should be created with the right reservation.
             self.assertEqual(expect_reserved, mocks["create_queued_tpu"].call_args[1]["reserved"])
+            self.assertEqual(expected_label, mocks["create_queued_tpu"].call_args[1]["labels"]['vmtier'])
             # Bundling should happen if not on VM.
             self.assertEqual(not running_from_vm, job._bundler.bundle.called)
 
@@ -235,6 +243,7 @@ class TPURunnerJobTest(TestWithTemporaryCWD):
         mocks = [
             mock_tpu(tpu_runner.__name__),
             mock_gcp_settings(bundler.__name__, settings={"ttl_bucket": "ttl_bucket"}),
+            mock_gcp_settings(tpu_runner.__name__, settings={"reserved_tpu": True}),
             _mock_credentials(),
         ]
 

--- a/axlearn/cloud/gcp/tpu.py
+++ b/axlearn/cloud/gcp/tpu.py
@@ -290,6 +290,7 @@ def create_queued_tpu(
     tpu_type: str,
     bundler_type: str,
     num_slices: int = 1,
+    labels: Optional[Dict[str, str]] = None,
     metadata: Optional[Dict[str, str]] = None,
     service_account: Optional[str] = None,
     reserved: Optional[bool] = None,
@@ -302,6 +303,7 @@ def create_queued_tpu(
         tpu_type: Type of each TPU slice.
         bundler_type: Type of bundle intended to be loaded to VM.
         num_slices: The number of slices of type tpu_type to start.
+        labels: Optional instance labels.
         metadata: Optional metadata for the instance.
         service_account: Service account to execute the TPU creation.
         reserved: Whether to use reserved or preemptible quota. If None, infers from `gcp_settings`.
@@ -340,6 +342,7 @@ def create_queued_tpu(
                             name,
                             tpu_type=tpu_type,
                             bundler_type=bundler_type,
+                            labels=labels,
                             metadata=metadata,
                             service_account=service_account,
                         ),
@@ -539,6 +542,7 @@ def _tpu_body(
     *,
     tpu_type: str,
     bundler_type: str,
+    labels: Optional[Dict[str, str]] = None,
     metadata: Optional[Dict[str, str]] = None,
     service_account: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -570,6 +574,7 @@ def _tpu_body(
     body.update(
         {
             "acceleratorType": tpu_type,
+            "labels": labels or {},
             "metadata": {
                 "bundle_bucket": gcp_settings("ttl_bucket"),
                 "enable-oslogin": "false",


### PR DESCRIPTION
# Overview
When using [tpu.googleapis.com/accelerator/tensorcore_utilization](https://cloud.google.com/monitoring/api/metrics_gcp) metric, there is no way to break down by VM tiers(i.e. reserved vs spot) as the information is not captured in the existing filtering labels. However the tier information can be injected with VM custom labels, which show up as user labels in the filtering and can be used for grouping by the tiers. The code changes in this PR injects a custom label, vmtier, for TPU VM provisioned via [QRM](https://cloud.google.com/tpu/docs/queued-resources). The custom label supports two values: reserved and spot. 
# Testing
## Unit Testing
```
(axlearn) ➜  axlearn git:(vm-tier-label-2) pytest axlearn/cloud/gcp/jobs/tpu_runner_test.py -v | grep test_start
axlearn/cloud/gcp/jobs/tpu_runner_test.py::TPURunnerJobTest::test_start0 PASSED
axlearn/cloud/gcp/jobs/tpu_runner_test.py::TPURunnerJobTest::test_start1 PASSED
axlearn/cloud/gcp/jobs/tpu_runner_test.py::TPURunnerJobTest::test_start2 PASSED
axlearn/cloud/gcp/jobs/tpu_runner_test.py::TPURunnerJobTest::test_start3 PASSED
axlearn/cloud/gcp/jobs/tpu_runner_test.py::TPURunnerJobTest::test_start4 PASSED
axlearn/cloud/gcp/jobs/tpu_runner_test.py::TPURunnerJobTest::test_start5 PASSED
axlearn/cloud/gcp/jobs/tpu_runner_test.py::TPURunnerJobTest::test_start6 PASSED
axlearn/cloud/gcp/jobs/tpu_runner_test.py::TPURunnerJobTest::test_start7 PASSED
axlearn/cloud/gcp/jobs/tpu_runner_test.py::TPURunnerJobTest::test_start8 PASSED
axlearn/cloud/gcp/jobs/tpu_runner_test.py::TPURunnerMainTest::test_start0 PASSED
axlearn/cloud/gcp/jobs/tpu_runner_test.py::TPURunnerMainTest::test_start1 PASSED

```

## e2e Testing (manual)

1. run ```BASTION_TIER=1 axlearn gcp tpu start --name=$USER-test --tpu_type=v4-8 -- python3 -c "'import jax; print(jax.devices())'"``` to start axlearn job on TPU that is provisioned through [queue resource](https://cloud.google.com/tpu/docs/queued-resources).
2. Once the queued resource state is active and run ```gcloud alpha compute tpus tpu-vm describe $USER-test --zone us-central2-b``` to check the TPU VM info which should have lines as below:
```
labels:
  bastion_tier: spot 
schedulingConfig:
  spot: true
```
if ```BASTION_TIER=0```,  bastion_tier: reserved. 