### PR TITLE
Allows patched_vmap in common/test_utils.py:read_param_init_specs_recursively to accept vmap kwargs. 

### DIFF
--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -462,11 +462,11 @@ def read_param_init_specs_recursively(
 
     orig_vmap = jax.vmap
 
-    def patched_vmap(fn):
+    def patched_vmap(fn, **vmap_kwargs):
         def wrapped_fn(*args, **kwargs):
             return _cast_ordered_dict(fn(*args, **kwargs))
 
-        return orig_vmap(wrapped_fn)
+        return orig_vmap(wrapped_fn, **vmap_kwargs)
 
     patch_vmap = patch("jax.vmap", side_effect=patched_vmap, autospec=True)
 


### PR DESCRIPTION
This in turn means that we can use kwargs in vmap calls to initialize parameters.