### PR TITLE
[5/N] Add evaluator for open_api inference

### DIFF
--- a/axlearn/open_api/evaluator.py
+++ b/axlearn/open_api/evaluator.py
@@ -1,0 +1,103 @@
+# Copyright © 2024 Apple Inc.
+
+"""Evaluates and computes metrics for responses from generator."""
+import logging
+import os
+from datetime import timedelta
+from typing import Optional, Type
+
+from absl import app, flags, logging
+from absl.flags import FlagValues
+
+from axlearn.open_api.common import (
+    BaseClient,
+    EvalGeneratorType,
+    Evaluator,
+    Generator,
+    check_vllm_readiness,
+    parse_decode_parameters,
+)
+from axlearn.open_api.generator import generator_config_from_flags
+from axlearn.open_api.registry import ClientRegistry, MetricRegistry
+
+FLAGS = flags.FLAGS
+
+
+def evaluate_from_file(fv: FlagValues):
+    """Evaluates and computes for responses from open api clients given a file path.
+
+    Args:
+        fv: The flag values of evaluator.py.
+
+    Returns:
+        None. The results are written directly to a file and logged.
+
+    Raises:
+        ValueError: Client class must not be empty.
+        ValueError: Grader client class must not be empty.
+        ValueError: Metric function must not be empty.
+        ValueError: Either default model name or grader model name must be set.
+    """
+    generator_cfg: Generator.Config = generator_config_from_flags(fv=fv)
+    # Checks vllm readiness.
+    if fv.check_vllm_readiness and "OPENAI_BASE_URL" in os.environ:
+        check_vllm_readiness(
+            timeout=timedelta(seconds=fv.readiness_timeout),
+            base_url=os.environ["OPENAI_BASE_URL"],
+        )
+
+    grader_generator_cfg = generator_cfg.clone()
+    grader_decode_parameters = grader_generator_cfg.decode_parameters
+    if fv.grader_decode_parameters is not None:
+        grader_decode_parameters, grader_extra_body = parse_decode_parameters(
+            fv.grader_decode_parameters, model=fv.grader_model or fv.model
+        )
+    else:
+        grader_extra_body = generator_cfg.client.extra_body
+    if fv.grader_model is not None:
+        grader_decode_parameters.update({"model": fv.grader_model})
+    grader_generator_cfg.set(decode_parameters=grader_decode_parameters)
+    if fv.grader_client_name is not None:
+        if fv.model is None and fv.grader_model is None:
+            raise ValueError("Either default model name or grader model name must be set.")
+        # Initializes grader generator.
+        grader_client_cls: Optional[Type[BaseClient]] = ClientRegistry.load_client_cls(
+            fv.grader_client_name
+        )
+        if grader_client_cls is None:
+            raise ValueError("Grader client class must not be empty.")
+        grader_client_cfg = grader_client_cls.default_config().set(
+            model=fv.grader_model or fv.model,
+            timeout=fv.timeout,
+            extra_body=grader_extra_body,
+        )
+        grader_generator_cfg.client = grader_client_cfg
+
+    evaluator: Evaluator = (
+        Evaluator.default_config()
+        .set(
+            generators={
+                EvalGeneratorType.RESPONSE: generator_cfg,
+                EvalGeneratorType.GRADER: grader_generator_cfg,
+            },
+            debug=fv.debug,
+        )
+        .instantiate()
+    )
+
+    metric_fn = MetricRegistry.load_metric(metric_name=fv.metric_name)
+    if metric_fn is None:
+        raise ValueError("Metric function must not be empty.")
+    evaluator.evaluate(input_file=fv.input_file, output_file=fv.output_file, metric_fn=metric_fn)
+
+
+def main(_):
+    if FLAGS.debug:
+        logging.set_verbosity(logging.DEBUG)
+    evaluate_from_file(FLAGS)
+
+
+if __name__ == "__main__":
+    Generator.define_flags(fv=FLAGS)
+    Evaluator.define_flags(fv=FLAGS)
+    app.run(main)

--- a/axlearn/open_api/evaluator_test.py
+++ b/axlearn/open_api/evaluator_test.py
@@ -1,0 +1,85 @@
+# Copyright © 2024 Apple Inc.
+
+# pylint: disable=protected-access
+"""Unit tests for generator.py."""
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from absl import flags
+
+from axlearn.open_api.mock_utils import mock_openai_package
+
+mock_openai_package()
+
+# isort: off
+# pylint: disable=wrong-import-position
+from axlearn.open_api import common
+from axlearn.open_api.common import Evaluator, Generator
+from axlearn.open_api.evaluator import evaluate_from_file
+
+# pylint: enable=wrong-import-position
+# isort: one
+
+
+class TestEvaluateFromFile(unittest.IsolatedAsyncioTestCase):
+    """Unit test for evaluate_from_file."""
+
+    def setUp(self):
+        self.mock_responses = [
+            {"response": "response1"},
+            {"response": "response2"},
+            {"response": "response3"},
+        ]
+
+        # Create a temporary file and write the mock responses to it.
+        # pylint: disable-next=consider-using-with
+        self.temp_file = tempfile.NamedTemporaryFile(mode="w+", delete=False)
+        json.dump(self.mock_responses, self.temp_file)
+        # Ensure data is written to file.
+        self.temp_file.flush()
+        self.temp_file_path = self.temp_file.name
+
+    def tearDown(self):
+        # Close and remove the temporary file
+        self.temp_file.close()
+        os.remove(self.temp_file_path)
+
+    @patch(
+        f"{common.__name__}.Evaluator.evaluate",
+        new_callable=MagicMock,
+    )
+    async def test_evaluate_from_file(self, mock_evaluate):
+        fv = flags.FlagValues()
+        Generator.define_flags(fv)
+        Evaluator.define_flags(fv)
+        fv.set_default("model", "test")
+        fv.set_default("check_vllm_readiness", False)
+        fv.set_default("metric_name", "tool_use_plan")
+        fv.set_default("input_file", self.temp_file_path)
+        fv.mark_as_parsed()
+
+        # Call the method under test.
+        evaluate_from_file(fv=fv)
+        mock_evaluate.assert_called_once()
+
+    @patch(
+        f"{common.__name__}.Evaluator.evaluate",
+        new_callable=MagicMock,
+    )
+    # pylint: disable-next=unused-argument
+    async def test_evaluate_from_file_no_metric(self, mock_evaluate):
+        fv = flags.FlagValues()
+        Generator.define_flags(fv)
+        Evaluator.define_flags(fv)
+        fv.set_default("model", "test")
+        fv.set_default("check_vllm_readiness", False)
+        fv.set_default("input_file", self.temp_file_path)
+        fv.mark_as_parsed()
+
+        # Test that ValueError is raised.
+        with self.assertRaises(ValueError):
+            # Call the method under test.
+            evaluate_from_file(fv=fv)

--- a/axlearn/open_api/metrics/__init__.py
+++ b/axlearn/open_api/metrics/__init__.py
@@ -1,0 +1,1 @@
+# Copyright © 2024 Apple Inc.

--- a/axlearn/open_api/metrics/code_contests.py
+++ b/axlearn/open_api/metrics/code_contests.py
@@ -1,0 +1,627 @@
+# Copyright © 2024 Apple Inc.
+
+"""CodeContests evaluation task.
+
+Evaluate the correctness of generated code, problem understanding or plans.
+"""
+import asyncio
+import copy
+import json
+import logging
+from enum import Enum
+from typing import Any, Dict, List, Type
+
+from axlearn.open_api.common import (
+    BaseClient,
+    EvalGeneratorType,
+    Generator,
+    flatten_responses,
+    repeat_requests,
+)
+from axlearn.open_api.metrics.code_execute import check_correctness
+
+# pylint: disable=line-too-long
+_plan2code_prompt_template = """You are an AI with advanced code generation and instruction following capabilities.
+
+When you encounter a specific problem (labeled #PROBLEM#) and a solving plan (labeled #PLAN#), your goal is to produce a valid python code that correctly solves the problem.
+Make sure to fully address the problem goals following the rules and constraints. Refer to the plan to generate the code.
+The code should be robust and general. It should output correct answers under any valid inputs, not only just the example inputs given in the problem description.
+
+#PROBLEM#:
+{description}
+
+#PLAN#:
+{plan}
+
+guidelines:
+- Generate only code, without any additional explanations or comments.
+- Make sure to include all the necessary module imports, properly initialize the variables, and address the problem constraints.
+- The code needs to be self-contained, and executable as-is.
+
+The code output must follow this structure:
+```
+def f1(...):
+    ...
+    return ...
+
+def f2(...):
+    ...
+    return ...
+...
+
+if __name__ == "__main__":
+    ...
+```
+The code should read the input using the 'input()' method. Make sure to properly parse the input, according to the problem description.
+The output should be printed without additional words using the 'print()' method.
+
+answer:
+```python
+
+"""
+# pylint: enable=line-too-long
+
+
+class CodeContestStatus(str, Enum):
+    """Possible status of solving CodeContests problems."""
+
+    SUCCESS = "success"
+    ERROR = "runtime_error"
+    MISMATCH = "wrong_output"
+    EMPTY = "empty_solution"
+
+
+def _parse_answer(gen: str) -> str:
+    """Extracts answer from the response.
+
+    Args:
+        gen: Generated response content str.
+
+    Returns:
+        Extracted answer str.
+    """
+    # The instruction asks the model to generate answer after #ANSWER#:.
+    if "#ANSWER#" in gen:
+        temp = gen.split("#ANSWER#:")[-1]
+        return temp
+    elif "ANSWER" in gen:
+        # Relaxes the instruction template for model outputs that do not have #.
+        temp = gen.split("ANSWER")[-1]
+        # Solves corner case with ANSWER\n.
+        if "\n" in temp:
+            temp = temp.split("\n")[1]
+        return temp
+    else:
+        return ""
+
+
+def _format_gen_code(gen: str) -> str:
+    """Formats the generated code into executable python code.
+
+    Args:
+        gen: Generated code str.
+
+    Returns:
+        Re-formated python code.
+    """
+    # Some models will generate some non-code explanations in the end.
+    # Hence we extract the code block between ```python and ```.
+    if "```python" in gen:
+        gen = gen.split("```python")[1]
+    if "```" in gen:
+        gen = gen.split("```")[0]
+    # Remove if main for local execution.
+    if "if __name__" in gen:
+        lines = gen.split("\n")
+        new_lines = []
+        enter_main = False
+        for l in lines:
+            if "if __name__" in l:
+                enter_main = True
+            else:
+                if enter_main:
+                    new_lines.append(l[4:])
+                else:
+                    new_lines.append(l)
+        gen = "\n".join(new_lines)
+    return gen.strip()
+
+
+def _check_execution_output_match(pred: str, *, expected: str) -> bool:
+    """Checks whether the generated code's output matches the expected.
+
+    Args:
+        pred: Generated output.
+        expected: Expected groundtruth output.
+
+    Returns:
+        Bool value of whether the outputs match.
+    """
+    pred = pred.strip()
+    expected = expected.strip()
+    if pred.replace(" ", "") == expected.replace(" ", ""):
+        return True
+    try:
+        if abs(float(pred) - float(expected)) / max(1.0, abs(expected)) <= 1e-4:
+            return True
+    # ValueError: If pred or expected are string type.
+    # TypeError: If pred or expected are dictionary or list type.
+    except (ValueError, TypeError):
+        return False
+    return False
+
+
+def _check_understand_str_match(pred: str, *, expected: str) -> bool:
+    """Checks whether the predicted understanding string matches the expected.
+
+    Args:
+        pred: Predicted output.
+        expected: Expected groundtruth output.
+
+    Returns:
+        Bool value of whether the outputs match.
+    """
+    # Check matches line by line.
+    # Ignore start and end space via strip.
+    pred = [p for p in pred.split("\n") if p]
+    expected = [e for e in expected.split("\n") if e]
+
+    if len(pred) == len(expected):
+        for p, e in zip(pred, expected):
+            if p.strip() != e.strip():
+                return False
+        return True
+    return False
+
+
+def _exec_and_check(
+    gen_code: str,
+    *,
+    problem: Dict[str, Any],
+    problem_id: str,
+    candidate_id: str,
+    save_errors: bool = False,
+) -> Dict[str, Any]:
+    """Executes generated code and checks whether it can pass all the tests of a problem.
+
+    Args:
+        gen_code: Generated code string.
+        problem: Expected groundtruth output.
+        problem_id: An identifier of the problem.
+        candidate_id: An identifier of the generated code candidate.
+        save_errors: Whether to save the error log.
+
+    Returns:
+        A dictionary of execution results.
+    """
+    if not gen_code:
+        return {"passed": False, "score": 0.0, "errors": {"status": CodeContestStatus.EMPTY}}
+
+    total_tests = 0
+    total_passed = 0
+    err_log = []
+
+    for eval_type in ["public_tests", "private_tests", "generated_tests"]:
+        eval_tests = problem.get(eval_type, None)
+        if not eval_tests:
+            continue
+        eval_inputs = eval_tests.get("input", [])
+        eval_outputs = eval_tests.get("output", [])
+        results = check_correctness(
+            check_program=gen_code,
+            inputs=eval_inputs,
+            timeout=3.0,
+            task_id=problem_id,
+            completion_id=candidate_id,
+        )
+        # Results format:
+        # Success: {"task_id": task_id, "completion_id": completion_id, "result": result}.
+        # Failure: {"error": "timeout", "result_list": []}.
+        if results["result"]["error"] is not None:
+            total_tests += len(eval_inputs)
+        else:
+            assert (
+                len(results["result"]["result_list"]) == len(eval_inputs) == len(eval_outputs)
+            ), ValueError("Non matched length exec_res, test_input, expected_output")
+            for exec_res, test_input, expected_output in zip(
+                results["result"]["result_list"],
+                eval_inputs,
+                eval_outputs,
+            ):
+                total_tests += 1
+                if not exec_res["passed"]:
+                    if save_errors:
+                        err_log.append(
+                            {
+                                "status": CodeContestStatus.ERROR,
+                                "test_input": test_input,
+                                "error_message": exec_res["error"],
+                            }
+                        )
+                elif _check_execution_output_match(
+                    pred=exec_res["output"], expected=expected_output
+                ):
+                    total_passed += 1
+                elif save_errors:
+                    err_log.append(
+                        {
+                            "status": CodeContestStatus.MISMATCH,
+                            "test_input": test_input,
+                            "expected_output": expected_output,
+                            "code_output": exec_res["output"],
+                        }
+                    )
+
+    if total_tests == 0:
+        logging.error("No test found for problem %s", problem_id)
+        return {"passed": False, "score": 0.0, "errors": []}
+
+    return {
+        "passed": total_tests == total_passed,
+        "score": total_passed * 1.0 / total_tests,
+        "errors": err_log,
+    }
+
+
+def code_execution_metric_fn(
+    *,
+    responses: List[Dict[str, Any]],
+    generators: Dict[EvalGeneratorType, Generator],
+    debug: bool = False,
+) -> Dict[str, Any]:
+    """Implements code contests metric following axlearn.open_api.common.MetricFn.
+    This computes the correctness of the generated code, returns pass rate and
+    average score of the generated code on all test cases per problem,
+    corresponding to the E2E standard task in the paper.
+
+    Args:
+        responses: A list of responses in dictionary.
+        generators: A dict of generator instances.
+        debug: True to add debug information in the metric.
+
+    Returns:
+        A dictionary of metrics.
+    """
+    total_passed = 0
+    num_candidates = []
+    global_stats = {}
+    errors = {}
+    avg_scores = []
+    client_cls: Type[BaseClient] = generators[EvalGeneratorType.RESPONSE].config.client.klass
+    for resp_id, response in enumerate(responses):
+        candidates: List[str] = []
+        pid = response["id"]
+        if "n_responses" in response:
+            for resp in response["n_responses"]:
+                gen = client_cls.parse_generation(response=json.loads(resp))
+                if len(gen) > 0:
+                    candidates.append(_format_gen_code(gen[0].content))
+                else:
+                    logging.debug(
+                        "deliverable_id: %s with empty response.",
+                        response.get("deliverable_id", response.get("id", "")),
+                    )
+                    candidates.append("")
+        else:
+            gen = client_cls.parse_generation(response=json.loads(response["response"]))
+            if len(gen) > 0:
+                candidates.append(_format_gen_code(gen[0].content))
+            else:
+                logging.debug(
+                    "deliverable_id: %s with empty response.",
+                    response.get("deliverable_id", response.get("id", "")),
+                )
+                candidates.append("")
+        num_candidates.append(len(candidates))
+        correct_candidates = 0
+        scores = []
+        errors[pid] = {}
+        for cand_id, candidate in enumerate(candidates):
+            result = _exec_and_check(
+                gen_code=candidate,
+                problem=response,
+                problem_id=pid,
+                candidate_id=f"candidate_{cand_id}",
+                save_errors=debug,
+            )
+            scores.append(result["score"])
+            if result["passed"]:
+                correct_candidates += 1
+            errors[pid][f"candidate_{cand_id}"] = result["errors"]
+        if len(candidates) > 0:
+            logging.info(
+                "problem %d acceptance rate: %.4f.",
+                resp_id,
+                correct_candidates * 1.0 / len(candidates),
+            )
+        else:
+            logging.info("found no solution to problem %d.", resp_id)
+        if correct_candidates > 0:
+            total_passed += 1
+        avg_score = sum(scores) / len(scores) if len(scores) > 0 else 0
+        avg_scores.append(avg_score)
+        global_stats[resp_id] = {
+            "id": pid,
+            "total_candidates": len(candidates),
+            "passed_candidates": correct_candidates,
+            "avg_score": avg_score,
+        }
+
+    metrics = {
+        "pass_rate": total_passed * 1.0 / len(responses),
+        "average_score": sum(avg_scores) / len(responses),
+        "candidates_per_example": sum(num_candidates) / len(responses),
+        "number_of_examples": len(responses),
+        "global_stats": global_stats,
+    }
+    if debug:
+        metrics.update({"errors": errors})
+    return metrics
+
+
+def understand_metric_fn(
+    *,
+    responses: List[Dict[str, Any]],
+    generators: Dict[EvalGeneratorType, Generator],
+    debug: bool = False,  # pylint: disable=unused-argument
+) -> Dict[str, Any]:
+    """Implements code contests understanding metric following axlearn.open_api.common.MetricFn.
+    Checks whether the understanding output from a coding question can match target string.
+    No execution is needed.
+
+    Args:
+        responses: A list of responses in dictionary.
+        generators: A dict of generator instances.
+        debug: True to add debug information in the metric.
+
+    Returns:
+        A dictionary of metrics.
+    """
+    correct = 0
+    total_valid_ans = 0
+    generator_cfg: Generator.Config = generators[EvalGeneratorType.RESPONSE].config
+    client_cls: Type[BaseClient] = generator_cfg.client.klass
+    for response in responses:
+        target_output = response.get("target_output", None)
+        if target_output is None:
+            raise ValueError(
+                "CodeContests Understand tasks must have target_output in each response."
+            )
+        pred = client_cls.parse_generation(response=json.loads(response["response"]))
+        if len(pred) == 0:
+            logging.debug(
+                "deliverable_id: %s with empty response.",
+                response.get("deliverable_id", response.get("id", "")),
+            )
+            continue
+
+        answer = _parse_answer(pred[0].content)
+        if not answer:
+            logging.debug(
+                "deliverable_id: %s", response.get("deliverable_id", response.get("id", ""))
+            )
+            logging.debug("Unable to find #ANSWER# in %s", pred[0].content)
+            continue
+        total_valid_ans += 1
+        if _check_understand_str_match(pred=answer, expected=target_output):
+            correct += 1
+
+    return {
+        "accuracy": correct * 1.0 / len(responses),
+        "valid_ans_rate": total_valid_ans * 1.0 / len(responses),
+        "number_of_examples": len(responses),
+    }
+
+
+# Repeat requests by the following number to do sampling for solving a code problem.
+_solver_candidates = 5
+
+
+def plan_metric_fn(
+    *,
+    responses: List[Dict[str, Any]],
+    generators: Dict[EvalGeneratorType, Generator],
+    debug: bool = False,
+) -> Dict[str, Any]:
+    """Implements code contests plan metric following axlearn.open_api.common.MetricFn.
+    Based on the plan, generate the code, execute the code and measure the accuracy.
+
+    Args:
+        responses: A list of responses in dictionary.
+        generators: A dict of generator instances.
+        debug: True to add debug information in the metric.
+
+    Returns:
+        A dictionary of metrics.
+    """
+    grader_generator = generators[EvalGeneratorType.GRADER]
+    plan2code_requests = []
+    generator_cfg: Generator.Config = generators[EvalGeneratorType.RESPONSE].config
+    client_cls: Type[BaseClient] = generator_cfg.client.klass
+    for response in responses:
+        plan = client_cls.parse_generation(response=json.loads(response["response"]))
+        if len(plan) == 0:
+            logging.debug(
+                "deliverable_id: %s with empty response.",
+                response.get("deliverable_id", response.get("id", "")),
+            )
+            continue
+        plan = plan[0].content
+        plan2code_prompt = _plan2code_prompt_template.format(
+            description=response["description"], plan=plan
+        )
+        # Make a copy to prepare a new request.
+        resp = copy.deepcopy(response)
+        del resp["response"]
+        if "prompt" in resp:
+            del resp["prompt"]
+        resp.update({"messages": [{"role": "user", "content": plan2code_prompt}]})
+        plan2code_requests.append(resp)
+
+    plan2code_requests = repeat_requests(plan2code_requests, _solver_candidates)
+    plan2code_responses = asyncio.run(
+        grader_generator.async_generate_from_requests(gen_requests=plan2code_requests)
+    )
+    plan2code_responses = flatten_responses(plan2code_responses)
+
+    # Evaluate generated code.
+    metrics = code_execution_metric_fn(
+        responses=plan2code_responses,
+        generators={
+            EvalGeneratorType.GRADER: grader_generator,
+            EvalGeneratorType.RESPONSE: grader_generator,
+        },
+        debug=debug,
+    )
+    if debug:
+        for resp in plan2code_responses:
+            del (
+                resp["description"],
+                resp["public_tests"],
+                resp["private_tests"],
+                resp["generated_tests"],
+            )
+        metrics.update({"solver_responses": plan2code_responses})
+    return metrics
+
+
+# Repeat requests by the following number
+# to do sampling for solving a code problem as a retry from previous failed error.
+_retry_candidates = 5
+_system_prompt = (
+    "A conversation between a user and a helpful code-generation assistant. "
+    "The assistant can directly generate code to help with user queries. "
+    "Retry the code generation if it does not succeed or if there are errors "
+    "in the previous generated code."
+)
+_wrong_output_template = """\nExecution result {num}: Wrong Output.
+Test input: {input}
+Expected output: {expected}
+Actual output: {output}\n
+"""
+_runtime_error_template = """\nExecution result {num}: Runtime Error.
+Test input: {input}
+Error Message: {error}\n
+"""
+
+
+def _gen_retry_request(
+    responses: List[Dict[str, Any]],
+    *,
+    generator: Generator,
+    eval_results: Dict[str, Any],
+    error_num: int = 1,
+) -> List[Any]:
+    """Generates retry requests for failed responses.
+
+    Args:
+        responses: A list of previous responses in dictionary.
+        generator: An instance of generator.
+        eval_results: A dictionary of evaluation results.
+        error_num: Number of error.
+
+    Returns:
+        A list of requests.
+    """
+    retry_requests = []
+    for resp_id, response in enumerate(responses):
+        pid = response["id"]
+        assert pid == eval_results["global_stats"][resp_id]["id"], "Order and id does not match."
+        if eval_results["global_stats"][resp_id]["passed_candidates"] > 0:
+            continue
+        messages = copy.deepcopy(response["messages"])
+        # Add system messages.
+        messages[0]["content"] = f"system\n{_system_prompt}\n\nuser\n" + messages[0]["content"]
+        # Load the first response.
+        gen = generator.config.client.klass.parse_generation(
+            response=json.loads(response["response"])
+        )
+        if len(gen) > 0:
+            messages.append(
+                {
+                    "content": gen[0].content,
+                    "role": "assistant",
+                }
+            )
+        else:
+            # edge case: no solution generated
+            messages.append(
+                {
+                    "content": ".",
+                    "role": "assistant",
+                }
+            )
+        err_msg = ""
+        if messages[-1]["content"] == ".":
+            err_msg = "\n\nNo solution is generated. Please try again.\n```python"
+        elif isinstance(eval_results["errors"][pid]["candidate_0"], list):
+            errors = eval_results["errors"][pid]["candidate_0"][:error_num]
+            for eid, err in enumerate(errors):
+                if err["status"] == "wrong_output":
+                    err_msg += _wrong_output_template.format(
+                        num=eid,
+                        input=err["test_input"],
+                        expected=err["expected_output"],
+                        output=err["code_output"],
+                    )
+                elif err["status"] == "runtime_error":
+                    err_msg += _runtime_error_template.format(
+                        num=eid, input=err["test_input"], error=err["error_message"]
+                    )
+            err_msg += "\n\nPlease try again.\n```python"
+        else:
+            err_msg += "\n\nFailed to parse or compile the solution. Please try again.\n```python"
+        messages.append({"content": err_msg, "role": "user"})
+        retry_requests.append(
+            {
+                "id": response["id"],
+                "messages": messages,
+                "public_tests": response["public_tests"],  # tests for evaluation
+                "private_tests": response["private_tests"],
+                "generated_tests": response["generated_tests"],
+            }
+        )
+    return retry_requests
+
+
+def retry_metric_fn(
+    *,
+    responses: List[Dict[str, Any]],
+    generators: Dict[EvalGeneratorType, Generator],
+    debug: bool = False,
+) -> Dict[str, Any]:
+    """Implements code contests retry metric following axlearn.open_api.common.MetricFn.
+    Retry failed problems to test whether the model can run self-correction.
+
+    Args:
+        responses: A list of responses in dictionary.
+        generators: A dict of generator instances.
+        debug: True to add debug information in the metric.
+
+    Returns:
+        A dictionary of metrics.
+    """
+
+    # Evaluate the first-round responses.
+    logging.debug("Evaluating initial generated code.")
+    init_metrics = code_execution_metric_fn(responses=responses, generators=generators, debug=debug)
+    # Generate retry responses.
+    retry_requests = _gen_retry_request(
+        responses, generator=generators[EvalGeneratorType.RESPONSE], eval_results=init_metrics
+    )
+    logging.debug("Retrying for %d failed problems.", len(retry_requests))
+
+    grader_generator = generators[EvalGeneratorType.GRADER]
+    retry_requests = repeat_requests(retry_requests, _retry_candidates)
+    retry_responses = asyncio.run(
+        grader_generator.async_generate_from_requests(gen_requests=retry_requests)
+    )
+    retry_responses = flatten_responses(retry_responses)
+
+    # Then evaluate generated code.
+    logging.debug("Evaluating re-generated code.")
+    return code_execution_metric_fn(
+        responses=retry_responses,
+        generators=generators,
+        debug=debug,
+    )

--- a/axlearn/open_api/metrics/code_contests_test.py
+++ b/axlearn/open_api/metrics/code_contests_test.py
@@ -1,0 +1,174 @@
+# Copyright © 2024 Apple Inc.
+
+# pylint: disable=protected-access
+"""Unit test for code_contests.py.
+
+TODO(gyin): Add more unit tests for code contests core functions.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from axlearn.open_api.mock_utils import mock_openai_package
+
+mock_openai_package()
+
+# isort: off
+# pylint: disable=wrong-import-position
+from axlearn.open_api.metrics import code_contests
+
+from axlearn.open_api.metrics.code_contests import (
+    CodeContestStatus,
+    _exec_and_check,
+    _format_gen_code,
+    _parse_answer,
+)
+
+# pylint: enable=wrong-import-position
+# isort: on
+
+
+class TestFormatGenCode(unittest.TestCase):
+    """Unit tests for _format_gen_code."""
+
+    def test_format_gen_code_with_python_tags(self):
+        gen_code = "```python\nprint('Hello World')\n```"
+        expected_output = "print('Hello World')"
+        self.assertEqual(_format_gen_code(gen_code), expected_output)
+
+    def test_format_gen_code_with_explanation(self):
+        gen_code = "```python\nprint('Hello World')\n```\nThis is a test."
+        expected_output = "print('Hello World')"
+        self.assertEqual(_format_gen_code(gen_code), expected_output)
+
+    def test_format_gen_code_with_if_main(self):
+        gen_code = "def main():\n    print('Hello World')\n\nif __name__ == '__main__':\n    main()"
+        expected_output = "def main():\n    print('Hello World')\n\nmain()"
+        self.assertEqual(_format_gen_code(gen_code), expected_output)
+
+    def test_format_gen_code_with_all_cases(self):
+        gen_code = (
+            "```python\ndef main():\n    print('Hello World')\n\n"
+            + "if __name__ == '__main__':\n    main()\n```\nThis is a test."
+        )
+        expected_output = "def main():\n    print('Hello World')\n\nmain()"
+        self.assertEqual(_format_gen_code(gen_code), expected_output)
+
+    def test_format_gen_code_without_special_cases(self):
+        gen_code = "print('Hello World')"
+        expected_output = "print('Hello World')"
+        self.assertEqual(_format_gen_code(gen_code), expected_output)
+
+
+class TestParseAnswer(unittest.TestCase):
+    """Unit tests for _parse_answer."""
+
+    def test_with_hash_answer(self):
+        self.assertEqual(
+            _parse_answer("Some text #ANSWER#: This is the answer."), " This is the answer."
+        )
+
+    def test_with_answer(self):
+        self.assertEqual(
+            _parse_answer("Some text ANSWER: This is the answer."), ": This is the answer."
+        )
+
+    def test_with_answer_newline(self):
+        self.assertEqual(
+            _parse_answer("Some text ANSWER\nThis is the answer."), "This is the answer."
+        )
+
+    def test_with_answer_no_content(self):
+        self.assertEqual(_parse_answer("Some text ANSWER"), "")
+
+    def test_without_answer_marker(self):
+        self.assertEqual(_parse_answer("Some text without the answer marker."), "")
+
+    def test_with_empty_string(self):
+        self.assertEqual(_parse_answer(""), "")
+
+    def test_with_only_hash_answer(self):
+        self.assertEqual(_parse_answer("#ANSWER#: This is the answer."), " This is the answer.")
+
+    def test_with_only_answer(self):
+        self.assertEqual(_parse_answer("ANSWER\nThis is the answer."), "This is the answer.")
+
+
+# pylint: disable=unused-argument
+class TestExecAndCheck(unittest.TestCase):
+    """Unit tests for _exec_and_check."""
+
+    @patch(f"{code_contests.__name__}.check_correctness")
+    def test_empty_gen_code(self, mock_check_correctness):
+        result = _exec_and_check(
+            gen_code="", problem={}, problem_id="prob_1", candidate_id="cand_1"
+        )
+        self.assertEqual(
+            result, {"passed": False, "score": 0.0, "errors": {"status": CodeContestStatus.EMPTY}}
+        )
+
+    @patch(f"{code_contests.__name__}.check_correctness")
+    def test_no_tests(self, mock_check_correctness):
+        problem = {}
+        result = _exec_and_check(
+            gen_code="code", problem=problem, problem_id="prob_1", candidate_id="cand_1"
+        )
+        self.assertEqual(result, {"passed": False, "score": 0.0, "errors": []})
+
+    @patch(f"{code_contests.__name__}.check_correctness")
+    def test_all_tests_passed(self, mock_check_correctness):
+        problem = {"public_tests": {"input": [1, 2], "output": ["3", "4"]}}
+        mock_check_correctness.return_value = {
+            "result": {
+                "error": None,
+                "result_list": [{"passed": True, "output": "3"}, {"passed": True, "output": "4"}],
+            }
+        }
+        result = _exec_and_check(
+            gen_code="code", problem=problem, problem_id="prob_1", candidate_id="cand_1"
+        )
+        self.assertEqual(result, {"passed": True, "score": 1.0, "errors": []})
+
+    @patch(f"{code_contests.__name__}.check_correctness")
+    def test_some_tests_failed(self, mock_check_correctness):
+        problem = {"public_tests": {"input": [1, 2], "output": ["3", "4"]}}
+        mock_check_correctness.return_value = {
+            "result": {
+                "error": None,
+                "result_list": [
+                    {"passed": True, "output": "3"},
+                    {"passed": False, "error": "Some error"},
+                ],
+            }
+        }
+        result = _exec_and_check(
+            gen_code="code", problem=problem, problem_id="prob_1", candidate_id="cand_1"
+        )
+        self.assertEqual(result, {"passed": False, "score": 0.5, "errors": []})
+
+    @patch(f"{code_contests.__name__}.check_correctness")
+    def test_save_errors(self, mock_check_correctness):
+        problem = {"public_tests": {"input": [1, 2], "output": ["3", "4"]}}
+        mock_check_correctness.return_value = {
+            "result": {
+                "error": None,
+                "result_list": [
+                    {"passed": True, "output": "3"},
+                    {"passed": False, "error": "Some error"},
+                ],
+            }
+        }
+        result = _exec_and_check(
+            gen_code="code",
+            problem=problem,
+            problem_id="prob_1",
+            candidate_id="cand_1",
+            save_errors=True,
+        )
+        self.assertEqual(
+            result["errors"],
+            [{"status": CodeContestStatus.ERROR, "test_input": 2, "error_message": "Some error"}],
+        )
+
+
+# pylint: enable=unused-argument

--- a/axlearn/open_api/metrics/code_execute.py
+++ b/axlearn/open_api/metrics/code_execute.py
@@ -1,0 +1,298 @@
+# Copyright © 2024 Apple Inc.
+#
+# Some of the code in this file is adapted from:
+#
+# openai/human-eval:
+# Copyright 2021 The OpenAI Authors. All Rights Reserved.
+# Licensed under the MIT License.
+#
+# huggingface/evaluate:
+# Copyright 2023 The Huggingface Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+
+# pylint: disable=reimported,import-outside-toplevel,redefined-outer-name
+"""Executing and verifying python code locally with test inputs.
+
+This file is adopted from
+https://github.com/openai/human-eval/blob/312c5e5532f0e0470bf47f77a6243e02a61da530/human_eval/execution.py
+with a slight modification on returning error message from execution.
+"""
+
+import contextlib
+import faulthandler
+import io
+import multiprocessing
+import os
+import platform
+import signal
+import sys
+import tempfile
+from typing import Any, Dict, List, Optional, Union
+
+
+# TODO(gyin): Consider refactoring this with context manager.
+def check_correctness(
+    check_program: str, *, inputs: List[Any], timeout: float, task_id: str, completion_id: str
+) -> Dict[str, Any]:
+    """Evaluates the functional correctness of a completion by running a set of test
+        inputs in the problem.
+
+    Args:
+        check_program: the python code to be checked.
+        inputs: a list of test case inputs to the code.
+        timeout: a timeout limit for code execution.
+        task_id: an indicator of the task.
+        completion_id: an indicator of the generated code sample.
+
+    Returns:
+        A dictionary containing the task_id, completion_id, and execution results.
+    """
+    manager = multiprocessing.Manager()
+    result = manager.list()
+
+    p = multiprocessing.Process(
+        target=_unsafe_execute, args=(check_program, inputs, result, timeout)
+    )
+    p.start()
+    p.join(timeout=timeout + 1)
+    if p.is_alive():
+        p.kill()
+
+    # Customized change compared with original humaneval implementation:
+    # Add output and error stream.
+    if not result:
+        result.append({"error": "timeout", "result_list": []})
+
+    if len(result) == 0:
+        result.append({"error": "invalid output", "result_list": []})
+    return {"task_id": task_id, "completion_id": completion_id, "result": result[0]}
+
+
+def _unsafe_execute(check_program: str, inputs: List[Any], result: List[Any], timeout: float):
+    """Evaluates the functional correctness of a completion by running a set of test
+     inputs in the problem.
+
+    Args:
+        check_program: the python code to be checked.
+        inputs: a list of test case inputs to the code.
+        result: a process manager list to store all execution results.
+        timeout: a timeout limit for code execution.
+    """
+    with _create_tempdir():
+        # These system calls are needed when cleaning up tempdir.
+        import os
+        import shutil
+
+        rmtree = shutil.rmtree
+        rmdir = os.rmdir
+        chdir = os.chdir
+
+        # Disable functionalities that can make destructive changes to the test.
+        _reliability_guard()
+
+        # Run program.
+        # Customized change compared with original humaneval implementation:
+        # Add output and error stream.
+        exec_results = {"error": None, "result_list": []}
+        try:
+            exec_globals = {}
+            for inp in inputs:
+                try:
+                    input_stream = io.BytesIO(inp.encode())
+                    input_stream.seek(0)
+                    with _swallow_io(input_stream=input_stream) as (stdout_stream, stderr_stream):
+                        with _time_limit(timeout):
+                            exec(check_program, exec_globals)  # pylint: disable=exec-used
+                    exec_results["result_list"].append(
+                        {
+                            "passed": True,
+                            "output": stdout_stream.getvalue(),
+                            "error": stderr_stream.getvalue(),
+                        }
+                    )
+                except TimeoutException:
+                    exec_results["result_list"].append(
+                        {"passed": False, "output": "", "error": "timeout"}
+                    )
+                except Exception as e:  # pylint: disable=broad-exception-caught
+                    exec_results["result_list"].append(
+                        {"passed": False, "output": "", "error": f"failed: {e}"}
+                    )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            exec_results["error"] = f"failed: {e}"
+
+        result.append(exec_results)
+        # Needed for cleaning up.
+        shutil.rmtree = rmtree
+        os.rmdir = rmdir
+        os.chdir = chdir
+
+
+@contextlib.contextmanager
+def _time_limit(seconds: float):
+    def signal_handler(signum: Any, frame: Any):
+        raise TimeoutException("Timed out!")
+
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    signal.signal(signal.SIGALRM, signal_handler)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+
+
+@contextlib.contextmanager
+def _swallow_io(
+    input_stream: Optional[Union[io.BytesIO, io.StringIO, io.BufferedIOBase, io.TextIOBase]] = None,
+    binary: bool = False,
+):
+    original_stdin = sys.stdin
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+
+    sys.stdin = input_stream if binary else io.TextIOWrapper(input_stream)
+    sys.stdout = io.BytesIO() if binary else io.StringIO()
+    sys.stderr = io.BytesIO() if binary else io.StringIO()
+
+    try:
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdin = original_stdin
+        sys.stdout = original_stdout
+        sys.stderr = original_stderr
+
+
+@contextlib.contextmanager
+def _create_tempdir():
+    """Creates a temporary directory."""
+    with tempfile.TemporaryDirectory() as dirname:
+        with _chdir(dirname):
+            yield dirname
+
+
+class TimeoutException(Exception):
+    """Defines a timeout exception."""
+
+    pass
+
+
+# pylint: disable=unused-argument
+class WriteOnlyStringIO(io.StringIO):
+    """StringIO that throws an exception when it's read from"""
+
+    def read(self, *args, **kwargs):
+        raise OSError
+
+    def readline(self, *args, **kwargs):
+        raise OSError
+
+    def readlines(self, *args, **kwargs):
+        raise OSError
+
+    def readable(self, *args, **kwargs):
+        """Returns True if the IO object can be read."""
+        return False
+
+
+# pylint: enable=unused-argument
+
+
+# pylint: disable-next=invalid-name, protected-access
+class redirect_stdin(contextlib._RedirectStream):  # pytype: disable=module-attr
+    _stream = "stdin"
+
+
+@contextlib.contextmanager
+def _chdir(root: str):
+    """Changes the current working directory."""
+    if root == ".":
+        yield
+        return
+    cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        yield
+    except BaseException as exc:
+        raise exc
+    finally:
+        os.chdir(cwd)
+
+
+def _reliability_guard(maximum_memory_bytes: Optional[int] = None):
+    """This disables various destructive functions and prevents the generated code
+    from interfering with the test (e.g. fork bomb, killing other processes,
+    removing filesystem files, etc.)
+
+    WARNING
+    This function is NOT a security sandbox. Untrusted code, including, model-
+    generated code, should not be blindly executed outside of one. See the
+    Codex paper for more information about OpenAI's code sandbox, and proceed
+    with caution.
+    """
+
+    if maximum_memory_bytes is not None:
+        import resource
+
+        resource.setrlimit(resource.RLIMIT_AS, (maximum_memory_bytes, maximum_memory_bytes))
+        resource.setrlimit(resource.RLIMIT_DATA, (maximum_memory_bytes, maximum_memory_bytes))
+        if not platform.uname().system == "Darwin":
+            resource.setrlimit(resource.RLIMIT_STACK, (maximum_memory_bytes, maximum_memory_bytes))
+
+    faulthandler.disable()
+
+    import builtins
+
+    builtins.exit = None
+    builtins.quit = None
+
+    import os
+
+    os.environ["OMP_NUM_THREADS"] = "1"
+
+    os.kill = None
+    os.system = None
+    os.putenv = None
+    os.remove = None
+    os.removedirs = None
+    os.rmdir = None
+    os.fchdir = None
+    os.setuid = None
+    os.fork = None
+    os.forkpty = None
+    os.killpg = None
+    os.rename = None
+    os.renames = None
+    os.truncate = None
+    os.replace = None
+    os.unlink = None
+    os.fchmod = None
+    os.fchown = None
+    os.chmod = None
+    os.chown = None
+    os.chroot = None
+    os.fchdir = None
+    os.lchflags = None
+    os.lchmod = None
+    os.lchown = None
+    os.getcwd = None
+    os.chdir = None
+
+    import shutil
+
+    shutil.rmtree = None
+    shutil.move = None
+    shutil.chown = None
+
+    import subprocess
+
+    subprocess.Popen = None  # pytype: disable=invalid-directive
+
+    __builtins__["help"] = None  # pytype: disable=unsupported-operands
+
+    import sys
+
+    sys.modules["ipdb"] = None
+    sys.modules["joblib"] = None
+    sys.modules["resource"] = None
+    sys.modules["psutil"] = None
+    sys.modules["tkinter"] = None

--- a/axlearn/open_api/metrics/code_execute_test.py
+++ b/axlearn/open_api/metrics/code_execute_test.py
@@ -1,0 +1,247 @@
+# Copyright © 2024 Apple Inc.
+
+# pylint: disable=protected-access
+"""Unit test for code_execute.py.
+"""
+import unittest
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from axlearn.open_api.mock_utils import mock_openai_package
+
+mock_openai_package()
+
+# pylint: disable=wrong-import-position
+from axlearn.open_api.metrics.code_execute import (
+    TimeoutException,
+    _unsafe_execute,
+    check_correctness,
+)
+
+# pylint: enable=wrong-import-position
+
+
+class TestCheckCorrectness(unittest.TestCase):
+    """Unit tests for check_correctness."""
+
+    @patch("multiprocessing.Process")
+    @patch("multiprocessing.Manager")
+    def test_check_correctness_success(self, mock_manager, mock_process):
+        check_program = 'print("Hello, World!")'
+        inputs = ["input1", "input2"]
+        timeout = 2.0
+        task_id = "task1"
+        completion_id = "comp1"
+
+        mock_result_list = [{"passed": True, "output": b"Hello, World!\n", "error": b""}]
+        mock_manager.return_value.list.return_value = mock_result_list
+
+        mock_proc = MagicMock()
+        mock_process.return_value = mock_proc
+
+        result = check_correctness(
+            check_program=check_program,
+            inputs=inputs,
+            timeout=timeout,
+            task_id=task_id,
+            completion_id=completion_id,
+        )
+
+        mock_proc.start.assert_called_once()
+        mock_proc.join.assert_called_once_with(timeout=timeout + 1)
+        self.assertEqual(result["task_id"], task_id)
+        self.assertEqual(result["completion_id"], completion_id)
+        self.assertEqual(result["result"], mock_result_list[0])
+
+    @patch("multiprocessing.Process")
+    @patch("multiprocessing.Manager")
+    def test_check_correctness_timeout(self, mock_manager, mock_process):
+        check_program = "while True: pass"
+        inputs = ["input1"]
+        timeout = 1.0
+        task_id = "task2"
+        completion_id = "comp2"
+
+        mock_result_list = []
+        mock_manager.return_value.list.return_value = mock_result_list
+
+        mock_proc = MagicMock()
+        mock_process.return_value = mock_proc
+        mock_proc.is_alive.return_value = True
+
+        result = check_correctness(
+            check_program=check_program,
+            inputs=inputs,
+            timeout=timeout,
+            task_id=task_id,
+            completion_id=completion_id,
+        )
+
+        mock_proc.start.assert_called_once()
+        mock_proc.join.assert_called_once_with(timeout=timeout + 1)
+        mock_proc.kill.assert_called_once()
+        self.assertEqual(result["task_id"], task_id)
+        self.assertEqual(result["completion_id"], completion_id)
+        self.assertEqual(result["result"]["error"], "timeout")
+        self.assertEqual(result["result"]["result_list"], [])
+
+    @patch("multiprocessing.Process")
+    @patch("multiprocessing.Manager")
+    def test_check_correctness_exception(self, mock_manager, mock_process):
+        check_program = 'raise ValueError("Test exception")'
+        inputs = ["input1"]
+        timeout = 2.0
+        task_id = "task3"
+        completion_id = "comp3"
+
+        mock_result_list = [{"error": "failed: Test exception", "result_list": []}]
+        mock_manager.return_value.list.return_value = mock_result_list
+
+        mock_proc = MagicMock()
+        mock_process.return_value = mock_proc
+
+        result = check_correctness(
+            check_program=check_program,
+            inputs=inputs,
+            timeout=timeout,
+            task_id=task_id,
+            completion_id=completion_id,
+        )
+
+        mock_proc.start.assert_called_once()
+        mock_proc.join.assert_called_once_with(timeout=timeout + 1)
+        self.assertEqual(result["task_id"], task_id)
+        self.assertEqual(result["completion_id"], completion_id)
+        self.assertEqual(result["result"], mock_result_list[0])
+
+
+class TestUnsafeExecute(unittest.TestCase):
+    """Unit tests for _unsafe_execute."""
+
+    @patch("axlearn.open_api.metrics.code_execute._create_tempdir")
+    @patch("axlearn.open_api.metrics.code_execute._reliability_guard")
+    @patch("axlearn.open_api.metrics.code_execute._swallow_io")
+    @patch("axlearn.open_api.metrics.code_execute._time_limit")
+    def test_successful_execution(
+        self, mock_time_limit, mock_swallow_io, mock_reliability_guard, mock_create_tempdir
+    ):
+        check_program = """
+def add(a, b):
+    return a + b
+
+result = add(2, 3)
+"""
+        inputs = ["test_input"]
+        result = []
+        timeout = 5.0
+
+        mock_create_tempdir.return_value = MagicMock()
+        mock_reliability_guard.return_value = None
+        mock_time_limit.return_value.__enter__ = lambda *args: None
+        mock_time_limit.return_value.__exit__ = lambda *args: None
+        mock_stdout_stream = BytesIO()
+        mock_stdout_stream.getvalue = lambda: b"test_input\n"
+        mock_stderr_stream = BytesIO()
+        mock_stderr_stream.getvalue = lambda: b""
+        mock_swallow_io.return_value.__enter__ = lambda *args: (
+            mock_stdout_stream,
+            mock_stderr_stream,
+        )
+        mock_swallow_io.return_value.__exit__ = lambda *args: None
+
+        _unsafe_execute(check_program, inputs, result, timeout)
+
+        expected_result = {
+            "error": None,
+            "result_list": [{"passed": True, "output": b"test_input\n", "error": b""}],
+        }
+
+        self.assertEqual(result, [expected_result])
+
+    @patch("axlearn.open_api.metrics.code_execute._create_tempdir")
+    @patch("axlearn.open_api.metrics.code_execute._reliability_guard")
+    @patch("axlearn.open_api.metrics.code_execute._swallow_io")
+    @patch("axlearn.open_api.metrics.code_execute._time_limit")
+    def test_execution_error(
+        self, mock_time_limit, mock_swallow_io, mock_reliability_guard, mock_create_tempdir
+    ):
+        check_program = """
+raise ValueError('test error')
+"""
+        inputs = [""]
+        result = []
+        timeout = 5.0
+
+        mock_create_tempdir.return_value = MagicMock()
+        mock_reliability_guard.return_value = None
+        mock_time_limit.return_value.__enter__ = lambda *args: None
+        mock_time_limit.return_value.__exit__ = lambda *args: None
+        mock_stdout_stream = MagicMock()
+        mock_stdout_stream.getvalue.return_value = b""
+        mock_stderr_stream = MagicMock()
+        mock_stderr_stream.getvalue.return_value = b""
+        mock_swallow_io.return_value.__enter__ = lambda *args: (
+            mock_stdout_stream,
+            mock_stderr_stream,
+        )
+        mock_swallow_io.return_value.__exit__ = lambda *args: None
+
+        _unsafe_execute(check_program, inputs, result, timeout)
+
+        expected_result = {
+            "error": None,
+            "result_list": [
+                {
+                    "passed": False,
+                    "output": "",
+                    "error": "failed: test error",
+                }
+            ],
+        }
+
+        self.assertEqual(result, [expected_result])
+
+    @patch("axlearn.open_api.metrics.code_execute._create_tempdir")
+    @patch("axlearn.open_api.metrics.code_execute._reliability_guard")
+    @patch("axlearn.open_api.metrics.code_execute._swallow_io")
+    @patch("axlearn.open_api.metrics.code_execute._time_limit")
+    def test_execution_timeout(
+        self, mock_time_limit, mock_swallow_io, mock_reliability_guard, mock_create_tempdir
+    ):
+        check_program = """
+while True:
+    pass
+"""
+        inputs = [""]
+        result = []
+        timeout = 0.1
+
+        mock_create_tempdir.return_value = MagicMock()
+        mock_reliability_guard.return_value = None
+
+        class MockTimeLimit:
+            def __enter__(self):
+                raise TimeoutException()
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                return False
+
+        mock_time_limit.return_value = MockTimeLimit()
+        mock_stdout_stream = MagicMock()
+        mock_stdout_stream.getvalue.return_value = b""
+        mock_stderr_stream = MagicMock()
+        mock_stderr_stream.getvalue.return_value = b""
+        mock_swallow_io.return_value.__enter__ = lambda *args: (
+            mock_stdout_stream,
+            mock_stderr_stream,
+        )
+        mock_swallow_io.return_value.__exit__ = lambda *args: None
+
+        _unsafe_execute(check_program, inputs, result, timeout)
+
+        expected_result = {
+            "error": None,
+            "result_list": [{"passed": False, "output": "", "error": "timeout"}],
+        }
+
+        self.assertEqual(result, [expected_result])

--- a/axlearn/open_api/metrics/code_kaggle.py
+++ b/axlearn/open_api/metrics/code_kaggle.py
@@ -1,0 +1,669 @@
+# Copyright © 2024 Apple Inc.
+
+"""Code interpreter for kaggle style evaluation tasks.
+
+Three parts:
+- code generation: generate a code based on previous conversations.
+- code execution: execute the generated code.
+- qa: question answering on previous conversations.
+
+Four settings:
+- end-to-end: evaluated model generates code, and interprets results.
+- oracle: evaluated model interprets results from oracle code execution.
+- gpt4-qa: evaluated model generates code, and GPT-4 interprets results to verify code relevance.
+- retry: retry failed attempts with execution feedback.
+
+Two Modes:
+- Text-only: when the grader_generator is not multimodal, only text output is evaluated.
+- Multi-modal: all outputs are evaluated if the grader_generator is multimodal.
+"""
+import asyncio
+import base64
+import copy
+import io
+import json
+import logging
+import os
+import re
+import shutil
+import traceback
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
+from typing import Any, Dict, List, Tuple, Type
+
+import numpy as np
+from tqdm import tqdm
+
+from axlearn.open_api.common import BaseClient, EvalGeneratorType, Generator
+
+# List of possible image MIME types.
+_IMAGE_MIME_TYPES = [
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+]
+_PLOTLY_MIME_TYPE = "application/vnd.plotly.v1+json"
+
+# pylint: disable=line-too-long
+_execution_feedback_template = """Your code execution failed. Please check the error message below and try again:
+
+{error_message}
+
+You MUST exactly follow nbformat structure when generating markdown and code cells.
+Respond ONLY with the cells in json format. DO NOT say anything else or put it in a ```json``` code block.
+You are only allowed to use the following math and visualization packages: numpy, pandas, scipy, scikit-learn, sympy, statsmodels, matplotlib, seaborn, plotly, wordcloud. Python standard libraries are also allowed. Make sure to import the necessary packages in the code cell.
+"""
+
+_question_template = """Given the following execution output and multiple choice questions, respond with the answers to the questions:
+
+Execution Output:
+{execution_output}
+
+Questions:
+{questions}
+
+You MUST answer in a list of uppercase single letter strings for multiple choice questions.
+"""
+# pylint: enable=line-too-long
+
+
+def _post_process_cells(cells: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Enhances cells with unique IDs and ensure consistent formatting.
+
+    Args:
+        cells: A list of cell dictionaries.
+
+    Returns:
+        A list of processed cell dictionaries with consistent formatting.
+    """
+    for cell in cells:
+        if isinstance(cell, dict):
+            cell["id"] = uuid.uuid4().hex[:8]
+            if cell.get("cell_type") == "code":
+                source = cell.get("source", [])
+                cell["source"] = [
+                    line + "\n" if not line.endswith("\n") else line for line in source
+                ]
+                cell["outputs"] = []
+                cell["execution_count"] = None
+    return cells
+
+
+def _strip_ansi_codes(text: str) -> str:
+    """Removes ANSI color codes from a string."""
+    ansi_escape = re.compile(r"\x1b\[[0-9;]*m")
+    return ansi_escape.sub("", text)
+
+
+def _execute_notebook(nb_json: str, timeout: int = 180) -> Tuple[Any, bool]:
+    """Executes a Jupyter notebook from a JSON string and return the executed notebook
+    along with a success status. This function strips any ANSI color codes that may
+    appear in error messages.
+
+    Args:
+        nb_json: The notebook JSON as a string.
+        timeout: The timeout for notebook execution in seconds. Defaults to 180.
+
+    Returns:
+        A tuple containing the executed notebook JSON and a boolean flag.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    # pytype: disable=import-error
+    import nbformat
+    from nbconvert.preprocessors import ExecutePreprocessor
+
+    # pytype: enable=import-error
+    # pylint: enable=import-error,import-outside-toplevel
+    try:
+        nb = nbformat.read(io.StringIO(nb_json), as_version=4)
+        ep = ExecutePreprocessor(timeout=timeout, kernel_name="python3")
+        ep.preprocess(nb)
+        return nb, True
+    except nbformat.reader.NotJSONError:
+        error_message = "Provided string could not be parsed as JSON."
+    except TimeoutError:
+        error_message = f"Notebook execution exceeded the time limit of {timeout} seconds."
+    except Exception as e:  # pylint: disable=broad-except
+        traceback_details = traceback.format_exc(limit=2)
+        error_message = _strip_ansi_codes(
+            f"An unexpected error occurred: {str(e)}\n"
+            + f"Traceback (last two levels):\n{traceback_details}"
+        )
+
+    return error_message, False
+
+
+def _execute_notebooks_batch(nb_jsons: List[str], timeout: int = 180, max_workers: int = 5) -> List:
+    """Executes a batch of notebooks in parallel using a ThreadPoolExecutor.
+
+    Args:
+        nb_jsons: List of notebook JSON strings.
+        timeout: The timeout for execution in seconds.
+        max_workers: The maximum number of worker threads to use.
+
+    Returns:
+        List of results from executing the notebooks.
+    """
+    results = [None] * len(nb_jsons)
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_index = {
+            executor.submit(_execute_notebook, nb_json, timeout): i
+            for i, nb_json in enumerate(nb_jsons)
+        }
+        for future in tqdm(
+            as_completed(future_to_index), total=len(nb_jsons), desc="Executing notebooks"
+        ):
+            index = future_to_index[future]
+            results[index] = future.result()
+    return results
+
+
+def _plotly_json_to_base64_png(plotly_json: Dict[str, Any]) -> str:
+    """Converts Plotly JSON data to a base64 PNG image."""
+    # pylint: disable-next=import-error,import-outside-toplevel
+    import plotly.graph_objects as go  # pytype: disable=import-error
+
+    fig = go.Figure(data=plotly_json["data"], layout=plotly_json.get("layout", {}))
+    img_bytes = io.BytesIO()
+    fig.write_image(img_bytes, format="png")
+    img_bytes.seek(0)  # Reset the buffer to start
+    return base64.b64encode(img_bytes.read()).decode("utf-8")
+
+
+def _organize_cell_output(
+    cell: Dict[str, Any], image_expected: bool
+) -> Tuple[Dict[str, Any], List]:
+    """Organizes the cell output to replace image data with placeholders and collect image data
+    in a dedicated list."""
+    if not image_expected:
+        return cell, []
+
+    if cell is None or "outputs" not in cell or len(cell["outputs"]) == 0:
+        return cell, []
+
+    # Initializes the response format and keep track of images.
+    image_data_list = []
+    image_counter = 1
+
+    # Replaces image data with placeholders and collect image URLs.
+    relevant_outputs = []
+    for output in cell.get("outputs", []):
+        if "data" in output:
+            for mime_type in _IMAGE_MIME_TYPES:
+                if mime_type in output["data"]:
+                    placeholder = f"<image_{image_counter}>"
+                    image_data_list.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:{mime_type};base64,{output['data'][mime_type]}"
+                            },
+                        }
+                    )
+                    output["data"][mime_type] = placeholder
+                    image_counter += 1
+
+            if _PLOTLY_MIME_TYPE in output["data"]:
+                base64_png = _plotly_json_to_base64_png(output["data"][_PLOTLY_MIME_TYPE])
+                placeholder = f"<image_{image_counter}>"
+                image_data_list.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{base64_png}"},
+                    }
+                )
+                output["data"][_PLOTLY_MIME_TYPE] = placeholder
+                output["data"].pop("text/html", None)
+                image_counter += 1
+
+            if "text/html" in output["data"]:
+                if "plotly.js" in "".join(output["data"]["text/html"]):
+                    del output["data"]["text/html"]
+
+            relevant_outputs.append(output)
+
+    cell["outputs"] = relevant_outputs
+    return cell, image_data_list
+
+
+@contextmanager
+def _set_code_kaggle_execution_directory():
+    """Changes the working directory temporarily to a newly created tmp directory
+    within the specified path.
+
+    Yields:
+        None
+
+    Raises:
+        ValueError: If the CODE_KAGGLE_DATA_DIR environment variable is not set.
+    """
+    current_dir = os.getcwd()
+    # Checks if the CODE_KAGGLE_DATA_DIR environment variable is set.
+    if "CODE_KAGGLE_DATA_DIR" not in os.environ:
+        raise ValueError("CODE_KAGGLE_DATA_DIR environment variable is not set.")
+    new_dir = os.path.join(os.environ["CODE_KAGGLE_DATA_DIR"], "tmp")
+    # Creates the temporary directory if it does not exist.
+    os.makedirs(new_dir, exist_ok=True)
+    try:
+        os.chdir(new_dir)
+        yield
+    finally:
+        os.chdir(current_dir)
+        # Removes the temporary directory after finishing operations.
+        shutil.rmtree(new_dir, ignore_errors=True)
+
+
+def _is_multimodal_model(model_name: str) -> bool:
+    """Checks if the model is multimodal by checking if its name contains any known multimodal model
+    identifiers.
+
+    Args:
+        model_name: The name of the model to check.
+
+    Returns:
+        True if the model is multimodal.
+    """
+    # Sets of known multimodal model identifiers.
+    multimodal_identifiers = {"gpt-4", "gemini", "claude-3"}
+
+    # Returns True if any identifier is a substring of the model name.
+    return any(identifier in model_name for identifier in multimodal_identifiers)
+
+
+def _post_process_responses(responses: List[Dict[str, Any]], *, client_cls: Type[BaseClient]):
+    """Extracts executable notebooks from responses.
+
+    Args:
+        responses: A list of responses in dictionary.
+        client_cls: The type of BaseClient.
+    """
+    for response in responses:
+        response.update({"solutions": {}})
+
+        # Loads some necessary data from the response.
+        notebook = response.get("notebook", None)
+        if notebook is None:
+            logging.error("No notebook in the response.")
+            continue
+
+        code_responses = []
+        for resp in response.get("n_responses", [response["response"]]):
+            code_response = client_cls.parse_generation(response=json.loads(resp))
+            code_responses.extend(code_response)
+
+        if len(code_responses) == 0:
+            logging.error("No code responses.")
+            continue
+
+        solutions = {}
+        for code_id, code_response in enumerate(code_responses):
+            # Gemini cannot follow instruction to omit the ```json block.
+            response_text = code_response.content.replace("```json", "").replace("```", "").strip()
+            try:
+                response_cells = json.loads(response_text)
+            except json.JSONDecodeError as e:
+                logging.error("Error decoding the code response (%s): %s", str(e), response_text)
+                continue
+            response_cells = _post_process_cells(response_cells)
+            preceding_conversation = copy.deepcopy(response["messages"])
+            if not isinstance(preceding_conversation, list):
+                continue
+            preceding_conversation.append({"role": "assistant", "content": code_response.content})
+            solution = copy.deepcopy(notebook)
+            solution["cells"] += response_cells
+            solutions[code_id] = {
+                "messages": preceding_conversation,
+                "notebook": json.dumps(solution),
+                "execution_success": False,
+                "executed_notebook": None,
+                "last_cell": None,
+                "answers": None,
+            }
+        response["solutions"] = solutions
+
+
+def _execute_notebooks(responses: List[Dict[str, Any]]):
+    """Executes the notebooks in the results and store the execution results.
+
+    Args:
+        responses: A dictionary of results.
+    """
+    execution_indices = []
+    execution_notebooks = []
+    for response_id, response in enumerate(responses):
+        for code_id, solution in response["solutions"].items():
+            if "notebook" in solution and not solution["execution_success"]:
+                execution_indices.append((response_id, code_id))
+                execution_notebooks.append(solution["notebook"])
+
+    if not execution_notebooks:
+        logging.error("No notebooks to execute.")
+        return
+
+    with _set_code_kaggle_execution_directory():
+        execution_results = _execute_notebooks_batch(execution_notebooks)
+
+    if not execution_results:
+        logging.error("No execution results.")
+        return
+
+    executed_notebooks, execution_successes = zip(*execution_results)
+
+    for (response_id, code_id), executed_notebook, execution_success in zip(
+        execution_indices, executed_notebooks, execution_successes
+    ):
+        responses[response_id]["solutions"][code_id]["execution_success"] = execution_success
+        responses[response_id]["solutions"][code_id]["executed_notebook"] = executed_notebook
+        if execution_success:
+            # Extract the last code cell with output
+            try:
+                last_code_cell = next(
+                    cell
+                    for cell in reversed(executed_notebook.cells)
+                    if cell.cell_type == "code" and cell.outputs
+                )
+            except StopIteration:
+                logging.debug("No code cell with output in the executed notebook.")
+                continue
+            responses[response_id]["solutions"][code_id]["last_cell"] = last_code_cell
+
+
+def _populate_qa_requests(responses: List[Dict[str, Any]], *, is_mutimodal: bool):
+    """Populates QA requests from execution results.
+
+    Args:
+        responses: A dictionary of responses.
+        multimodal: True if it is multimodal.
+    """
+    for response in responses:
+        for solution in response["solutions"].values():
+            if not solution["execution_success"]:
+                continue
+            # Skip if image is expected but grader_generator is not multimodal.
+            if response["image_expected"] and not is_mutimodal:
+                continue
+            processed_cell, image_data_list = _organize_cell_output(
+                solution["last_cell"], response["image_expected"]
+            )
+            question_prompt = _question_template.format(
+                execution_output=json.dumps(processed_cell),
+                questions=json.dumps(response["questions"]),
+            )
+            if len(image_data_list) > 0:
+                question_prompt = [{"type": "text", "text": question_prompt}] + image_data_list
+            solution["messages"].append({"role": "user", "content": question_prompt})
+
+
+def _generate_answers_from_qa_requests(
+    responses: List[Dict[str, Any]], *, grader_generator: Generator
+):
+    """Generates answers from QA requests.
+
+    Args:
+        responses: A dictionary of responses.
+        grader_generator: An instance of grader generator.
+    """
+    qa_indices = []
+    qa_requests = []
+    for response_id, response in enumerate(responses):
+        for code_id, solution in response["solutions"].items():
+            if solution["last_cell"] is not None:
+                qa_requests.append({"messages": solution["messages"]})
+                qa_indices.append((response_id, code_id))
+
+    if len(qa_requests) > 0:
+        answer_responses = asyncio.run(
+            grader_generator.async_generate_from_requests(gen_requests=qa_requests)
+        )
+        for (idx, code_idx), answer_response in zip(qa_indices, answer_responses):
+            answer_response = grader_generator.config.client.klass.parse_generation(
+                response=json.loads(answer_response["response"])
+            )
+            if len(answer_response) == 0:
+                logging.error("No answer response.")
+                continue
+            answer_response = answer_response[0].content
+            answer_response = answer_response.replace("```json", "").replace("```", "").strip()
+            answer_response = answer_response.replace("'", '"')
+            try:
+                answer = json.loads(answer_response)
+                responses[idx]["solutions"][code_idx]["answers"] = answer
+            except json.JSONDecodeError as e:
+                logging.error(
+                    "Error decoding the answer response (%s): %s", str(e), answer_response
+                )
+                continue
+
+
+def _compute_metrics_from_responses(responses: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Compute metrics based on responses.
+
+    Args:
+        responses: A list of responses in dictionary.
+
+    Returns:
+        A dictionary of metrics.
+    """
+    question_counts = []
+    correct_counts = []
+    image_output = []
+    execution_success_count = 0
+    for response in responses:
+        image_output.append(response["image_expected"])
+        n_questions = len(response["gt_answers"])
+        question_counts.append(n_questions)
+        gt_answers = np.array(response["gt_answers"])
+        correct_answers = np.zeros(n_questions, dtype=bool)
+        any_execution_success = False
+        for solution in response["solutions"].values():
+            any_execution_success = any_execution_success or solution["execution_success"]
+            if solution["answers"] is not None:
+                pred_answers = np.array(solution["answers"])
+                if len(pred_answers) != n_questions:
+                    continue
+                correct_answers = np.logical_or(correct_answers, pred_answers == gt_answers)
+        correct_counts.append(np.sum(correct_answers))
+        if any_execution_success:
+            execution_success_count += 1
+
+    question_counts = np.array(question_counts, dtype=np.float32)
+    correct_counts = np.array(correct_counts, dtype=np.float32)
+    image_output = np.array(image_output, dtype=bool)
+    per_response_accuracy = correct_counts / question_counts
+    overall_accuracy = np.sum(correct_counts) / np.sum(question_counts)
+    text_per_response_accuracy = np.mean(per_response_accuracy[~image_output])
+    text_overall_accuracy = np.sum(correct_counts[~image_output]) / np.sum(
+        question_counts[~image_output]
+    )
+    image_per_response_accuracy = np.mean(per_response_accuracy[image_output])
+    image_overall_accuracy = np.sum(correct_counts[image_output]) / np.sum(
+        question_counts[image_output]
+    )
+
+    return {
+        "execution_success_rate": float(execution_success_count) / len(responses),
+        "overall_accuracy": float(overall_accuracy),
+        "text_overall_accuracy": float(text_overall_accuracy),
+        "image_overall_accuracy": float(image_overall_accuracy),
+        "per_response_accuracy": float(per_response_accuracy.mean()),
+        "text_per_response_accuracy": float(text_per_response_accuracy),
+        "image_per_response_accuracy": float(image_per_response_accuracy),
+        "execution_success_count": execution_success_count,
+        "total_questions": float(np.sum(question_counts)),
+        "total_correct": float(np.sum(correct_counts)),
+        "total_text_questions": float(np.sum(question_counts[~image_output])),
+        "total_text_correct": float(np.sum(correct_counts[~image_output])),
+        "total_image_questions": float(np.sum(question_counts[image_output])),
+        "total_image_correct": float(np.sum(correct_counts[image_output])),
+    }
+
+
+def metric_fn(
+    *,
+    responses: List[Dict[str, Any]],
+    generators: Dict[EvalGeneratorType, Generator],
+    debug: bool = False,  # pylint: disable=unused-argument
+) -> Dict[str, Any]:
+    """Implements code kaggle metric following axlearn.open_api.common.MetricFn.
+
+    Args:
+        responses: A list of responses in dictionary.
+        generators: A dict of generator instances.
+        debug: True to add debug information in the metric.
+
+    Returns:
+        A dictionary of metrics.
+    """
+    generator_cfg: Generator.Config = generators[EvalGeneratorType.RESPONSE].config
+    _post_process_responses(responses, client_cls=generator_cfg.client.klass)
+    _execute_notebooks(responses)
+    grader_generator = generators[EvalGeneratorType.GRADER]
+    grader_generator_cfg: Generator.Config = grader_generator.config
+    _populate_qa_requests(
+        responses, is_mutimodal=_is_multimodal_model(grader_generator_cfg.client.model)
+    )
+    _generate_answers_from_qa_requests(responses, grader_generator=grader_generator)
+    return _compute_metrics_from_responses(responses)
+
+
+def _populate_retry_requests(responses: List[Dict[str, Any]]):
+    """Prepares retry requests from execution results.
+
+    Args:
+        responses: A dictionary of responses.
+    """
+    for response in responses:
+        for solution in response["solutions"].values():
+            if not solution["execution_success"]:
+                solution["messages"].append(
+                    {
+                        "role": "user",
+                        "content": _execution_feedback_template.format(
+                            error_message=solution["executed_notebook"]
+                        ),
+                    }
+                )
+
+
+def _generate_retry_solutions(responses: List[Dict[str, Any]], *, generator: Generator):
+    """Generates retry requests from execution results and generate answers.
+
+    Args:
+        responses: A dictionary of responses.
+        generator: An instance of generator.
+    """
+    retry_indices = []
+    retry_requests = []
+    for response_id, response in enumerate(responses):
+        for code_id, solution in response["solutions"].items():
+            if not solution["execution_success"]:
+                retry_requests.append({"messages": solution["messages"]})
+                retry_indices.append((response_id, code_id))
+
+    if len(retry_requests) > 0:
+        retry_responses = asyncio.run(
+            generator.async_generate_from_requests(gen_requests=retry_requests)
+        )
+        for (idx, code_idx), retry_response in zip(retry_indices, retry_responses):
+            retry_response = generator.config.client.klass.parse_generation(
+                response=json.loads(retry_response["response"])
+            )
+            if len(retry_response) == 0:
+                logging.error("No retry response.")
+                continue
+            retry_response = retry_response[0].content
+            retry_response = retry_response.replace("```json", "").replace("```", "").strip()
+            try:
+                retry_solution = json.loads(retry_response)
+            except json.JSONDecodeError as e:
+                logging.error("Error decoding the retry response (%s): %s", str(e), retry_response)
+                continue
+            retry_cells = _post_process_cells(retry_solution)
+            preceding_conversation = responses[idx]["solutions"][code_idx]["messages"]
+            preceding_conversation.append({"role": "assistant", "content": retry_response})
+            retry_solution = copy.deepcopy(responses[idx]["notebook"])
+            retry_solution["cells"] += retry_cells
+            responses[idx]["solutions"][code_idx]["notebook"] = json.dumps(retry_solution)
+
+
+def retry_metric_fn(
+    *,
+    responses: List[Dict[str, Any]],
+    generators: Dict[EvalGeneratorType, Generator],
+    debug: bool = False,  # pylint: disable=unused-argument
+) -> Dict[str, Any]:
+    """Implements code kaggle with onlien retry metric following axlearn.open_api.common.MetricFn.
+
+    Args:
+        responses: A list of responses in dictionary.
+        generators: A dict of generator instances.
+        debug: True to add debug information in the metric.
+
+    Returns:
+        A dictionary of metrics.
+    """
+    generator_cfg: Generator.Config = generators[EvalGeneratorType.RESPONSE].config
+    _post_process_responses(responses, client_cls=generator_cfg.client.klass)
+    _execute_notebooks(responses)
+    _populate_retry_requests(responses)
+    _generate_retry_solutions(responses, generator=generators[EvalGeneratorType.RESPONSE])
+    _execute_notebooks(responses)
+    grader_generator = generators[EvalGeneratorType.GRADER]
+    grader_generator_cfg: Generator.Config = grader_generator.config
+    _populate_qa_requests(
+        responses, is_mutimodal=_is_multimodal_model(grader_generator_cfg.client.model)
+    )
+    _generate_answers_from_qa_requests(responses, grader_generator=grader_generator)
+    return _compute_metrics_from_responses(responses)
+
+
+def _post_process_responses_oracle(responses: List[Dict[str, Any]]):
+    """Extracts executable notebooks from responses with oracle response.
+
+    Args:
+        responses: A list of responses in dictionary.
+    """
+    for response in responses:
+        response["messages"].append(
+            {
+                "role": "assistant",
+                "content": json.dumps(response["oracle_response"]),
+            }
+        )
+        response["solutions"] = {
+            0: {
+                "messages": response["messages"],
+                "notebook": response["notebook"],
+                "execution_success": True,
+                "last_cell": response["last_cell"],
+                "answers": None,
+            }
+        }
+
+
+def oracle_metric_fn(
+    *,
+    responses: List[Dict[str, Any]],
+    generators: Dict[EvalGeneratorType, Generator],
+    debug: bool = False,  # pylint: disable=unused-argument
+) -> Dict[str, Any]:
+    """Implements code kaggle with oracle response metric
+        following axlearn.open_api.common.MetricFn.
+
+    Args:
+        responses: A list of responses in dictionary.
+        generators: A dict of generator instances.
+        debug: True to add debug information in the metric.
+
+    Returns:
+        A dictionary of metrics.
+    """
+    _post_process_responses_oracle(responses)
+    grader_generator = generators[EvalGeneratorType.GRADER]
+    grader_generator_cfg: Generator.Config = grader_generator.config
+    _populate_qa_requests(
+        responses, is_mutimodal=_is_multimodal_model(grader_generator_cfg.client.model)
+    )
+    _generate_answers_from_qa_requests(responses, grader_generator=grader_generator)
+    return _compute_metrics_from_responses(responses)

--- a/axlearn/open_api/metrics/code_kaggle_test.py
+++ b/axlearn/open_api/metrics/code_kaggle_test.py
@@ -1,0 +1,89 @@
+# Copyright © 2024 Apple Inc.
+
+# pylint: disable=protected-access
+"""Unit test for code_kaggle.py.
+
+TODO(gyin): Add more unit tests for code kaggle core functions.
+"""
+
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+from axlearn.open_api.mock_utils import mock_openai_package
+
+mock_openai_package()
+
+
+# pylint: disable=wrong-import-position
+from axlearn.open_api.metrics import code_kaggle
+from axlearn.open_api.metrics.code_kaggle import BaseClient, _post_process_responses
+
+# pylint: enable=wrong-import-position
+
+
+class TestPostProcessResponses(unittest.TestCase):
+    """Unit tests for _post_process_responses."""
+
+    @patch(f"{code_kaggle.__name__}._post_process_cells")
+    def test_post_process_responses(self, mock_post_process_cells):
+        responses = [
+            {
+                "response": json.dumps({"key": "value"}),
+                "notebook": {"cells": []},
+                "messages": [{"role": "user", "content": "Some user content"}],
+            }
+        ]
+        client_cls = Mock(spec=BaseClient)
+        mock_code_response = Mock()
+        mock_code_response.content = '{"key": "value"}'
+        client_cls.parse_generation.return_value = [mock_code_response]
+
+        mock_post_process_cells.side_effect = lambda x: x
+
+        _post_process_responses(responses, client_cls=client_cls)
+
+        self.assertIn("solutions", responses[0])
+        self.assertTrue(client_cls.parse_generation.called)
+        self.assertTrue(mock_post_process_cells.called)
+        self.assertEqual(len(responses[0]["solutions"]), 1)
+        self.assertIn("messages", responses[0]["solutions"][0])
+        self.assertIn("notebook", responses[0]["solutions"][0])
+        self.assertIn("execution_success", responses[0]["solutions"][0])
+        self.assertIn("executed_notebook", responses[0]["solutions"][0])
+        self.assertIn("last_cell", responses[0]["solutions"][0])
+        self.assertIn("answers", responses[0]["solutions"][0])
+
+    @patch(f"{code_kaggle.__name__}.logging.error")
+    def test_post_process_responses_no_notebook(self, mock_logging_error):
+        responses = [
+            {
+                "response": json.dumps({"key": "value"}),
+                "messages": [{"role": "user", "content": "Some user content"}],
+            }
+        ]
+        client_cls = Mock(spec=BaseClient)
+
+        _post_process_responses(responses, client_cls=client_cls)
+
+        mock_logging_error.assert_called_with("No notebook in the response.")
+        self.assertIn("solutions", responses[0])
+        self.assertEqual(responses[0]["solutions"], {})
+
+    @patch(f"{code_kaggle.__name__}.logging.error")
+    def test_post_process_responses_no_code_responses(self, mock_logging_error):
+        responses = [
+            {
+                "response": json.dumps({"key": "value"}),
+                "notebook": {"cells": []},
+                "messages": [{"role": "user", "content": "Some user content"}],
+            }
+        ]
+        client_cls = Mock(spec=BaseClient)
+        client_cls.parse_generation.return_value = []
+
+        _post_process_responses(responses, client_cls=client_cls)
+
+        mock_logging_error.assert_called_with("No code responses.")
+        self.assertIn("solutions", responses[0])
+        self.assertEqual(responses[0]["solutions"], {})

--- a/axlearn/open_api/metrics/math.py
+++ b/axlearn/open_api/metrics/math.py
@@ -1,0 +1,128 @@
+# Copyright © 2024 Apple Inc.
+
+"""Math evaluation tasks.
+
+LLM grader would be used to judge the math solution.
+"""
+import asyncio
+import copy
+import json
+import logging
+import re
+from typing import Any, Dict, List, Type
+
+from axlearn.open_api.common import BaseClient, EvalGeneratorType, Generator
+
+# pylint: disable=line-too-long
+_math_prompt_template = """As a math expert, you will be provided with three items: a #Question#, an #Answer#, and the #Ground Truth#.
+Your task is to determine whether the #Answer# matches the #Ground Truth#.
+You need to considering mathmetical theorems when verifing the answer. For example, '$(c + 9)(c - 4)$' and '(c - 4)*(c + 9)'should be
+the same expressions based on factorization theorems.
+If they align, respond with 'correct'. If they do not, respond with 'wrong'.
+Ensure that your #Response# is the final line and consists solely of the word 'correct' or 'wrong', without any additional commentary or explanation.
+
+#Question#:
+{question}
+
+#Answer#:
+{answer}
+
+#Ground Truth#:
+{ground_truth}
+
+#Response#:
+"""
+# pylint: enable=line-too-long
+
+
+def _get_judgement_from_generation(resp: str) -> str:
+    """Gets judgment from generation."""
+    matches = re.findall(r"```python(.*?)```", resp, re.DOTALL)
+    if matches:
+        return matches[-1].strip().lower()
+    return resp.strip().lower()
+
+
+def metric_fn(
+    *,
+    responses: List[Dict[str, Any]],
+    generators: Dict[EvalGeneratorType, Generator],
+    debug: bool = False,
+) -> Dict[str, Any]:
+    """Implements math accuracy metric following axlearn.open_api.common.MetricFn.
+
+    Args:
+        responses: A list of responses in dictionary.
+        generators: A dict of generator instances.
+        debug: True to add debug information in the metric.
+
+    Returns:
+        A dictionary of metrics.
+    """
+    # Valid answers from first round of generation.
+    total_valid_answers = 0
+    # Judgements from LLM grading.
+    correct_judgments = 0
+    incorrect_judgments = 0
+    invalid_judgments = 0
+    judgement_requests = []
+    generator_cfg: Generator.Config = generators[EvalGeneratorType.RESPONSE].config
+    client_cls: Type[BaseClient] = generator_cfg.client.klass
+    for response in responses:
+        pred = client_cls.parse_generation(response=json.loads(response["response"]))
+        if len(pred) == 0:
+            logging.debug(
+                "deliverable_id: %s with empty response.",
+                response.get("deliverable_id", response.get("id", "")),
+            )
+            continue
+        if "#ANSWER#" not in pred[0].content:
+            logging.debug(
+                "deliverable_id: %s", response.get("deliverable_id", response.get("id", ""))
+            )
+            logging.debug("Unable to find #ANSWER# in %s", pred[0].content)
+            continue
+        total_valid_answers += 1
+        judgement_prompt = _math_prompt_template.format(
+            question=response["raw_problem"], answer=pred, ground_truth=response["gt_answer"]
+        )
+        # Make a copy to prepare a new request.
+        resp = copy.deepcopy(response)
+        del resp["response"]
+        resp.update({"messages": [{"role": "user", "content": judgement_prompt}]})
+        judgement_requests.append(resp)
+
+    grader_generator = generators[EvalGeneratorType.GRADER]
+    judgement_responses = asyncio.run(
+        grader_generator.async_generate_from_requests(gen_requests=judgement_requests)
+    )
+    grader_client_cls: Type[BaseClient] = grader_generator.config.client.klass
+    for response in judgement_responses:
+        pred = grader_client_cls.parse_generation(response=json.loads(response["response"]))
+        if len(pred) == 0:
+            invalid_judgments += 1
+            continue
+        judgement = _get_judgement_from_generation(pred[0].content.strip())
+
+        if judgement == "correct":
+            correct_judgments += 1
+        elif judgement == "wrong":
+            incorrect_judgments += 1
+        else:
+            invalid_judgments += 1
+
+    if total_valid_answers - invalid_judgments == 0:
+        accuracy = 0.0
+    else:
+        accuracy = correct_judgments / (total_valid_answers - invalid_judgments)
+    metrics = {
+        "number_of_examples": len(responses),
+        "accuracy": accuracy,
+        "total_valid_answers": total_valid_answers,
+        "correct_judgments": correct_judgments,
+        "invalid_judgments": invalid_judgments,
+        "incorrect_judgments": incorrect_judgments,
+    }
+    if debug:
+        metrics.update({"judgement_responses": judgement_responses})
+    return metrics

--- a/axlearn/open_api/metrics/math_test.py
+++ b/axlearn/open_api/metrics/math_test.py
@@ -1,0 +1,112 @@
+# Copyright © 2024 Apple Inc.
+
+"""Unit test for math.py."""
+import json
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from axlearn.open_api.mock_utils import mock_openai_package
+
+mock_openai_package()
+
+# pylint: disable=wrong-import-position
+from axlearn.open_api.common import EvalGeneratorType
+from axlearn.open_api.metrics.math import _get_judgement_from_generation, metric_fn
+
+# pylint: enable=wrong-import-position
+
+
+class TestMathEvaluator(unittest.IsolatedAsyncioTestCase):
+    """Unit test for metric_fn in math.py."""
+
+    def setUp(self):
+        self.generator = AsyncMock()
+        self.generator.config = MagicMock()
+        self.generator.config.client.klass = MagicMock()
+
+        self.messages = [
+            [MagicMock(content="#ANSWER# math solution is x = 4", role="assistant")],
+            [MagicMock(content="#ANSWER# math solution is x = 3", role="assistant")],
+            [MagicMock(content="#ANSWER# math solution is x = 4", role="assistant")],
+        ]
+        self.judgement_messages = [
+            [MagicMock(content="```python correct ```", role="assistant")],
+            [MagicMock(content="```python incorrect ```", role="assistant")],
+            [MagicMock(content="```python wrong ```", role="assistant")],
+        ]
+        self.responses = []
+        for idx, message in enumerate(self.messages):
+            self.responses.append(
+                {
+                    "response": json.dumps(
+                        {
+                            "choices": [
+                                {"message": {"role": "assistant", "content": message[0].content}}
+                            ]
+                        }
+                    ),
+                    "raw_problem": "Solve 2x + 3 = 11",
+                    "gt_answer": "x = 4",
+                    "id": f"test{idx+1}",
+                }
+            )
+
+    def test_get_judgement_from_generation(self):
+        test_input = "```python correct ```"
+        expected_output = "correct"
+        self.assertEqual(_get_judgement_from_generation(test_input), expected_output)
+
+        test_input = "```python incorrect ```"
+        expected_output = "incorrect"
+        self.assertEqual(_get_judgement_from_generation(test_input), expected_output)
+
+    def test_compute_metrics(self):
+        self.generator.config.client.klass.parse_generation.side_effect = (
+            self.messages + self.judgement_messages
+        )
+        self.generator.async_generate_from_requests.return_value = [
+            {
+                "response": json.dumps(
+                    {
+                        "choices": [
+                            {"message": {"content": "```python correct ```", "role": "assistant"}}
+                        ]
+                    }
+                ),
+                "raw_problem": "Solve 2x + 3 = 11",
+                "gt_answer": "x = 4",
+                "id": "test1",
+            },
+            {
+                "response": json.dumps(
+                    {
+                        "choices": [
+                            {"message": {"content": "```python incorrect ```", "role": "assistant"}}
+                        ]
+                    }
+                ),
+                "raw_problem": "Solve 2x + 3 = 11",
+                "gt_answer": "x = 4",
+                "id": "test3",
+            },
+            {
+                "response": json.dumps(
+                    {"choices": [{"message": {"content": "```wrong```", "role": "assistant"}}]}
+                ),
+                "raw_problem": "Solve 2x + 3 = 11",
+                "gt_answer": "x = 4",
+                "id": "test4",
+            },
+        ]
+        metrics = metric_fn(
+            responses=self.responses,
+            generators={
+                EvalGeneratorType.RESPONSE: self.generator,
+                EvalGeneratorType.GRADER: self.generator,
+            },
+        )
+        self.assertEqual(metrics["accuracy"], 0.5)
+        self.assertEqual(metrics["total_valid_answers"], 3)
+        self.assertEqual(metrics["correct_judgments"], 1)
+        self.assertEqual(metrics["incorrect_judgments"], 1)
+        self.assertEqual(metrics["invalid_judgments"], 1)

--- a/axlearn/open_api/metrics/tool_use_execution.py
+++ b/axlearn/open_api/metrics/tool_use_execution.py
@@ -1,0 +1,344 @@
+# Copyright © 2024 Apple Inc.
+#
+# Some of the code in this file is adapted from:
+#
+# ShishirPatil/gorilla:
+# Copyright 2023 The Gorilla Authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""Tool use execution evaluation task.
+
+Following https://platform.openai.com/docs/guides/function-calling
+for target message.
+"""
+
+import copy
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional, Sequence, Type
+
+import dateutil
+import dateutil.parser
+
+from axlearn.open_api.common import BaseClient, EvalGeneratorType, Generator
+from axlearn.open_api.openai import OpenAIClient
+
+
+def _standardize_string(input_string: str) -> str:
+    """Standardizes the string by removing all the spaces,
+    ",./-_*^" punctuation and converting it to lowercase.
+    It will also convert all the single quotes to double quotes and used to compare the model output
+    with the possible answers. We don't want to punish model for answer
+    like April 1, 2024 vs April 1,2024, vs April 1 2024.
+
+    This is adopted from Gorilla:
+    https://github.com/ShishirPatil/gorilla/blob/cb694ea16ecd23317e4b8d93bc9772dc0f09c4d2/berkeley-function-call-leaderboard/eval_checker/checker.py#L151
+    """
+    regex_string = r"[ \,\.\/\-\_\*\?\+\^]"
+    return re.sub(regex_string, "", input_string).lower().replace("'", '"')
+
+
+def _default_value_match(pred_v: Any, target_v: Any) -> bool:
+    """Checks whether a string value matches."""
+    if isinstance(pred_v, str):
+        pred_v = _standardize_string(pred_v)
+    if isinstance(target_v, str):
+        target_v = _standardize_string(target_v)
+    return pred_v == target_v
+
+
+def _date_match(val: str, gt: str) -> bool:
+    """Interprets strings as date and then compare."""
+    try:
+        date_val = dateutil.parser.parse(val)
+        date_gt = dateutil.parser.parse(gt)
+    except dateutil.parser.ParserError:
+        return False
+    return date_val == date_gt
+
+
+def _extract_arguments(tool_call: Dict) -> Dict:
+    """Extracts arguments from tool call."""
+    args = tool_call["arguments"]
+    return json.loads(args) if isinstance(args, str) else args
+
+
+def _match_argument(
+    *,
+    arg_name: str,
+    arg_rule: Dict,
+    pred_arg: Any,
+    target_arg: Optional[Any],
+) -> bool:
+    """Matches a predicted argument against an argument rule.
+
+    Args:
+        arg_name: The name of the argument.
+        arg_rule: The argument rule.
+        pred_arg: The predicted argument value.
+        target_get: The target argument value.
+
+    Returns:
+        True if the argument is matched against the rule, False other.
+
+    Raises:
+        ValueError: If the argument rule does not contain a valid sub-rule.
+    """
+    if "regex_match" in arg_rule:
+        if not isinstance(pred_arg, str):
+            return False
+        pattern = re.compile(arg_rule["regex_match"], re.IGNORECASE)
+        return pattern.match(pred_arg) is not None
+
+    if "multi_choices" in arg_rule:
+        return any(
+            _default_value_match(pred_arg, candidate) for candidate in arg_rule["multi_choices"]
+        )
+
+    if "date_match" in arg_rule:
+        if arg_rule["date_match"] is True:
+            if not isinstance(pred_arg, str):
+                return False
+            assert isinstance(target_arg, str)
+            return _date_match(pred_arg, target_arg)
+        else:
+            return _default_value_match(pred_arg, target_arg)
+
+    raise ValueError(f"Unknown argument rules with keys {list(arg_rule.keys())} fpr {arg_name}")
+
+
+def _match_tool_call_with_rules(
+    *,
+    pred_tool_call: Dict,
+    match_rule: Dict,
+    target_tool_call: Dict,
+) -> bool:
+    """Matches a tool call against a target tool call or a match rule. It works as follows:
+    - Check the function name
+    - Iterate over all match attributes:
+        - Check all arguments with the attribute_rule
+    - Iterate over all unseen arguments and compare them against the target attributes.
+
+    Args:
+        pred_tool_call: The predicted tool call.
+        match_rule: The match rule.
+        target_tool_call: The target tool call.
+
+    Returns:
+        True if the tool call matches against the target tool call or the match rule, false
+        otherwise.
+    """
+
+    if target_tool_call["name"] != pred_tool_call["name"]:
+        return False
+
+    try:
+        pred_args = _extract_arguments(pred_tool_call)
+        target_args = _extract_arguments(target_tool_call)
+    except (json.JSONDecodeError, KeyError):
+        logging.error(
+            "Unable to decode arguments from predicted call %s or target call %s",
+            pred_tool_call["arguments"],
+            target_tool_call["arguments"],
+        )
+        return False
+
+    if not isinstance(pred_args, dict):
+        logging.error("Arguments are not a dictionary %s", str(pred_args))
+        return False
+
+    seen_arguments = []
+    if "arguments" in match_rule:
+        for arg_name, rule in match_rule["arguments"].items():
+            if not arg_name in pred_args:
+                return False
+            if not _match_argument(
+                arg_name=arg_name,
+                arg_rule=rule,
+                pred_arg=pred_args[arg_name],
+                target_arg=target_args.get(arg_name, None),
+            ):
+                return False
+            seen_arguments.append(arg_name)
+
+    for arg in set(list(pred_args.keys()) + list(target_args.keys())):
+        if not arg in seen_arguments:
+            pred_value = pred_args.get(arg, None)
+            target_value = target_args.get(arg, None)
+            if not _default_value_match(pred_value, target_value):
+                return False
+
+    return True
+
+
+def _compare_tool_calls(
+    *,
+    pred_tool_calls: Sequence[Dict[str, Any]],
+    target_tool_calls: List[Dict[str, Any]],
+    match_rules: Optional[List[Dict[str, Any]]] = None,
+) -> bool:
+    """Compares the predicted tool calls with the target, potentially with matching rules.
+
+    Args:
+        pred_tool_calls: Predicted tool calls.
+        target_tool_calls: Target tool calls.
+        match_rules: A dict containing the matching rules corresponding to each target tool call.
+            E.g.
+            ```[{
+                "param1": {
+                    "multi_choices": [..,],
+                    "regex_match": ...,
+                    "flexible_date_match": True,
+                },
+                "param2": ...
+            }]```
+            The match rules should correspond to each target function call. If there's no rule for
+            a corresponding function call, an empty dict should be used.
+
+    Returns:
+        True if predicted tool calls match the target or False otherwise.
+
+    Raises:
+        ValueError: If length of target_tool_calls don't match that of match_rules.
+    """
+    if match_rules is not None and len(target_tool_calls) != len(match_rules):
+        raise ValueError(
+            f"match_rules ({len(match_rules)}) should match the "
+            f"number of target_tool_calls ({len(target_tool_calls)})."
+        )
+
+    target_tool_calls = copy.deepcopy(target_tool_calls)
+    match_rules = copy.deepcopy(match_rules)
+    match_rules = [{}] * len(target_tool_calls) if match_rules is None else match_rules
+    for pred_tool in pred_tool_calls:
+        tool_matched = False
+
+        for call_idx, target_tool in enumerate(target_tool_calls):
+            tool_matched = _match_tool_call_with_rules(
+                pred_tool_call=pred_tool["function"],
+                target_tool_call=target_tool["function"],
+                match_rule={} if match_rules is None else match_rules[call_idx],
+            )
+            if tool_matched:
+                target_tool_calls.pop(call_idx)
+                match_rules.pop(call_idx)
+                tool_matched = True
+                break
+        if not tool_matched:
+            return False
+    if target_tool_calls:
+        return False
+    return True
+
+
+def metric_fn(
+    *,
+    responses: List[Dict[str, Any]],
+    generators: Dict[EvalGeneratorType, Generator],
+    debug: bool = False,
+) -> Dict[str, Any]:
+    """Implements the tool use execution accuracy metric following axlearn.open_api.common.MetricFn.
+
+    Args:
+        responses: A list of responses in dictionary.
+        generators: A dict of generator instances.
+        debug: True to add debug information in the metric.
+
+    Returns:
+        A dictionary of metrics.
+    """
+    if len(responses) == 0:
+        return {
+            "accuracy": 0,
+            "number_of_examples": 0,
+            "number_of_errors": 0,
+        }
+
+    def get_tool_calls_from_message(message: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Extracts tool call arguments in message."""
+
+        if "tool_calls" not in message:
+            return [{}]
+        new_tool_calls = []
+        for tool_call in message["tool_calls"]:
+            if "id" in tool_call:
+                del tool_call["id"]
+            new_tool_calls.append(tool_call)
+        return new_tool_calls
+
+    total_matches = 0
+    number_of_parsing_errors = 0
+    number_of_generation_errors = 0
+    generator_cfg: Generator.Config = generators[EvalGeneratorType.RESPONSE].config
+    client_cls: Type[BaseClient] = generator_cfg.client.klass
+    for response in responses:
+        matched = False
+        target_message = response.get("target_message", None)
+        if target_message is None:
+            raise ValueError("ToolUseExecution must have target message in each response.")
+        try:
+            pred_messages = client_cls.parse_generation(response=json.loads(response["response"]))
+        # pylint: disable-next=broad-except
+        except Exception as e:
+            logging.error("Found error %s: %s", type(e), e)
+            logging.error("Response %s", response["response"])
+            pred_messages = []
+            number_of_parsing_errors += 1
+        if (
+            len(pred_messages) == 1
+            and pred_messages[0].content == ""
+            and pred_messages[0].tool_calls is None
+            and pred_messages[0].function_call is None
+        ):
+            # If the content is empty and there are no tool or function calls we usually have
+            # a generation error. In this case, there is no content field generated, but
+            # sometimes an error field.
+            number_of_generation_errors += 1
+        pred_tool_calls, target_tool_calls = None, None
+        if len(pred_messages) > 0:
+            pred = pred_messages[0]
+            target = OpenAIClient.format_message(target_message)
+            # Check string match.
+            if (
+                target.content is not None
+                and target.content != ""
+                and target.content == pred.content
+            ):
+                matched = True
+            elif (
+                target.tool_calls is not None
+                and pred.tool_calls is not None
+                and len(target.tool_calls) == len(pred.tool_calls)
+            ):
+                pred_tool_calls = get_tool_calls_from_message(pred.model_dump())
+                target_tool_calls = get_tool_calls_from_message(target.model_dump())
+                match_rules = response.get("target_message_match_rules", None)
+                matched = _compare_tool_calls(
+                    pred_tool_calls=pred_tool_calls,
+                    target_tool_calls=target_tool_calls,
+                    match_rules=match_rules,
+                )
+        if debug and not matched:
+            deliverable_id = response.get("deliverable_id", response.get("id", ""))
+            target = target_tool_calls or json.dumps(target_message, sort_keys=True)
+            pred = (
+                pred_tool_calls or json.dumps(pred_messages[0].model_dump(), sort_keys=True)
+                if len(pred_messages) > 0
+                else ""
+            )
+            debug_info = (
+                f"deliverable_id: {deliverable_id}\n"
+                + f"target: {target}\n"
+                + f"pred: {pred}\n"
+                + f"resp: {response['response']}"
+            )
+            logging.debug(debug_info)
+        if matched:
+            total_matches += 1
+
+    return {
+        "accuracy": total_matches / len(responses),
+        "number_of_examples": len(responses),
+        "number_of_parsing_errors": number_of_parsing_errors,
+        "number_of_generation_errors": number_of_generation_errors,
+    }

--- a/axlearn/open_api/metrics/tool_use_execution_test.py
+++ b/axlearn/open_api/metrics/tool_use_execution_test.py
@@ -1,0 +1,196 @@
+# Copyright © 2024 Apple Inc.
+
+"""Unit test for tool_use_execution.py."""
+
+import json
+from unittest.mock import MagicMock, Mock, patch
+
+from absl.testing import parameterized
+
+from axlearn.open_api.mock_utils import mock_openai_package
+
+mock_openai_package()
+
+# pylint: disable=wrong-import-position
+from axlearn.open_api.common import EvalGeneratorType
+from axlearn.open_api.metrics.tool_use_execution import metric_fn
+
+# pylint: enable=wrong-import-position
+
+
+class TestToolUseExecution(parameterized.TestCase):
+    """Unit tests for tool_use_execution."""
+
+    def setUp(self):
+        self.generator = MagicMock()
+        self.generator.config = MagicMock()
+        self.generator.config.client.klass = MagicMock()
+
+        self.grader_generator = MagicMock()
+
+    def test_empty_responses(self):
+        """Test compute_metrics with an empty list of responses."""
+        responses = []
+        metrics = metric_fn(
+            responses=responses,
+            generators={
+                EvalGeneratorType.RESPONSE: self.generator,
+                EvalGeneratorType.GRADER: self.generator,
+            },
+        )
+        self.assertEqual(metrics["accuracy"], 0)
+        self.assertEqual(metrics["number_of_examples"], 0)
+
+    def test_responses_without_tool_calls(self):
+        """Tests with responses that lack target_message field."""
+        responses = [
+            {
+                "response": json.dumps({"content": "Test message"}),
+            }
+        ]
+        with self.assertRaises(ValueError):
+            metric_fn(
+                responses=responses,
+                generators={
+                    EvalGeneratorType.RESPONSE: self.generator,
+                    EvalGeneratorType.GRADER: self.generator,
+                },
+            )
+
+    @parameterized.parameters(
+        # Date normalization.
+        dict(
+            target_message_match_rules=[{"arguments": {"date": {"date_match": True}}}],
+            target_arguments=json.dumps({"date": "4/2/2024"}),
+            accuracy=1,
+        ),
+        # Date normalization but incorrect argument.
+        dict(
+            target_message_match_rules=[{"arguments": {"date": {"date_match": True}}}],
+            target_arguments=json.dumps({"date": "4/2024"}),
+            accuracy=0,
+        ),
+        # No date normalization.
+        dict(
+            target_message_match_rules=[{"arguments": {"date": {"date_match": False}}}],
+            target_arguments=json.dumps({"date": "4/2/2024"}),
+            accuracy=0,
+        ),
+        # Mutiple choices.
+        dict(
+            target_message_match_rules=[
+                {"arguments": {"date": {"multi_choices": ["4/2/2024", "April 2, 2024"]}}}
+            ],
+            target_arguments=json.dumps({"date": "4/2/2024"}),
+            accuracy=1,
+        ),
+        # Mutiple choices.
+        dict(
+            target_message_match_rules=[
+                {"arguments": {"date": {"multi_choices": ["4/2/2023", "April 2, 2023"]}}}
+            ],
+            target_arguments=json.dumps({"date": "4/2/2024"}),
+            accuracy=0,
+        ),
+        # Regex match.
+        dict(
+            target_message_match_rules=[
+                {"arguments": {"location": {"regex_match": r"^cupertino"}}}
+            ],
+            target_arguments=json.dumps({"location": "cupertino."}),
+            accuracy=1,
+            pred_arguments=json.dumps({"location": "Cupertino, CA"}),
+        ),
+        # Regex match.
+        dict(
+            target_message_match_rules=[{"arguments": {"location": {"regex_match": r"^san jose"}}}],
+            target_arguments=json.dumps({"location": "cupertino."}),
+            accuracy=0,
+            pred_arguments=json.dumps({"location": "Cupertino, CA"}),
+        ),
+        # Partial match.
+        dict(
+            target_message_match_rules=None,
+            target_arguments=json.dumps({"location": "cupertino", "unit": "celcius"}),
+            accuracy=0,
+            pred_arguments=json.dumps({"location": "cupertino"}),
+        ),
+        # String match.
+        dict(
+            target_message_match_rules=None,
+            target_arguments=json.dumps({"location": "cupertino"}),
+            accuracy=1,
+            pred_arguments=json.dumps({"location": "cupertino"}),
+        ),
+        # Punctuation normalization match.
+        dict(
+            target_message_match_rules=None,
+            target_arguments=json.dumps({"location": "cupertino"}),
+            accuracy=1,
+            pred_arguments=json.dumps({"location": "cupertino."}),
+        ),
+        # Invalid arguments json format.
+        dict(
+            target_message_match_rules=None,
+            target_arguments=json.dumps({"location": "cupertino"}),
+            accuracy=0,
+            pred_arguments='{"location": "cupertino"',
+        ),
+    )
+    def test_match_rules(
+        self, target_arguments, accuracy, target_message_match_rules=None, pred_arguments=None
+    ):
+        """Tests where responses match the targets"""
+        pred_message = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {
+                        "arguments": pred_arguments or json.dumps({"date": "April 2, 2024"}),
+                        "name": "get_weather",
+                    },
+                }
+            ],
+        }
+        target_message = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {
+                        "arguments": target_arguments,
+                        "name": "get_weather",
+                    },
+                }
+            ],
+        }
+        responses = [
+            {
+                "response": json.dumps({"choices": [{"message": pred_message}]}),
+                "target_message": target_message,
+            }
+        ]
+        if target_message_match_rules:
+            responses[0].update({"target_message_match_rules": target_message_match_rules})
+        mock_target_message = Mock(**target_message)
+        mock_target_message.model_dump.return_value = target_message
+        mock_pred_message = Mock(**pred_message)
+        mock_pred_message.model_dump.return_value = pred_message
+        self.generator.config.client.klass.parse_generation.return_value = [mock_pred_message]
+
+        with patch(
+            "axlearn.open_api.openai.OpenAIClient.format_message", return_value=mock_target_message
+        ):
+            metrics = metric_fn(
+                responses=responses,
+                generators={
+                    EvalGeneratorType.RESPONSE: self.generator,
+                    EvalGeneratorType.GRADER: self.generator,
+                },
+            )
+            self.assertEqual(metrics["accuracy"], accuracy)

--- a/axlearn/open_api/metrics/tool_use_plan.py
+++ b/axlearn/open_api/metrics/tool_use_plan.py
@@ -1,0 +1,70 @@
+# Copyright © 2024 Apple Inc.
+
+"""Tool use plan evaluation task.
+
+Generating an DAG graph based a list of tools
+and then ask the model to select the right plan
+from multi choices.
+"""
+import json
+import logging
+import re
+from typing import Any, Dict, List, Type
+
+from axlearn.open_api.common import BaseClient, EvalGeneratorType, Generator
+
+
+def metric_fn(
+    *,
+    responses: List[Dict[str, Any]],
+    generators: Dict[EvalGeneratorType, Generator],
+    debug: bool = False,
+) -> Dict[str, Any]:
+    """Implements the tool use plan accuracy metric following axlearn.open_api.common.MetricFn.
+
+    Args:
+        responses: A list of responses in dictionary.
+        generators: A dict of generator instances.
+        debug: True to add debug information in the metric.
+
+    Returns:
+        A dictionary of metrics.
+    """
+    total_matches = 0
+    if_error = 0
+    generator_cfg: Generator.Config = generators[EvalGeneratorType.RESPONSE].config
+    client_cls: Type[BaseClient] = generator_cfg.client.klass
+    for response in responses:
+        matched = False
+        target_plan_number = response.get("target_plan_number", None)
+        if target_plan_number is None:
+            raise ValueError("ToolUsePlan must have target_plan_number in each response.")
+        pred = client_cls.parse_generation(response=json.loads(response["response"]))
+        if len(pred) > 0:
+            matches = re.findall(r"\*{0,2}Chosen Plan:\*{0,2}\s+(\d+)", pred[0].content)
+
+            if matches:
+                try:
+                    pred_plan_number = int(matches[0])
+                    if target_plan_number == pred_plan_number:
+                        matched = True
+                except ValueError:
+                    logging.error("Unable to cast %s", matches[0])
+                    if_error += 1
+            else:
+                if_error += 1
+        if debug and not matched:
+            deliverable_id = response.get("deliverable_id", response.get("id", ""))
+            debug_info = (
+                f"deliverable_id: {deliverable_id}\n"
+                + f"target plan number: {target_plan_number}\npred: {pred}"
+            )
+            logging.debug(debug_info)
+        if matched:
+            total_matches += 1
+    metrics = {
+        "accuracy": total_matches / len(responses),
+        "instruction_following_error": if_error / len(responses),
+        "number_of_examples": len(responses),
+    }
+    return metrics

--- a/axlearn/open_api/metrics/tool_use_plan_test.py
+++ b/axlearn/open_api/metrics/tool_use_plan_test.py
@@ -1,0 +1,108 @@
+# Copyright © 2024 Apple Inc.
+
+"""Unit tests for tool_use_plan.py."""
+import json
+import unittest
+from unittest.mock import MagicMock
+
+from axlearn.open_api.mock_utils import mock_openai_package
+
+mock_openai_package()
+
+# pylint: disable=wrong-import-position
+from axlearn.open_api.common import EvalGeneratorType
+from axlearn.open_api.metrics.tool_use_plan import metric_fn
+
+# pylint: enable=wrong-import-position
+
+
+class TestMetricFn(unittest.TestCase):
+    """Unit tests for metric_fn in tool_use_plan.py."""
+
+    def setUp(self):
+        self.responses = [
+            {"target_plan_number": 1, "response": json.dumps({"content": "**Chosen Plan:** 1"})},
+            {"target_plan_number": 2, "response": json.dumps({"content": "**Chosen Plan:** 2"})},
+        ]
+
+        self.generator = MagicMock()
+        self.generator.config = MagicMock()
+        self.generator.config.client.klass = MagicMock()
+
+        self.grader_generator = MagicMock()
+
+    def test_metric_fn_success(self):
+        self.generator.config.client.klass.parse_generation.side_effect = [
+            [MagicMock(content="**Chosen Plan:** 1")],
+            [MagicMock(content="**Chosen Plan:** 2")],
+        ]
+
+        metrics = metric_fn(
+            responses=self.responses,
+            generators={
+                EvalGeneratorType.RESPONSE: self.generator,
+                EvalGeneratorType.GRADER: self.grader_generator,
+            },
+            debug=False,
+        )
+
+        self.assertEqual(metrics["accuracy"], 1.0)
+        self.assertEqual(metrics["instruction_following_error"], 0.0)
+        self.assertEqual(metrics["number_of_examples"], 2)
+
+    def test_metric_fn_mismatch(self):
+        self.generator.config.client.klass.parse_generation.side_effect = [
+            [MagicMock(content="**Chosen Plan:** 1")],
+            [MagicMock(content="**Chosen Plan:** 3")],
+        ]
+
+        metrics = metric_fn(
+            responses=self.responses,
+            generators={
+                EvalGeneratorType.RESPONSE: self.generator,
+                EvalGeneratorType.GRADER: self.grader_generator,
+            },
+            debug=False,
+        )
+
+        self.assertEqual(metrics["accuracy"], 0.5)
+        self.assertEqual(metrics["instruction_following_error"], 0.0)
+        self.assertEqual(metrics["number_of_examples"], 2)
+
+    def test_metric_fn_with_debug(self):
+        self.generator.config.client.klass.parse_generation = MagicMock(
+            return_value=[MagicMock(content="**Chosen Plan:** 3")]
+        )
+
+        with self.assertLogs(level="DEBUG") as log:
+            metrics = metric_fn(
+                responses=self.responses,
+                generators={
+                    EvalGeneratorType.RESPONSE: self.generator,
+                    EvalGeneratorType.GRADER: self.grader_generator,
+                },
+                debug=True,
+            )
+
+        self.assertEqual(metrics["accuracy"], 0.0)
+        self.assertEqual(metrics["instruction_following_error"], 0.0)
+        self.assertEqual(metrics["number_of_examples"], 2)
+        self.assertIn("deliverable_id", log.output[0])
+
+    def test_metric_fn_invalid_response(self):
+        self.generator.config.client.klass.parse_generation = MagicMock(
+            return_value=[MagicMock(content="**Chosen Plan:** X")]
+        )
+
+        metrics = metric_fn(
+            responses=self.responses,
+            generators={
+                EvalGeneratorType.RESPONSE: self.generator,
+                EvalGeneratorType.GRADER: self.grader_generator,
+            },
+            debug=False,
+        )
+
+        self.assertEqual(metrics["accuracy"], 0.0)
+        self.assertEqual(metrics["instruction_following_error"], 1.0)
+        self.assertEqual(metrics["number_of_examples"], 2)

--- a/axlearn/open_api/openai_test.py
+++ b/axlearn/open_api/openai_test.py
@@ -78,7 +78,10 @@ class TestOpenAIAsyncGenerateFromRequests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(response["response"], "test response")  # Validate response content
 
         # Check if async_generate_from_request is called correctly.
-        calls = [unittest.mock.call(client=ANY, request=ANY) for i in range(len(mock_requests))]
+        calls = [
+            unittest.mock.call(client=ANY, request=ANY, **self.open_api.config.decode_parameters)
+            for _ in range(len(mock_requests))
+        ]
         mock_async_generate_from_request.assert_has_calls(
             calls, any_order=True
         )  # Ensure each request is processed

--- a/axlearn/open_api/registry.py
+++ b/axlearn/open_api/registry.py
@@ -1,5 +1,5 @@
 # Copyright © 2024 Apple Inc.
-
+#
 # Some of the code in this file is adapted from:
 #
 # vllm-project/vllm:
@@ -11,7 +11,7 @@ import importlib
 import logging
 from typing import Dict, List, Optional, Type
 
-from axlearn.open_api.common import BaseClient
+from axlearn.open_api.common import BaseClient, MetricFn
 
 # The dict of {client_name: (module, class)}.
 _OPEN_API_CLIENTS_MODULE_CLASS = {
@@ -58,3 +58,56 @@ class ClientRegistry:
                 client_cls.__name__,
             )
         _OPEN_API_CLIENTS_CLASS[client_name] = client_cls
+
+
+# The dict of {metric_name: (module, func)}.
+_METRIC_MODULE_FUNC = {
+    "tool_use_plan": ("tool_use_plan", "metric_fn"),
+    "tool_use_execution": ("tool_use_execution", "metric_fn"),
+    "math": ("math", "metric_fn"),
+    "code_kaggle": ("code_kaggle", "metric_fn"),
+    "code_kaggle_retry": ("code_kaggle", "retry_metric_fn"),
+    "code_kaggle_oracle": ("code_kaggle", "oracle_metric_fn"),
+    "code_contests": ("code_contests", "code_execution_metric_fn"),
+    "code_contests_understand": ("code_contests", "understand_metric_fn"),
+    "code_contests_plan": ("code_contests", "plan_metric_fn"),
+    "code_contests_retry": ("code_contests", "retry_metric_fn"),
+}
+
+# The dict of {metric_name: func}.
+_METRIC_FUNC: Dict[str, MetricFn] = {}
+
+
+class MetricRegistry:
+    """A registry of metrics."""
+
+    @staticmethod
+    def load_metric(metric_name: str) -> Optional[MetricFn]:
+        """Loads a metric compute function."""
+        if metric_name in _METRIC_FUNC:
+            return _METRIC_FUNC[metric_name]
+        if metric_name not in _METRIC_MODULE_FUNC:
+            return None
+        module_name, metric_func_name = _METRIC_MODULE_FUNC[metric_name]
+        module = importlib.import_module(f"axlearn.open_api.metrics.{module_name}")
+        return getattr(module, metric_func_name, None)
+
+    @staticmethod
+    def get_supported_metrics() -> List[str]:
+        """Gets supported metrics."""
+        return list(_METRIC_FUNC.keys()) + list(_METRIC_MODULE_FUNC.keys())
+
+    @staticmethod
+    def register(metric_name: str, metric_func: MetricFn):
+        """Registers a new metric.
+
+        Args:
+           metric_name: A string of metric name.
+           metric_func: A function to compute metric.
+        """
+        if metric_name in _METRIC_FUNC:
+            logging.warning(
+                "Metric %s will be overwritten by the new metric function.",
+                metric_name,
+            )
+        _METRIC_FUNC[metric_name] = metric_func


### PR DESCRIPTION
**Design and Motivation**

This pull request enhances the axlearn.open_api module by introducing a new evaluator class, and additional metric modules.

**Key Changes**:
- Evaluator Class: Introduced the Evaluator class for loading responses, computing metrics, and writing results.
- Protocol Integration: Defined MetricFn as a Protocol for metric computation.
- New Metrics: Added codecontests, code_kaggle, math, tool_use_plan, and tool_use_execution modules for specific evaluation tasks.

Reviewed internally. This is for a publication. We will avoid checking in such a large PR in the future. 