### PR TITLE
[4/N] Add generator for open_api inference

### DIFF
--- a/axlearn/open_api/generator.py
+++ b/axlearn/open_api/generator.py
@@ -1,0 +1,131 @@
+# Copyright © 2024 Apple Inc.
+
+"""Generates responses from open api or open source models.
+Input format is json line with each line in OpenAI requests style.
+"""
+import asyncio
+import logging
+import os
+from datetime import timedelta
+from typing import Any, Dict, List, Optional, Type
+
+from absl import app, flags, logging
+from absl.flags import FlagValues
+
+from axlearn.open_api.common import (
+    BaseClient,
+    Generator,
+    check_vllm_readiness,
+    flatten_responses,
+    load_requests,
+    parse_decode_parameters,
+    repeat_requests,
+    write_responses,
+)
+from axlearn.open_api.registry import ClientRegistry
+
+FLAGS = flags.FLAGS
+
+
+def generator_config_from_flags(fv: FlagValues) -> Generator.Config:
+    """Creates config from flags.
+
+    Args:
+        fv: The flag values of generator.py.
+
+    Returns:
+        An instance of Generator.
+
+    Raises:
+        ValueError: Client class must not be empty.
+    """
+    client_cls: Optional[Type[BaseClient]] = ClientRegistry.load_client_cls(fv.client_name)
+    if client_cls is None:
+        raise ValueError("Client class must not be empty.")
+    decode_parameters, extra_body = parse_decode_parameters(fv.decode_parameters, model=fv.model)
+    # Initializes generator.
+    cfg: Generator.Config = Generator.default_config().set(
+        concurrency=fv.concurrency,
+        max_non_rate_limit_retries=fv.max_non_rate_limit_retries,
+        allow_non_rate_limit_error=fv.allow_non_rate_limit_error,
+        max_rate_limit_retries=fv.max_rate_limit_retries,
+        decode_parameters=decode_parameters,
+        retry_sleep_in_seconds=fv.retry_sleep_in_seconds,
+        client=client_cls.default_config().set(
+            model=fv.model, timeout=fv.timeout, extra_body=extra_body
+        ),
+    )
+    return cfg
+
+
+async def generate_from_requests(
+    *, gen_requests: List[Dict[str, Any]], fv: FlagValues
+) -> List[Dict[str, Any]]:
+    """Generates responses for open api clients given a file path.
+
+    Args:
+        gen_requests: A list of OpenAI style requests. Ref:
+            https://platform.openai.com/docs/api-reference/chat/create.
+        fv: The flag values of generator.py.
+
+    Returns:
+        A list of generation responses.
+
+    Raises:
+        ValueError: Decode parameters n must be larger than 0.
+    """
+    cfg: Generator.Config = generator_config_from_flags(fv=fv)
+    generator: Generator = cfg.instantiate()
+    # Repeat requests if n in decode parameters is larger than 1.
+    n = cfg.decode_parameters.get("n", 1)
+    if fv.repeat_requests_for_n and n > 1:
+        gen_requests = repeat_requests(gen_requests, n)
+        del cfg.decode_parameters["n"]
+    elif n < 1:
+        raise ValueError("Decode parameters n must be larger than 0.")
+    # Checks vllm readiness.
+    if fv.check_vllm_readiness and "OPENAI_BASE_URL" in os.environ:
+        check_vllm_readiness(
+            timeout=timedelta(seconds=fv.readiness_timeout),
+            base_url=os.environ["OPENAI_BASE_URL"],
+        )
+    # Generates responses.
+    responses = await generator.async_generate_from_requests(
+        gen_requests=gen_requests, **cfg.decode_parameters
+    )
+    # Parses responses.
+    if n > 1:
+        responses = flatten_responses(responses)
+
+    return responses
+
+
+async def generate_from_file(fv: FlagValues):
+    """Generates responses for open api clients given a file path.
+
+    Args:
+        fv: The flag values of generator.py.
+
+    Returns:
+        None. The results are written directly to a file and logged.
+    """
+    # Loads requests.
+    gen_requests = load_requests(
+        fv.input_file,
+        max_instances=fv.max_instances,
+    )
+    responses = await generate_from_requests(gen_requests=gen_requests, fv=fv)
+
+    # Writes responses.
+    write_responses(responses, file_path=fv.output_file)
+
+
+def main(_):
+    if FLAGS.debug:
+        logging.set_verbosity(logging.DEBUG)
+    asyncio.run(generate_from_file(FLAGS))
+
+
+if __name__ == "__main__":
+    Generator.define_flags(FLAGS)
+    app.run(main)

--- a/axlearn/open_api/generator_test.py
+++ b/axlearn/open_api/generator_test.py
@@ -1,0 +1,67 @@
+# Copyright © 2024 Apple Inc.
+
+# pylint: disable=protected-access
+"""Unit tests for generator.py."""
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from absl import flags
+
+from axlearn.open_api.mock_utils import mock_openai_package
+
+mock_openai_package()
+
+_module_root = "axlearn"
+
+
+# pylint: disable=wrong-import-position
+from axlearn.open_api.common import Generator
+from axlearn.open_api.generator import generate_from_requests
+from axlearn.open_api.openai import OpenAIClient
+
+# pylint: enable=wrong-import-position
+
+
+class TestGenerateFromRequests(unittest.IsolatedAsyncioTestCase):
+    """Unit test for generate_from_requests."""
+
+    def setUp(self):
+        cfg: Generator.Config = Generator.default_config().set(
+            concurrency=2,
+            max_non_rate_limit_retries=3,
+            client=OpenAIClient.default_config().set(model="gpt-3.5-turbo"),
+        )
+        open_api: Generator = cfg.instantiate()
+        self.open_api = open_api
+        # Mock clients for concurrency.
+        self.open_api._clients = [MagicMock(), MagicMock()]
+
+    @patch(
+        f"{_module_root}.open_api.common.Generator._async_generate_from_request",
+        new_callable=AsyncMock,
+    )
+    async def test_async_generate_from_requests(self, mock_async_generate_from_request):
+        # Mock async_generate_from_request to return a predefined response.
+        mock_response = {"response": "test response", "async_index": 1}
+        mock_async_generate_from_request.return_value = mock_response
+
+        # Create mock requests.
+        mock_requests = [
+            {"messages": [{"role": "user", "content": "How are you?"}]},
+            {"messages": [{"role": "user", "content": "Tell me a joke."}]},
+            {"messages": [{"role": "user", "content": "What is the weather today?"}]},
+        ]
+
+        fv = flags.FlagValues()
+        Generator.define_flags(fv)
+        fv.set_default("model", "test")
+        fv.mark_as_parsed()
+
+        # Call the method under test.
+        responses = await generate_from_requests(gen_requests=mock_requests, fv=fv)
+
+        # Assertions to verify behavior.
+        self.assertEqual(len(responses), len(mock_requests))
+        for response in responses:
+            self.assertIn("response", response)
+            self.assertEqual(response["response"], "test response")

--- a/axlearn/open_api/registry.py
+++ b/axlearn/open_api/registry.py
@@ -1,0 +1,60 @@
+# Copyright © 2024 Apple Inc.
+
+# Some of the code in this file is adapted from:
+#
+# vllm-project/vllm:
+# Copyright 2023 The vLLM team. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+
+"""Registers all available clients and uses lazy import via client name."""
+import importlib
+import logging
+from typing import Dict, List, Optional, Type
+
+from axlearn.open_api.common import BaseClient
+
+# The dict of {client_name: (module, class)}.
+_OPEN_API_CLIENTS_MODULE_CLASS = {
+    "openai": ("openai", "OpenAIClient"),
+    "gemini": ("gemini", "GeminiClient"),
+    "anthropic": ("anthropic", "AnthropicClient"),
+}
+
+# The dict of {client_name: class}.
+_OPEN_API_CLIENTS_CLASS: Dict[str, Type[BaseClient]] = {}
+
+
+class ClientRegistry:
+    """A registry of open api clients."""
+
+    @staticmethod
+    def load_client_cls(client_name: str) -> Optional[Type[BaseClient]]:
+        """Loads an open api client."""
+        if client_name in _OPEN_API_CLIENTS_CLASS:
+            return _OPEN_API_CLIENTS_CLASS[client_name]
+        if client_name not in _OPEN_API_CLIENTS_MODULE_CLASS:
+            return None
+        module_name, client_cls_name = _OPEN_API_CLIENTS_MODULE_CLASS[client_name]
+        module = importlib.import_module(f"axlearn.open_api.{module_name}")
+        return getattr(module, client_cls_name, None)
+
+    @staticmethod
+    def get_supported_clients() -> List[str]:
+        """Gets supported clients."""
+        return list(_OPEN_API_CLIENTS_MODULE_CLASS.keys()) + list(_OPEN_API_CLIENTS_CLASS.keys())
+
+    @staticmethod
+    def register(client_name: str, client_cls: Type[BaseClient]):
+        """Registers a new client.
+
+        Args:
+           client_name: A string of client name.
+           client_cls: A class of Open API client in the type of BaseClient.
+        """
+        if client_name in _OPEN_API_CLIENTS_CLASS:
+            logging.warning(
+                "Client %s will be overwritten by the new client class %s.",
+                client_name,
+                client_cls.__name__,
+            )
+        _OPEN_API_CLIENTS_CLASS[client_name] = client_cls

--- a/axlearn/open_api/registry_test.py
+++ b/axlearn/open_api/registry_test.py
@@ -1,0 +1,82 @@
+# Copyright © 2024 Apple Inc.
+
+# pylint: disable=protected-access
+"""Unit tests for common.py."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from axlearn.open_api.mock_utils import mock_openai_package
+
+mock_openai_package()
+
+# pylint: disable=wrong-import-position
+
+from axlearn.open_api.common import BaseClient
+from axlearn.open_api.registry import (
+    _OPEN_API_CLIENTS_CLASS,
+    _OPEN_API_CLIENTS_MODULE_CLASS,
+    ClientRegistry,
+)
+
+# pylint: enable=wrong-import-position
+
+_module_root = "axlearn"
+
+
+class MockClient(BaseClient):
+    """A mock of open api client."""
+
+    pass
+
+
+class TestClientRegistry(unittest.TestCase):
+    """Unit tests for ClientRegistry."""
+
+    def setUp(self):
+        # Clear the client registry before each test
+        _OPEN_API_CLIENTS_CLASS.clear()
+
+    @patch(f"{_module_root}.open_api.registry.importlib.import_module")
+    def test_load_client_cls_existing_client(self, mock_import_module):
+        # Mock the import and getattr functions
+        mock_module = MagicMock()
+        mock_import_module.return_value = mock_module
+        mock_module.OpenAIClient = MockClient
+
+        _OPEN_API_CLIENTS_MODULE_CLASS["mockclient"] = ("mock_module", "OpenAIClient")
+
+        client_cls = ClientRegistry.load_client_cls("mockclient")
+        self.assertEqual(client_cls, MockClient)
+
+    def test_load_client_cls_registered_client(self):
+        _OPEN_API_CLIENTS_CLASS["mockclient"] = MockClient
+
+        client_cls = ClientRegistry.load_client_cls("mockclient")
+        self.assertEqual(client_cls, MockClient)
+
+    def test_load_client_cls_non_existing_client(self):
+        client_cls = ClientRegistry.load_client_cls("nonexistent")
+        self.assertIsNone(client_cls)
+
+    def test_get_supported_clients(self):
+        _OPEN_API_CLIENTS_MODULE_CLASS["client1"] = ("module1", "Client1")
+        _OPEN_API_CLIENTS_CLASS["client2"] = MockClient
+
+        supported_clients = ClientRegistry.get_supported_clients()
+        self.assertIn("client1", supported_clients)
+        self.assertIn("client2", supported_clients)
+
+    def test_register_new_client(self):
+        ClientRegistry.register("mockclient", MockClient)
+
+        self.assertIn("mockclient", _OPEN_API_CLIENTS_CLASS)
+        self.assertEqual(_OPEN_API_CLIENTS_CLASS["mockclient"], MockClient)
+
+    @patch(f"{_module_root}.open_api.registry.logging.warning")
+    def test_register_existing_client(self, mock_warning):
+        _OPEN_API_CLIENTS_CLASS["mockclient"] = BaseClient
+
+        ClientRegistry.register("mockclient", MockClient)
+
+        mock_warning.assert_called_once()
+        self.assertEqual(_OPEN_API_CLIENTS_CLASS["mockclient"], MockClient)


### PR DESCRIPTION
- generator.py: it is a script to launch via python3 -m axlearn.open_api.generator to generate responses given an input file
- registry.py: it is a registry hub to collect existing clients via load_client_cls and allow dynamically import via importlib. This will allow separate client package installation without binding them as one. It also supports a register function to allow users to add a new client outside axlearn package

reviewed internally