### PR TITLE
Neuron support in Axlearn

### DIFF
--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -1193,6 +1193,10 @@ def create_device_mesh(
         logging.warning("Falling back to ICI-only mesh on GPU, performance may be reduced.")
         return build_standard_mesh(mesh_shape, devices=devices)
 
+    # Neuron also only uses standard mesh 
+    if device_platform == "neuron":
+        return build_standard_mesh(mesh_shape, devices=devices)
+
     # We only break the first device axis (the least communication intensive) across granules.
     assert (
         ici_mesh_shape[0] % num_granules == 0

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -1176,7 +1176,7 @@ def create_device_mesh(
     # Check if the devices are part of a multi-granule configuration.
     # <https://github.com/google/jax/blob/b81b79c1b0d2ec/jax/experimental/mesh_utils.py#L313>
     device_platform = devices[0].platform
-    attr = "process_index" if device_platform != "tpu" else "slice_index"
+    attr = "process_index" if device_platform == "gpu" else "slice_index"
     is_multi_granule_env = hasattr(devices[0], attr)
     if not all(el.platform == device_platform for el in devices):
         raise NotImplementedError(f"Not all devices had platform: {device_platform}.")
@@ -1193,7 +1193,7 @@ def create_device_mesh(
         logging.warning("Falling back to ICI-only mesh on GPU, performance may be reduced.")
         return build_standard_mesh(mesh_shape, devices=devices)
 
-    # Neuron also only uses standard mesh 
+    # Neuron also only uses standard mesh
     if device_platform == "neuron":
         return build_standard_mesh(mesh_shape, devices=devices)
 

--- a/axlearn/experiments/text/gpt/common.py
+++ b/axlearn/experiments/text/gpt/common.py
@@ -11,11 +11,11 @@ See c4_trainer.py for how they are used.
 """
 
 import math
-import numpy as np
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import tensorflow as tf
 from jax.sharding import PartitionSpec
 
@@ -271,8 +271,8 @@ def model_config(
     )
 
     device_platform = np.asarray(jax.devices())[0].platform
-    # neuron uses Zero 3
-    fsdp_axis_names = ("expert", "fsdp", "seq") if device_platform != 'neuron' else ("data", "expert", "fsdp", "seq") 
+    # Trainium will have FSDP support soon, for now use Zero 3.
+    fsdp_axis_names = ("expert", "fsdp", "seq") if device_platform != "neuron" else ("data")
 
     cfg.dtype = jnp.float32
     # Shard some FFN and attention weights over multiple axes.

--- a/axlearn/experiments/text/gpt/common.py
+++ b/axlearn/experiments/text/gpt/common.py
@@ -11,8 +11,10 @@ See c4_trainer.py for how they are used.
 """
 
 import math
+import numpy as np
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
+import jax
 import jax.numpy as jnp
 import tensorflow as tf
 from jax.sharding import PartitionSpec

--- a/axlearn/experiments/text/gpt/common.py
+++ b/axlearn/experiments/text/gpt/common.py
@@ -267,12 +267,17 @@ def model_config(
         batch_axis_names=batch_axis_names,
         seq_axis_names="seq",
     )
+
+    device_platform = np.asarray(jax.devices())[0].platform
+    # neuron uses Zero 3
+    fsdp_axis_names = ("expert", "fsdp", "seq") if device_platform != 'neuron' else ("data", "expert", "fsdp", "seq") 
+
     cfg.dtype = jnp.float32
     # Shard some FFN and attention weights over multiple axes.
     set_double_shard_weights_config(
         cfg.decoder.transformer.layer,
         batch_axis_names=batch_axis_names,
-        fsdp_axis_names=("expert", "fsdp", "seq"),
+        fsdp_axis_names=fsdp_axis_names,
         tp_axis_names="model",
         seq_axis_names=("seq",),
     )

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -83,6 +83,7 @@ TOTAL_TOKENS = {
     },
 }
 
+TRN_MODEL_AXIS_SIZE=8
 
 def get_trainer_kwargs(
     model_size: str,
@@ -103,7 +104,6 @@ def get_trainer_kwargs(
         num_kv_heads = 8
 
     rope_theta = ROPE_THETA[version]
-
     # dict() is more readable here.
     # pylint: disable=use-dict-literal
     if model_size == "test":
@@ -166,6 +166,10 @@ def get_trainer_kwargs(
                 (
                     "gpu-(p5.48xlarge|p4de.24xlarge)-(256|512|1024)",
                     mesh_shape_from_axes(data=-1, fsdp=8),
+                ),
+                (   
+                    "neuron-(trn1.32xlarge|trn1n.32xlarge)-(32|64|256|512|1024|2048)",
+                    mesh_shape_from_axes(data=-1, model=TRN_MODEL_AXIS_SIZE),
                 ),
             ),
         )

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -83,7 +83,6 @@ TOTAL_TOKENS = {
     },
 }
 
-TRN_MODEL_AXIS_SIZE=8
 
 def get_trainer_kwargs(
     model_size: str,
@@ -167,9 +166,9 @@ def get_trainer_kwargs(
                     "gpu-(p5.48xlarge|p4de.24xlarge)-(256|512|1024)",
                     mesh_shape_from_axes(data=-1, fsdp=8),
                 ),
-                (   
+                (
                     "neuron-(trn1.32xlarge|trn1n.32xlarge)-(32|64|256|512|1024|2048)",
-                    mesh_shape_from_axes(data=-1, model=TRN_MODEL_AXIS_SIZE),
+                    mesh_shape_from_axes(data=-1, model=8),
                 ),
             ),
         )


### PR DESCRIPTION
This PR enables use of neuron devices in Axlearn for model training.

- Chooses correct mesh for TRN devices for Fuji 7B with the mesh selector flag ```--mesh_selector=neuron-trn1.32xlarge-64```