### PR TITLE
[1/N] Add open api inference (starts with openai)

### DIFF
--- a/axlearn/open_api/__init__.py
+++ b/axlearn/open_api/__init__.py
@@ -1,0 +1,1 @@
+# Copyright © 2024 Apple Inc.

--- a/axlearn/open_api/common.py
+++ b/axlearn/open_api/common.py
@@ -1,0 +1,463 @@
+# Copyright © 2024 Apple Inc.
+
+"""Common utils for generating responses from open API or open source models."""
+
+import asyncio
+import copy
+import json
+import logging
+import os
+import time
+from collections import defaultdict
+from datetime import timedelta
+from enum import Enum
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
+
+import requests
+
+# isort: off
+from tqdm.asyncio import tqdm
+
+from axlearn.common.config import REQUIRED, Configurable, Required, config_class
+
+# pylint: disable=import-error
+# pytype: disable=import-error
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+
+# pylint: enable=import-error
+# pytype: enable=import-error
+# isort: on
+
+# Default decoding parameters.
+_default_decode_parameters = {"max_tokens": 1024, "temperature": 0.0}
+
+
+_openai_decode_parameters = [
+    "best_of",
+    "echo",
+    "frequency_penalty",
+    "logit_bias",
+    "logprobs",
+    "max_tokens",
+    "n",
+    "presence_penalty",
+    "seed",
+    "stop",
+    "top_p",
+    "temperature",
+    "suffix",
+    # Not used in openai api but popular in other frameworks.
+    "top_k",
+]
+
+
+class ClientType(Enum):
+    """Type of different clients."""
+
+    OPENAI = "openai"
+
+
+class ClientRateLimitError(ValueError):
+    """Exception for client rate limit request."""
+
+    pass
+
+
+class ValidationError(ValueError):
+    """Validation failure (e.g. input request format)."""
+
+    pass
+
+
+class BaseClient(Configurable):
+    """Defines the client for Open API style model endpoint for decoding
+    and response parsing."""
+
+    @config_class
+    class Config(Configurable.Config):
+        """Configures BaseClient."""
+
+        # The model name.
+        model: Required[str] = REQUIRED
+        # Seconds for timeout requests.
+        timeout: int = 120
+        # A dict of extra body for requests.
+        extra_body: Optional[Dict[str, Any]] = None
+
+    def __init__(self, cfg: Config):
+        super().__init__(cfg)
+        # Creates the endpoint client.
+        self._client = self._create_client()
+
+    def _create_client(self) -> Any:
+        """Initializes the client.
+
+        Returns:
+            Any: a client for the target endpoint.
+        """
+        raise NotImplementedError(type(self))
+
+    @classmethod
+    def parse_generation(cls, response: Dict[str, Any]) -> Sequence[ChatCompletionMessage]:
+        """Parses generation from response.
+
+        Args:
+           response: A dictionary consisting of the response obtained from the generator.
+
+        Returns:
+            A list of ChatCompletionMessage generation.
+        """
+        raise NotImplementedError(cls)
+
+    async def async_generate(
+        self,
+        *,
+        messages: Optional[Sequence[Dict[str, Any]]] = None,
+        tools: Optional[Sequence[Dict[str, Any]]] = None,
+        prompt: Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        """Generates response asynchronously from the client.
+
+        Args:
+            client: Endpoint client.
+            messages: OpenAI requests style messages. Ref:
+                https://github.com/openai/openai-python/blob/f3e6e634a86d5789ab1274ae27f43adc842f4ba8/src/openai/types/chat/chat_completion_message.py#L25
+            tools: OpenAI tools definitions.
+            prompt: OpenAI prompt style.
+            **kwargs: API request keyword arguments.
+
+        Returns:
+            Response in string format.
+
+        Raises:
+            RateLimitError: Hits rate limiting for retries.
+        """
+        raise NotImplementedError(type(self))
+
+
+class Generator(Configurable):
+    """Defines the generator for Open API style models decoding and generation
+    with sync and async concurrency implementation."""
+
+    @config_class
+    class Config(Configurable.Config):
+        """Configures Generator."""
+
+        # Seconds for timeout requests.
+        timeout: int = 120
+        # Number of concurrent clients for generations.
+        concurrency: int = 8
+        # Max number of retries for a request due to non rate limit error.
+        max_non_rate_limit_retries: int = 5
+        # Max number of retries for a request due to rate limit error.
+        max_rate_limit_retries: int = 25
+        # Seconds for retry sleep time when hitting rate limit.
+        retry_sleep_in_seconds: int = 4
+        # True to allow non rate limit error and store empty response.
+        allow_non_rate_limit_error: bool = True
+        # A dict of decoding parameters.
+        # If None, max_tokens is 1024 and temperature is 0.0 for greedy decoding.
+        decode_parameters: Optional[Dict[str, Any]] = None
+        # Client for API endpoint.
+        client: Required[BaseClient.Config] = REQUIRED
+
+    def __init__(self, cfg: Config):
+        super().__init__(cfg)
+        cfg = self.config
+        # Create number of clients for concurrent requests.
+        self._clients = [cfg.client.instantiate() for _ in range(cfg.concurrency)]
+        self._semaphore = asyncio.Semaphore(cfg.concurrency)
+
+    async def _async_generate_from_request(
+        self,
+        client: BaseClient,
+        *,
+        request: Dict[str, Any],
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Processes individual request asynchronously using the configured client.
+
+        Args:
+            client: Target endpoint client like AsyncOpenAI.
+            request: Prompt request data to be processed.
+            kwargs: Additional keyword arguments.
+
+        Returns:
+            Processed prompt data.
+
+        Raises:
+            ValueError: Exceed max retries.
+        """
+        cfg: Generator.Config = self.config
+        async with self._semaphore:
+            non_rate_limit_retries = 0
+            rate_limit_retries = 0
+            while True:
+                try:
+                    response = await client.async_generate(
+                        messages=request.get("messages", None),
+                        tools=request.get("tools", None),
+                        prompt=request.get("prompt", None),
+                        **kwargs,
+                    )
+                    break
+                except ValidationError as e:
+                    raise e
+                except ClientRateLimitError as e:
+                    logging.error("Hit request with rate limit error: %s.", str(e))
+                    rate_limit_retries += 1
+                    if rate_limit_retries >= cfg.max_rate_limit_retries:
+                        response = json.dumps(
+                            {"error": "Exceed max retries of rate limiting error"}
+                        )
+                        break
+                    await asyncio.sleep(cfg.retry_sleep_in_seconds)
+                # pylint: disable-next=broad-except,broad-exception-caught
+                except Exception as e:
+                    logging.error("Hit request with non rate limit error: %s.", str(e))
+                    non_rate_limit_retries += 1
+                    if not cfg.allow_non_rate_limit_error:
+                        raise ValueError(
+                            "Non rate limit error happened. Please inspect the issue."
+                        ) from e
+                    elif non_rate_limit_retries >= cfg.max_non_rate_limit_retries:
+                        response = json.dumps(
+                            {"error": "Exceed max retries of non rate limiting error."}
+                        )
+                        break
+
+            request["response"] = response
+            return request
+
+    async def async_generate_from_requests(
+        self,
+        gen_requests: Sequence[Dict[str, Any]],
+        **kwargs,
+    ) -> List[Dict[str, Any]]:
+        """Generates from OpenAI style requests.
+
+        Args:
+           gen_requests: A list of OpenAI style request.
+           kwargs: Extra decode parameters, eg: model=xxx,top_p=xxx,max_tokens=xxx.
+                Ref: https://platform.openai.com/docs/api-reference/chat/create
+
+        Returns:
+            A list of copied requests where each request has a new field response.
+        """
+        cfg: Generator.Config = self.config
+        # Collect responses for each prompt.
+        tasks = []
+        # Run async requests for each prompt with limited concurrency.
+        for index, request in enumerate(gen_requests):
+            client_index = index % cfg.concurrency
+            if "async_index" in request:
+                raise ValueError("Please do not add key async_index in the data.")
+            request["async_index"] = index
+            client: BaseClient = self._clients[client_index]
+            task = self._async_generate_from_request(
+                client=client,
+                request=request,
+                **kwargs,
+            )
+            tasks.append(task)
+        responses: List[Dict[str, Any]] = []
+        for task_ in tqdm.as_completed(tasks, total=len(tasks), desc="Generating Response"):
+            responses.append(await task_)
+
+        if len(responses) > 0 and "async_index" in responses[0]:
+            responses = sorted(responses, key=lambda x: x["async_index"])
+            for item in responses:
+                if "async_index" in item:
+                    del item["async_index"]
+        return responses
+
+
+def check_vllm_readiness(timeout: timedelta, base_url: str):
+    """Checks the readiness of vllm server.
+
+    Args:
+        timeout: The time duration to wait for readiness.
+        base_url: The base URL for the VLLM like http://0.0.0.0:8000/v1.
+
+    Raises:
+        TimeoutError: Server did not start within the specified timeout.
+    """
+    base_url = base_url.rstrip("/")
+    url = f"{base_url}/models"
+    start_time = time.time()
+
+    while time.time() - start_time < timeout.total_seconds():
+        try:
+            response = requests.get(url, timeout=1)
+            if response.status_code == 200:
+                break  # Server is up, exit the loop.
+        except requests.RequestException:
+            logging.info("Server is not available. Retrying...")
+        time.sleep(5)
+    else:
+        raise TimeoutError("Server did not start within the specified timeout.")
+
+    logging.info("VLLM server is up and running at %s", url)
+
+
+def parse_decode_parameters(
+    decode_parameters_str: Optional[str] = None,
+    *,
+    model: Optional[str] = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Parses all decode parameters into API supported parameters and request body.
+
+
+    Args:
+        decode_parameters_str: A json string of decode parameters. If None is parsed,
+            defaults to max_tokens=1024 and temperature=0.0 (greedy decoding).
+        model: Model name. If not None, will be added to decoding parameters
+            with the key "model".
+
+    Returns:
+        A tuple of:
+           decode_parameters: Parsed decode parameters in pre-defined arguments.
+           extra_body: Parsed extra key value setting.
+    """
+    # Create a dictionary from key-value pairs.
+    extra_body = {}
+    all_decode_parameters = _default_decode_parameters
+    if decode_parameters_str is not None:
+        all_decode_parameters.update(json.loads(decode_parameters_str))
+    decode_parameters = {}
+    logging.info("Decode parameters are:")
+    log_info = ""
+    for key, value in all_decode_parameters.items():
+        log_info += f"Key=[{key}] and Value=[{value}]\n"
+        if key in _openai_decode_parameters:
+            decode_parameters[key] = value
+        else:
+            extra_body[key] = value
+    logging.info(log_info)
+    if model is not None:
+        decode_parameters.update({"model": model})
+    return decode_parameters, extra_body
+
+
+def repeat_requests(
+    gen_requests: List[Dict[str, Any]],
+    num_repeats: int,
+) -> List[Dict[str, Any]]:
+    """Duplicates repuests to generate multiple samples.
+
+    Args:
+        gen_requests: A list of OpenAI style requests.
+        num_repeats: Number of repeats for each request.
+
+    Returns:
+        A list of OpenAI style requests expanded with num_repeats copies.
+    """
+    new_requests: List[Dict[str, Any]] = []
+    id_key = "id" if "id" in gen_requests[0] else "deliverable_id"
+    for request in gen_requests:
+        for i in range(num_repeats):
+            aug_id = f"{request[id_key]}:::{i}"
+            new_request = copy.deepcopy(request)
+            new_request.update({id_key: aug_id})
+            new_requests.append(new_request)
+    logging.info("Generating %d samples per request.", num_repeats)
+    return new_requests
+
+
+def flatten_responses(
+    responses: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Flattens responses from repeated requests.
+
+    Args:
+        responses: A list of repeated OpenAI style requests with responses.
+
+    Returns:
+        A flatten list of OpenAI style requests with responses and candidates.
+    """
+    new_responses: List[Dict[str, Any]] = []
+    candidate_pool = defaultdict(list)
+    id_key = "id" if "id" in responses[0] else "deliverable_id"
+    for resp in responses:
+        original_id = resp[id_key].split(":")[0]
+        candidate_pool[original_id].append(resp["response"])
+    for resp in responses:
+        original_id, sample_id = resp[id_key].split(":::")
+        if sample_id == "0":
+            resp.update({id_key: original_id, "n_responses": candidate_pool[original_id]})
+            new_responses.append(resp)
+    return new_responses
+
+
+def load_requests(
+    file_path: str,
+    *,
+    max_instances: int,
+) -> List[Dict[str, Any]]:
+    """Loads JSON prompt objects from a file.
+
+    Args:
+        file_path: A string representing the path to the file containing JSON prompts.
+        max_instances: An integer specifying the maximum number of prompt instances to load.
+
+    Returns:
+        A list of dictionaries, where each dictionary represents a prompt object
+            loaded from the file.
+    """
+    gen_requests: List[Dict[str, Any]] = []
+    logging.info("Loading prompts.")
+    with open(file_path, "r", encoding="utf-8") as file:
+        for line in file:
+            json_data = json.loads(line)
+            gen_requests.append(json_data)
+    if max_instances is not None:
+        gen_requests = gen_requests[:max_instances]
+    logging.info("Loaded %d prompts.", len(gen_requests))
+    return gen_requests
+
+
+def write_responses(responses: Sequence[Dict[str, Any]], *, file_path: str):
+    """Writes responses to a JSONL file.
+
+    Args:
+        responses: A list of model responses.
+        file_path: The output file path.
+    """
+    if not os.path.exists(os.path.dirname(file_path)):
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    logging.info("Writing responses to %s.", file_path)
+    with open(file_path, "w", encoding="utf-8") as file:
+        for chat_completion in responses:
+            json.dump(chat_completion, file)
+            file.write("\n")
+
+
+def parse_responses(
+    client: Type[BaseClient], responses: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Parses responses from a generator.
+
+    Args:
+        client: A client type.
+        responses: A list of responses from the generator.
+
+    Returns:
+        A list of parsed generations.
+    """
+    parsed_responses: List[Dict[str, Any]] = []
+    for response in responses:
+        response = copy.deepcopy(response)
+        try:
+            response_body = response["response"]
+            if isinstance(response_body, str):
+                response_body = json.loads(response_body)
+            parsed = client.parse_generation(response_body)
+            parsed = [c.model_dump_json() for c in parsed]
+            response["parsed_response"] = parsed
+            parsed_responses.append(response)
+        # pylint: disable-next=broad-except,broad-exception-caught
+        except Exception as e:
+            logging.error("Parsing error: %s.", str(e))
+            parsed_responses.append(response)
+    return parsed_responses

--- a/axlearn/open_api/common_test.py
+++ b/axlearn/open_api/common_test.py
@@ -1,0 +1,124 @@
+# Copyright © 2024 Apple Inc.
+
+"""Unit tests for common.py."""
+import json
+import unittest
+from datetime import timedelta
+from unittest.mock import mock_open, patch
+
+from .mock_utils import mock_openai_package
+
+mock_openai_package()
+
+# pylint: disable=wrong-import-position
+from axlearn.open_api.common import (
+    check_vllm_readiness,
+    flatten_responses,
+    load_requests,
+    parse_decode_parameters,
+    repeat_requests,
+    write_responses,
+)
+
+# pylint: enable=wrong-import-position
+
+
+class TestUtilities(unittest.TestCase):
+    """Unit tests for utilities function."""
+
+    @patch("requests.get")
+    def test_check_vllm_readiness(self, mock_get):
+        mock_get.return_value.status_code = 200
+        # No exception should be raised
+        check_vllm_readiness(timedelta(seconds=10), "http://0.0.0.0:8000/v1")
+
+    @patch("json.loads")
+    def test_parse_decode_parameters(self, mock_json_loads):
+        mock_json_loads.return_value = {"max_tokens": 1024}
+        decode_parameters, _ = parse_decode_parameters('{"max_tokens": 1024}')
+        self.assertEqual(decode_parameters["max_tokens"], 1024)
+
+    @patch("os.path.exists")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_write_responses(self, mock_file, mock_exists):
+        mock_exists.return_value = True
+        write_responses([{"response": "data"}], file_path="path/to/file")
+        mock_file.assert_called_with("path/to/file", "w", encoding="utf-8")
+
+    def test_expand_requests(self):
+        # Test expanding OpenAI style requests.
+        requests = [
+            {"id": "001", "prompt": "Hello, world!", "temperature": 0.5},
+            {"id": "002", "prompt": "Goodbye, world!", "temperature": 0.5},
+        ]
+        expanded = repeat_requests(requests, 3)
+        self.assertEqual(len(expanded), 6)
+        self.assertEqual(expanded[0]["id"], "001:::0")
+        self.assertEqual(expanded[1]["id"], "001:::1")
+        self.assertEqual(expanded[4]["id"], "002:::1")
+
+    def test_expand_requests_with_deliverable_id(self):
+        # Test with 'deliverable_id' instead of 'id'.
+        requests = [{"deliverable_id": "101", "prompt": "Test prompt", "temperature": 1.0}]
+        expanded = repeat_requests(requests, 2)
+        self.assertEqual(len(expanded), 2)
+        self.assertEqual(expanded[0]["deliverable_id"], "101:::0")
+        self.assertEqual(expanded[1]["deliverable_id"], "101:::1")
+
+    def test_squeeze_responses(self):
+        # Test squeezing responses to form a single entry per original ID.
+        responses = [
+            {"id": "001:::0", "response": "Hello!"},
+            {"id": "001:::1", "response": "Hi!"},
+            {"id": "002:::0", "response": "Goodbye!"},
+        ]
+        squeezed = flatten_responses(responses)
+        self.assertEqual(len(squeezed), 2)
+        self.assertIn("Hi!", squeezed[0]["n_responses"])
+        self.assertIn("Hello!", squeezed[0]["n_responses"])
+        self.assertEqual(squeezed[0]["id"], "001")
+        self.assertEqual(squeezed[1]["id"], "002")
+
+
+class TestLoadRequests(unittest.TestCase):
+    """Unit test for load_requests"""
+
+    def test_empty_file(self):
+        """Test loading from an empty file."""
+        with patch("builtins.open", mock_open(read_data="")):
+            result = load_requests("dummy_path", max_instances=10)
+            self.assertEqual(result, [])
+
+    def test_single_line(self):
+        """Test loading a single line of JSON."""
+        json_line = '{"name": "example"}'
+        with patch("builtins.open", mock_open(read_data=json_line)):
+            result = load_requests("dummy_path", max_instances=10)
+            self.assertEqual(result, [{"name": "example"}])
+
+    def test_multiple_lines(self):
+        """Test loading multiple lines of JSON."""
+        json_data = '{"name": "example1"}\n{"name": "example2"}'
+        with patch("builtins.open", mock_open(read_data=json_data)):
+            result = load_requests("dummy_path", max_instances=10)
+            self.assertEqual(result, [{"name": "example1"}, {"name": "example2"}])
+
+    def test_max_instances(self):
+        """Test the max_instances limit."""
+        json_data = '{"name": "example1"}\n{"name": "example2"}\n{"name": "example3"}'
+        with patch("builtins.open", mock_open(read_data=json_data)):
+            result = load_requests("dummy_path", max_instances=2)
+            self.assertEqual(result, [{"name": "example1"}, {"name": "example2"}])
+
+    def test_file_not_found(self):
+        """Test file not found error handling."""
+        with patch("builtins.open", side_effect=FileNotFoundError()):
+            with self.assertRaises(FileNotFoundError):
+                load_requests("nonexistent_path", max_instances=10)
+
+    def test_invalid_json(self):
+        """Test behavior with invalid JSON."""
+        json_data = '{"name": "valid"}\ninvalid_json'
+        with patch("builtins.open", mock_open(read_data=json_data)):
+            with self.assertRaises(json.JSONDecodeError):
+                load_requests("dummy_path", max_instances=10)

--- a/axlearn/open_api/mock_utils.py
+++ b/axlearn/open_api/mock_utils.py
@@ -1,0 +1,40 @@
+# Copyright © 2024 Apple Inc.
+
+"""Utils for unit test mocking."""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+def mock_openai_package():
+    """Initialize openai package for unit tests."""
+    # Create mock for the openai module and its submodules.
+    mock_openai = types.ModuleType("openai")
+    mock_async_openai = MagicMock()
+    mock_openai.AsyncOpenAI = mock_async_openai
+    mock_rate_limit_error = MagicMock()
+    mock_openai.RateLimitError = mock_rate_limit_error
+
+    mock_openai_types = types.ModuleType("openai.types")
+    mock_openai_types_chat = types.ModuleType("openai.types.chat")
+    mock_chat_completion_message = types.ModuleType("openai.types.chat.chat_completion_message")
+    mock_chat_completion_message.ChatCompletionMessage = MagicMock()
+
+    mock_openai_types_completion = types.ModuleType("openai.types.completion")
+    mock_completion = MagicMock()
+
+    # Set up the mock module structure.
+    mock_openai.types = mock_openai_types
+    mock_openai.types.chat = mock_openai_types_chat
+    mock_openai.types.chat.ChatCompletion = MagicMock()
+    mock_openai.types.chat.chat_completion_message = mock_chat_completion_message
+    mock_openai.types.completion = mock_openai_types_completion
+    mock_openai.types.completion.Completion = mock_completion
+
+    # Patch sys.modules to replace the openai package with our mock.
+    sys.modules["openai"] = mock_openai
+    sys.modules["openai.types"] = mock_openai_types
+    sys.modules["openai.types.chat"] = mock_openai_types_chat
+    sys.modules["openai.types.chat.chat_completion_message"] = mock_chat_completion_message
+    sys.modules["openai.types.completion"] = mock_openai_types_completion

--- a/axlearn/open_api/openai.py
+++ b/axlearn/open_api/openai.py
@@ -1,0 +1,210 @@
+# Copyright © 2024 Apple Inc.
+
+"""Implements of OpenAI style API endpoint via
+https://github.com/openai/openai-python
+
+This would work for both ChatGPT and vLLM based open source models.
+"""
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+# isort: off
+from axlearn.open_api.common import BaseClient, ClientRateLimitError, ValidationError
+
+# pylint: disable=import-error
+# pytype: disable=import-error
+from openai import AsyncOpenAI, RateLimitError
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.completion import Completion
+
+# pylint: enable=import-error
+# pytype: enable=import-error
+# isort: on
+
+
+class OpenAIClient(BaseClient):
+    """OpenAI endpoint client.
+
+    Compatible with vLLM service OpenAI endpoint.
+    """
+
+    def _create_client(self) -> AsyncOpenAI:
+        """Creates an AsyncOpenAI client."""
+        cfg: OpenAIClient.Config = self.config
+        default_headers = None
+        if os.environ.get("COOKIE") is not None:
+            default_headers = {"Cookie": os.environ["COOKIE"]}
+        return AsyncOpenAI(
+            api_key=os.environ.get("OPENAI_API_KEY", "EMPTY"),
+            default_headers=default_headers,
+            timeout=cfg.timeout,
+        )
+
+    async def async_generate(
+        self,
+        *,
+        messages: Optional[List[Dict[str, Any]]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        prompt: Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        """Generate response asynchronously from the client.
+
+        Args:
+            messages: OpenAI requests style messages.
+            tools: OpenAI tools definitions.
+            prompt: OpenAI prompt style.
+            **kwargs: API request keyword arguments.
+
+        Returns:
+            Response in string format.
+
+        Raises:
+            ClientRateLimitError: Hits rate limiting for retries.
+            ValidationError: Both prompt and messages are None.
+        """
+        cfg: OpenAIClient.Config = self.config
+        client: AsyncOpenAI = self._client
+        assert prompt is not None or messages is not None, ValidationError(
+            "Either prompt or messages must be not None."
+        )
+        try:
+            if prompt is not None:
+                response: Completion = await client.completions.create(
+                    prompt=prompt,
+                    extra_body=cfg.extra_body,
+                    **kwargs,
+                )
+            else:
+                response: ChatCompletion = await client.chat.completions.create(
+                    messages=messages,
+                    tools=tools,
+                    extra_body=cfg.extra_body,
+                    **kwargs,
+                )
+        except RateLimitError as e:
+            raise ClientRateLimitError("Rate limiting") from e
+        # pylint: disable-next=broad-except,broad-exception-caught
+        except Exception as e:
+            self._maybe_reduce_tokens(e, request_kwargs=kwargs)
+            raise e
+        return response.model_dump_json()
+
+    def _maybe_reduce_tokens(self, exception: Exception, request_kwargs: dict):
+        """Reduces completion tokens based on the exception message.
+
+        Args:
+            exception: Exception from the request.
+            request_kwargs: Request kwargs to update.
+        """
+        exception: str = str(exception)
+        if "Please reduce" not in exception:
+            return
+        max_completion_tokens = _calculate_openai_max_completion_tokens(exception)
+        if max_completion_tokens < 0:
+            logging.error("Prompt is already longer than max context length.")
+        elif max_completion_tokens > 0:
+            request_kwargs["max_tokens"] = max_completion_tokens
+        else:
+            request_kwargs["max_tokens"] = int(request_kwargs["max_tokens"] * 0.8)
+            if request_kwargs["max_tokens"] == 0:
+                logging.error("Prompt is already longer than max context length.")
+        logging.warning("Reducing target length to %d, Retrying...", request_kwargs["max_tokens"])
+
+    @classmethod
+    def _parse_generation_from_message(cls, message: Dict[str, Any]) -> ChatCompletionMessage:
+        """Parse generation from a message.
+
+        Args:
+           message: A dictionary of message.
+
+        Returns:
+            A string of generation or a list of tool calls.
+        """
+        message: ChatCompletionMessage = ChatCompletionMessage(**message)
+        if message.content is not None and message.content != "":
+            generation = message.content
+            # Strip left side space for some SPM generations.
+            generation = generation.replace("\n", "<n>").lstrip().replace("<n>", "\n")
+            message.content = generation
+            return message
+
+        return message
+
+    @classmethod
+    def parse_generation(cls, response: Dict[str, Any]) -> List[ChatCompletionMessage]:
+        """Parse generation from response.
+
+        Args:
+           response: A dictionary of response.
+
+        Returns:
+            A string of generation or a list of tool calls.
+        """
+        if len(response.get("choices", [])) == 0:
+            return [ChatCompletionMessage(role="assistant", content="")]
+
+        # Extract text generation.
+        generations = []
+        for choice in response["choices"]:
+            generations.append(OpenAIClient._parse_generation_from_message(choice["message"]))
+        return generations
+
+    @classmethod
+    def format_message(cls, message: Dict[str, Any]) -> ChatCompletionMessage:
+        """Format message with requirements.
+
+        Args:
+           message: A dictionary of message.
+
+        Returns:
+            A formatted ChatCompletionMessage.
+        """
+        if "content" in message and isinstance(message["content"], dict):
+            message["content"] = json.dumps(message["content"])
+        if "tool_calls" in message:
+            new_tool_calls = []
+            for tool_call in message["tool_calls"]:
+                if isinstance(tool_call["function"]["arguments"], dict):
+                    tool_call["function"]["arguments"] = json.dumps(
+                        tool_call["function"]["arguments"], sort_keys=True
+                    )
+                new_tool_calls.append(tool_call)
+            message["tool_calls"] = new_tool_calls
+        return ChatCompletionMessage(**message)
+
+
+def _calculate_openai_max_completion_tokens(err_msg: str) -> int:
+    """Use regular expression to get max completion tokens based on model max length.
+
+    Args:
+        err_msg: A string of error message.
+
+    Returns:
+        An integer of calculated max tokens.
+    """
+    # Use regular expression to find model max length.
+    match = re.search(r"maximum context length is (\d+) tokens", err_msg)
+
+    if match:
+        model_max_tokens = int(match.group(1))
+    else:
+        logging.warning("Didn't find max model tokens")
+        return 0
+
+    # Use regular expression to find messages token.
+    match = re.search(r"\((\d+) in the messages", err_msg)
+
+    if match:
+        message_tokens = int(match.group(1))
+    else:
+        logging.warning("Didn't find message tokens")
+        return 0
+    if message_tokens >= model_max_tokens:
+        return -1
+    logging.info("Max completion tokens is %d", model_max_tokens - message_tokens)
+    return model_max_tokens - message_tokens

--- a/axlearn/open_api/openai_test.py
+++ b/axlearn/open_api/openai_test.py
@@ -1,0 +1,150 @@
+# Copyright © 2024 Apple Inc.
+
+# pylint: disable=protected-access
+"""Unit tests for openai.py."""
+import asyncio
+import json
+import unittest
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+from axlearn.open_api.mock_utils import mock_openai_package
+
+mock_openai_package()
+
+_module_root = "axlearn"
+
+
+# pylint: disable=wrong-import-position
+from .common import ClientRateLimitError, Generator
+from .openai import OpenAIClient
+
+# pylint: enable=wrong-import-position
+
+
+class TestOpenAIAsyncGenerateFromRequests(unittest.IsolatedAsyncioTestCase):
+    """Unit test for async_generate_from_requests."""
+
+    def setUp(self):
+        cfg: Generator.Config = Generator.default_config().set(
+            concurrency=2,
+            max_non_rate_limit_retries=3,
+            client=OpenAIClient.default_config().set(model="gpt-3.5-turbo"),
+        )
+        open_api: Generator = cfg.instantiate()
+        self.open_api = open_api
+        # Mock clients for concurrency.
+        self.open_api._clients = [MagicMock(), MagicMock()]
+
+    @patch(
+        f"{_module_root}.open_api.common.Generator._async_generate_from_request",
+        new_callable=AsyncMock,
+    )
+    async def test_async_generate_from_requests(self, mock_async_generate_from_request):
+        # Mock async_generate_from_request to return a predefined response.
+        mock_response = {"response": "test response", "async_index": 1}
+        mock_async_generate_from_request.return_value = mock_response
+
+        # Create mock requests.
+        mock_requests = [
+            {"prompt": "How are you?"},
+            {"prompt": "Tell me a joke."},
+            {"prompt": "What is the weather today?"},
+        ]
+
+        # Call the method under test.
+        responses = await self.open_api.async_generate_from_requests(mock_requests)
+
+        # Assertions to verify behavior.
+        self.assertEqual(len(responses), len(mock_requests))  # Ensure all requests are processed
+        for response in responses:
+            self.assertIn("response", response)  # Check structure of the response
+            self.assertEqual(response["response"], "test response")  # Validate response content
+
+        # Check if async_generate_from_request is called correctly.
+        calls = [unittest.mock.call(client=ANY, request=ANY) for i in range(len(mock_requests))]
+        mock_async_generate_from_request.assert_has_calls(
+            calls, any_order=True
+        )  # Ensure each request is processed
+
+
+class TestOpenAI(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for the OpenAIClient class focusing
+    on the async_generate_from_request method."""
+
+    async def asyncSetUp(self):
+        """Set up resources prior to each test."""
+        cfg: Generator.Config = Generator.default_config().set(
+            concurrency=1,
+            max_non_rate_limit_retries=3,
+            client=OpenAIClient.default_config().set(model="gpt-3.5-turbo"),
+        )
+        open_api: Generator = cfg.instantiate()
+        # Mock clients for concurrency.
+        open_api._clients = [AsyncMock()]
+        open_api._clients[0].handle_error = MagicMock(return_value=False)
+        open_api._semaphore = asyncio.Semaphore(1)
+        self.open_api = open_api
+        self.request = {"messages": [{"text": "Hello"}], "prompt": "Test prompt"}
+
+    async def test_async_generate_from_request_success(self):
+        """Test that async_generate_from_request returns a successful response."""
+        self.open_api._clients[0].async_generate = AsyncMock(return_value="success response")
+        result = await self.open_api._async_generate_from_request(
+            self.open_api._clients[0], request=self.request
+        )
+        self.assertEqual(result["response"], "success response")
+
+    async def test_async_generate_from_request_failure_with_retries(self):
+        """Test retries on failure that is not due to rate limiting."""
+        self.open_api._clients[0].async_generate = AsyncMock(
+            side_effect=[Exception("Error"), "success response"]
+        )
+        result = await self.open_api._async_generate_from_request(
+            self.open_api._clients[0], request=self.request
+        )
+        self.assertEqual(result["response"], "success response")
+        self.assertEqual(self.open_api._clients[0].async_generate.call_count, 2)
+
+    async def test_async_generate_from_request_handles_rate_limiting(self):
+        """Test handling of rate limiting by pausing and retrying."""
+        self.open_api._clients[0].handle_error = MagicMock(return_value=True)
+        self.open_api._clients[0].async_generate = AsyncMock(
+            side_effect=[ClientRateLimitError("Rate limiting"), "success response"]
+        )
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await self.open_api._async_generate_from_request(
+                self.open_api._clients[0], request=self.request
+            )
+            mock_sleep.assert_awaited()
+            self.assertEqual(result["response"], "success response")
+
+    async def test_async_generate_from_request_exceeds_max_retries(self):
+        """Test the behavior when the number of retries exceeds the max not allowed."""
+        cfg: Generator.Config = Generator.default_config().set(
+            concurrency=1,
+            max_non_rate_limit_retries=3,
+            allow_non_rate_limit_error=False,
+            client=OpenAIClient.default_config().set(model="gpt-3.5-turbo"),
+        )
+        open_api: Generator = cfg.instantiate()
+        open_api = cfg.instantiate()
+        # Mock clients for concurrency.
+        open_api._clients = [MagicMock()]
+        open_api._clients[0].handle_error = MagicMock(return_value=False)
+        open_api._clients[0].async_generate = AsyncMock(side_effect=[Exception("Error")])
+        open_api._semaphore = asyncio.Semaphore(1)
+        with self.assertRaises(ValueError):
+            await open_api._async_generate_from_request(open_api._clients[0], request=self.request)
+            self.assertEqual(open_api._clients[0].async_generate.call_count, 1)
+
+    async def test_async_generate_from_request_exceeds_allowed_max_retries(self):
+        """Test the behavior when the number of retries exceeds the max allowed."""
+        self.open_api._clients[0].async_generate = AsyncMock(side_effect=Exception("Error"))
+        result = await self.open_api._async_generate_from_request(
+            self.open_api._clients[0], request=self.request
+        )
+        self.assertEqual(
+            result["response"],
+            json.dumps({"error": "Exceed max retries of non rate limiting error."}),
+        )
+        self.assertEqual(self.open_api._clients[0].async_generate.call_count, 3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,10 @@ dataflow = [
 gpu = [
     "triton==2.1.0",
 ]
+# Open API inference.
+open_api = [
+    "openai==1.35.1",
+]
 
 [tool.flit.module]
 # This defines the import name. https://flit.pypa.io/en/stable/pyproject_toml.html#module-section


### PR DESCRIPTION
This has been reviewed in the internal repo.

Goal:
- Add open api style inference with async support for open source models via vLLM and OpenAI models.
- Used for evaluation (related to paper publication as well)
- Used for data generation pipeline