### PR TITLE
[2/N] Add gemini for open_api inference

### DIFF
--- a/axlearn/open_api/gemini.py
+++ b/axlearn/open_api/gemini.py
@@ -1,0 +1,323 @@
+# Copyright © 2024 Apple Inc.
+
+"""Implements of Gemini style API endpoint via
+https://github.com/googleapis/python-aiplatform"""
+
+import copy
+import json
+import logging
+import os
+import random
+import string
+from typing import Any, Dict, List, Optional
+
+# isort: off
+from axlearn.open_api.common import BaseClient, ClientRateLimitError, ValidationError
+
+# pylint: disable=import-error
+# pytype: disable=import-error
+import vertexai
+from openai.types.chat.chat_completion_message import (
+    ChatCompletionMessage,
+    ChatCompletionMessageToolCall,
+)
+from openai.types.chat.chat_completion_message_tool_call import Function
+from vertexai.generative_models import (
+    Content,
+    FunctionDeclaration,
+    GenerationConfig,
+    GenerativeModel,
+    Part,
+    Tool,
+)
+
+# pylint: enable=import-error
+# pytype: enable=import-error
+# isort: on
+
+
+class GeminiClient(BaseClient):
+    """Gemini endpoint client."""
+
+    def _create_client(self) -> GenerativeModel:
+        """Creates a GenerativeModel client for Gemini."""
+        cfg: GeminiClient.Config = self.config
+        _init_vertexai()
+        return GenerativeModel(model_name=cfg.model)
+
+    async def async_generate(
+        self,
+        *,
+        messages: Optional[List[Dict[str, Any]]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        prompt: Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        """Generates response asynchronously from the client.
+
+        Args:
+            messages: OpenAI requests style messages.
+            tools: OpenAI tools definitions.
+            prompt: OpenAI prompt style.
+            **kwargs: API request keyword arguments.
+
+        Returns:
+            Response in string format.
+        """
+
+        contents = _convert_openai_messages_to_gemini(messages=messages)
+        if tools is not None:
+            gemini_tools = _convert_openai_tools_to_gemini(tools=tools)
+        else:
+            gemini_tools = None
+        client: GenerativeModel = self._client
+        try:
+            response = await client.generate_content_async(
+                contents=contents,
+                tools=gemini_tools,
+                generation_config=GenerationConfig(
+                    temperature=kwargs.get("temperature", None),
+                    top_k=kwargs.get("top_k", None),
+                    top_p=kwargs.get("top_p", None),
+                    max_output_tokens=kwargs.get("max_tokens", None),
+                    stop_sequences=kwargs.get("stop_sequences", None),
+                ),
+            )
+            return json.dumps(response.to_dict())
+        # pylint: disable-next=broad-except,broad-exception-caught
+        except Exception as e:
+            if "resource has been exhausted" in str(e).lower():
+                raise ClientRateLimitError("Rate limiting") from e
+            else:
+                self._maybe_reduce_tokens(e, request_kwargs=kwargs)
+                raise e
+
+    def _maybe_reduce_tokens(self, exception: Exception, request_kwargs: dict):
+        """Reduces completion tokens based on the exception message.
+
+        Args:
+            exception: Exception from the request.
+            request_kwargs: Request kwargs to update.
+        """
+        exception: str = str(exception)
+        if "reduce" not in exception:
+            return
+        request_kwargs["max_tokens"] = int(request_kwargs["max_tokens"] * 0.8)
+        if request_kwargs["max_tokens"] == 0:
+            logging.error("Prompt is already longer than max context length.")
+        logging.warning(
+            "Reducing target length to %d, Retrying...",
+            request_kwargs["max_tokens"],
+        )
+
+    @classmethod
+    def parse_generation(cls, response: Dict[str, Any]) -> List[ChatCompletionMessage]:
+        """Parse generation from response.
+
+        Args:
+           response: A dictionary of response.
+
+        Returns:
+            A string of generation or a list of tool calls.
+        """
+        if len(response.get("candidates", [])) == 0:
+            return [ChatCompletionMessage(role="assistant", content="")]
+
+        generations = []
+        for candidate in response["candidates"]:
+            if candidate.get("content", None) is None:
+                continue
+
+            tool_calls = []
+            message = ChatCompletionMessage(role="assistant", content="")
+            for part in candidate["content"].get("parts", []):
+                if "text" in part:
+                    message.content = part["text"]
+                    continue
+                if "function_call" not in part or "name" not in part["function_call"]:
+                    continue
+                tool_calls.append(
+                    ChatCompletionMessageToolCall(
+                        function=Function(
+                            name=part["function_call"]["name"],
+                            arguments=json.dumps(part["function_call"]["args"]),
+                        ),
+                        type="function",
+                        id=_generate_call_id(),
+                    )
+                )
+            if len(tool_calls) > 0:
+                message.tool_calls = tool_calls
+            generations.append(message)
+        return generations
+
+
+# Current gemini model has a length limit for tool name. Set it as 32.
+_max_tool_name_length = 32
+
+
+def _format_tool_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Formats tool role message to reduce tool name length."""
+    if "tool_calls" in message:
+        new_tool_calls = []
+        for tool_call in message["tool_calls"]:
+            tool_call["function"]["name"] = tool_call["function"]["name"][-_max_tool_name_length:]
+            new_tool_calls.append(tool_call)
+        message["tool_calls"] = new_tool_calls
+    if message["role"] == "tool" and "name" in message:
+        message["name"] = message["name"][-_max_tool_name_length:]
+    return message
+
+
+def _aggregate_tool_role_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Aggregates all tool role messages into one."""
+    aggregated_messages = []
+    for message in messages:
+        if message["role"] != "tool":
+            aggregated_messages.append(message)
+            continue
+        # Reduce tool name length which is smaller than OpenAI models.
+        message = _format_tool_message(message=message)
+        if len(aggregated_messages) > 0 and aggregated_messages[-1]["role"] == "tool":
+            tool_messages: list = aggregated_messages[-1]["tool_messages"]
+            aggregated_messages[-1]["tool_messages"] = tool_messages.append(message)
+            continue
+
+        aggregated_messages.append({"role": "tool", "tool_messages": [message]})
+
+    return aggregated_messages
+
+
+def _convert_openai_messages_to_gemini(messages: List[Dict[str, Any]]) -> List[Content]:
+    """Converts OpenAI messages to Gemini Content.
+
+    Args:
+        messages: OpenAI format messages.
+
+    Returns:
+        A list of Gemini Content format messages.
+
+    Raises:
+        ValidationError: Invalid role.
+        ValidationError: Invalid content type.
+    """
+    # Aggregate tool role messages into one.
+    messages = _aggregate_tool_role_messages(messages=messages)
+
+    gemini_messages = []
+    for message in messages:
+        role = message["role"]
+        if role == "user":
+            if isinstance(message["content"], str):
+                content = Content(
+                    role=role,
+                    parts=[
+                        Part.from_text(message["content"]),
+                    ],
+                )
+            elif isinstance(message["content"], list):
+                # Supports multi modal content.
+                parts = []
+                for content in message["content"]:
+                    if content["type"] == "text":
+                        parts.append(Part.from_text(content["text"]))
+                    elif content["type"] == "image_url":
+                        mime_type, data = (
+                            content["image_url"]["url"].split("data:")[1].split(";base64,")
+                        )
+                        parts.append(Part.from_data(data=data, mime_type=mime_type))
+                content = Content(
+                    role=role,
+                    parts=parts,
+                )
+            else:
+                raise ValidationError(f"Invalid content type {type(message['content'])}")
+        elif role == "assistant":
+            role = "model"
+            if "tool_calls" in message:
+                parts = []
+                for tool_call in message["tool_calls"]:
+                    args = tool_call["function"]["arguments"]
+
+                    if isinstance(args, str):
+                        args = json.loads(args)
+
+                    part = Part.from_dict(
+                        {
+                            "function_call": {
+                                "name": tool_call["function"]["name"],
+                                "args": args,
+                            }
+                        }
+                    )
+                    parts.append(part)
+                content = Content(
+                    role=role,
+                    parts=parts,
+                )
+            else:
+                content = Content(
+                    role=role,
+                    parts=[
+                        Part.from_text(message["content"]),
+                    ],
+                )
+        elif role == "tool":
+            content = Content(
+                parts=[
+                    Part.from_function_response(
+                        name=m["name"],
+                        response={
+                            "content": m["content"],
+                        },
+                    )
+                    for m in message["tool_messages"]
+                ],
+            )
+        else:
+            raise ValidationError(f"Invalid role {role}")
+
+        gemini_messages.append(content)
+    return gemini_messages
+
+
+def _convert_openai_tools_to_gemini(tools: Optional[List[Any]]) -> List[Tool]:
+    """Converts openai tools to Gemini FunctionDeclaration."""
+
+    def _convert_parameters(params: Dict[str, Any]) -> Dict[str, Any]:
+        if "properties" not in params:
+            return params
+        for param in params["properties"].values():
+            # Gemini only support string enums.
+            # Converting it to strings if the type is not a string.
+            if "enum" in param and param["type"] != "string":
+                enums = [str(e) for e in param["enum"]]
+                param["enum"] = enums
+                param["type"] = "string"
+        return params
+
+    gemini_tools = copy.deepcopy(tools)
+    funcs = []
+    for tool in gemini_tools:
+        tool["function"]["name"] = tool["function"]["name"][-_max_tool_name_length:]
+        funcs.append(
+            FunctionDeclaration(
+                name=tool["function"]["name"],
+                description=tool["function"]["description"],
+                parameters=_convert_parameters(tool["function"]["parameters"]),
+            )
+        )
+    return [Tool(function_declarations=funcs)]
+
+
+def _init_vertexai():
+    """Initializes vertex ai environment."""
+    project = os.environ.get("VERTEX_AI_PROJECT")
+    location = os.environ.get("VERTEX_AI_LOCATION")
+    vertexai.init(project=project, location=location)
+
+
+def _generate_call_id(length: int = 24) -> str:
+    """Generates call id like call_AUBkf9IL3lGQ2CUu2JmDs9Vf."""
+    characters = string.ascii_letters + string.digits
+    return "".join(random.choice(characters) for _ in range(length))

--- a/axlearn/open_api/gemini_test.py
+++ b/axlearn/open_api/gemini_test.py
@@ -1,0 +1,170 @@
+# Copyright © 2024 Apple Inc.
+
+# pylint: disable=protected-access
+"""Unit tests for gemini.py"""
+import json
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from axlearn.open_api.mock_utils import mock_openai_package, mock_vertexai_package
+
+mock_openai_package()
+mock_vertexai_package()
+
+
+_module_root = "axlearn"
+
+
+# pylint: disable=wrong-import-position
+from axlearn.open_api.common import ValidationError
+from axlearn.open_api.gemini import (
+    GeminiClient,
+    _convert_openai_messages_to_gemini,
+    _format_tool_message,
+)
+
+# pylint: enable=wrong-import-position
+
+
+class TestGeminiClient(unittest.IsolatedAsyncioTestCase):
+    """Unit test for class GeminiClient."""
+
+    @patch(f"{_module_root}.open_api.gemini._init_vertexai")
+    def _create_gemini_client(
+        self,
+        mock_init_vertexai=None,
+    ) -> GeminiClient:
+        mock_init_vertexai.return_value = AsyncMock()
+        client: GeminiClient = (
+            GeminiClient.default_config().set(model="gemini-1.0-pro").instantiate()
+        )
+        client._client = AsyncMock()
+        return client
+
+    @patch(f"{_module_root}.open_api.gemini._convert_openai_messages_to_gemini")
+    @patch(f"{_module_root}.open_api.gemini._convert_openai_tools_to_gemini")
+    async def test_async_generate(self, mock_convert_tools, mock_convert_messages):
+        mock_convert_messages.return_value = "converted_messages"
+        mock_convert_tools.return_value = "converted_tools"
+        client = self._create_gemini_client()
+        mock_response = MagicMock()
+        mock_response.to_dict.return_value = {"response": "test_response"}
+        client._client.generate_content_async = AsyncMock(return_value=mock_response)
+
+        result = await client.async_generate(
+            messages=[{"role": "user", "content": "Hello"}],
+            tools=[{"name": "tool1"}],
+            temperature=0.7,
+            top_k=50,
+            top_p=0.9,
+            max_tokens=100,
+            stop_sequences=["\n"],
+        )
+        # Assert the expected result.
+        self.assertEqual(result, json.dumps({"response": "test_response"}))
+
+    def test_format_tool_message(self):
+        message = {"role": "assistant", "tool_calls": [{"function": {"name": "long_name" * 32}}]}
+        processed_message = _format_tool_message(message)
+        self.assertTrue(len(processed_message["tool_calls"][0]["function"]["name"]) <= 32)
+
+
+class TestConvertOpenAIMessagesToGemini(unittest.TestCase):
+    """Unit tests for _convert_openai_messages_to_gemini."""
+
+    def setUp(self):
+        # Reset mocks before each test.
+        self.mock_part = sys.modules["vertexai.generative_models"].Part
+        self.mock_part.reset_mock()
+
+        self.mock_content = sys.modules["vertexai.generative_models"].Content
+        self.mock_content.reset_mock()
+
+    def test_convert_user_text_message(self):
+        messages = [{"role": "user", "content": "Hello, how can I help you?"}]
+
+        part_instance = MagicMock()
+        self.mock_part.from_text.return_value = part_instance
+
+        content_instance = MagicMock()
+        self.mock_content.return_value = content_instance
+
+        result = _convert_openai_messages_to_gemini(messages)
+        # mock_part
+        self.mock_part.from_text.assert_called_with("Hello, how can I help you?")
+        self.mock_content.assert_called_once()
+        self.mock_content.assert_called_with(role="user", parts=[part_instance])
+        self.assertEqual(result, [content_instance])
+
+    def test_convert_user_multimodal_message(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Look at this image:"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+                ],
+            }
+        ]
+
+        text_part_instance = MagicMock()
+        image_part_instance = MagicMock()
+        self.mock_part.from_text.return_value = text_part_instance
+        self.mock_part.from_data.return_value = image_part_instance
+
+        content_instance = MagicMock()
+        self.mock_content.return_value = content_instance
+
+        result = _convert_openai_messages_to_gemini(messages)
+
+        self.mock_part.from_text.assert_called_with("Look at this image:")
+        self.mock_part.from_data.assert_called_with(data="abc123", mime_type="image/png")
+        self.mock_content.assert_called_with(
+            role="user", parts=[text_part_instance, image_part_instance]
+        )
+        self.assertEqual(result, [content_instance])
+
+    def test_convert_assistant_message(self):
+        messages = [{"role": "assistant", "content": "Sure, I can help with that."}]
+
+        part_instance = MagicMock()
+        self.mock_part.from_text.return_value = part_instance
+
+        content_instance = MagicMock()
+        self.mock_content.return_value = content_instance
+
+        result = _convert_openai_messages_to_gemini(messages)
+
+        self.mock_part.from_text.assert_called_with("Sure, I can help with that.")
+        self.mock_content.assert_called_with(role="model", parts=[part_instance])
+        self.assertEqual(result, [content_instance])
+
+    def test_convert_tool_message(self):
+        messages = [
+            {
+                "role": "tool",
+                "content": "tool response",
+                "name": "tool1",
+            }
+        ]
+
+        part_instance = MagicMock()
+        self.mock_part.from_function_response.return_value = part_instance
+
+        content_instance = MagicMock()
+        self.mock_content.return_value = content_instance
+
+        result = _convert_openai_messages_to_gemini(messages)
+
+        self.mock_part.from_function_response.assert_called_with(
+            name="tool1", response={"content": "tool response"}
+        )
+        self.mock_content.assert_called_with(parts=[part_instance])
+        self.assertEqual(result, [content_instance])
+
+    def test_invalid_role(self):
+        messages = [{"role": "invalid_role", "content": "This should raise an error."}]
+
+        with self.assertRaises(ValidationError):
+            _convert_openai_messages_to_gemini(messages)

--- a/axlearn/open_api/mock_utils.py
+++ b/axlearn/open_api/mock_utils.py
@@ -19,7 +19,13 @@ def mock_openai_package():
     mock_openai_types = types.ModuleType("openai.types")
     mock_openai_types_chat = types.ModuleType("openai.types.chat")
     mock_chat_completion_message = types.ModuleType("openai.types.chat.chat_completion_message")
+    mock_chat_completion_message_tool_call = types.ModuleType(
+        "openai.types.chat.chat_completion_message_tool_call"
+    )
+
     mock_chat_completion_message.ChatCompletionMessage = MagicMock()
+    mock_chat_completion_message.ChatCompletionMessageToolCall = MagicMock()
+    mock_chat_completion_message_tool_call.Function = MagicMock()
 
     mock_openai_types_completion = types.ModuleType("openai.types.completion")
     mock_completion = MagicMock()
@@ -29,6 +35,10 @@ def mock_openai_package():
     mock_openai.types.chat = mock_openai_types_chat
     mock_openai.types.chat.ChatCompletion = MagicMock()
     mock_openai.types.chat.chat_completion_message = mock_chat_completion_message
+    mock_openai.types.chat.chat_completion_message_tool_call = (
+        mock_chat_completion_message_tool_call
+    )
+
     mock_openai.types.completion = mock_openai_types_completion
     mock_openai.types.completion.Completion = mock_completion
 
@@ -37,4 +47,36 @@ def mock_openai_package():
     sys.modules["openai.types"] = mock_openai_types
     sys.modules["openai.types.chat"] = mock_openai_types_chat
     sys.modules["openai.types.chat.chat_completion_message"] = mock_chat_completion_message
+    sys.modules[
+        "openai.types.chat.chat_completion_message_tool_call"
+    ] = mock_chat_completion_message_tool_call
     sys.modules["openai.types.completion"] = mock_openai_types_completion
+
+
+def mock_vertexai_package():
+    """Initialize vertexai package for unit tests."""
+    # Create mock for the vertexai module and its submodules.
+    mock_vertexai = types.ModuleType("vertexai")
+    mock_generative_models = types.ModuleType("vertexai.generative_models")
+
+    # Create mocks for each class in the generative_models submodule.
+    mock_content = MagicMock()
+    mock_function_declaration = MagicMock()
+    mock_generation_config = MagicMock()
+    mock_generative_model = MagicMock()
+    mock_part = MagicMock()
+    mock_tool = MagicMock()
+
+    # Set up the mock module structure.
+    mock_generative_models.Content = mock_content
+    mock_generative_models.FunctionDeclaration = mock_function_declaration
+    mock_generative_models.GenerationConfig = mock_generation_config
+    mock_generative_models.GenerativeModel = mock_generative_model
+    mock_generative_models.Part = mock_part
+    mock_generative_models.Tool = mock_tool
+
+    mock_vertexai.generative_models = mock_generative_models
+
+    # Patch sys.modules to replace the vertexai package with our mock.
+    sys.modules["vertexai"] = mock_vertexai
+    sys.modules["vertexai.generative_models"] = mock_generative_models

--- a/axlearn/open_api/openai.py
+++ b/axlearn/open_api/openai.py
@@ -52,7 +52,7 @@ class OpenAIClient(BaseClient):
         prompt: Optional[str] = None,
         **kwargs,
     ) -> str:
-        """Generate response asynchronously from the client.
+        """Generates response asynchronously from the client.
 
         Args:
             messages: OpenAI requests style messages.


### PR DESCRIPTION
- Add gemini models support in open_api
- Used for evaluation and paper

We use vertextai python sdk so far https://github.com/googleapis/python-aiplatform. Just in case Google has decided to move the major support in this https://github.com/google-gemini/generative-ai-python, we may need to change it. I will review the sdk implementation to decide whether we switch to that one later. 

Reviewed internally