### PR TITLE
Makes trainer.py donate both prng_key and prebuilt_model_state for `init_computation`.

### DIFF
--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -618,6 +618,7 @@ class SpmdTrainer(Module):
             _init_state,
             in_shardings=(None, prebuilt_model_state_partition_spec),
             out_shardings=self._trainer_state_partition_specs,
+            donate_argnums=(0, 1),  # donate both prng_key and prebuilt_model_state
         )
         self._step_log("Initializing trainer state.")
         with self.mesh():


### PR DESCRIPTION
To avoid duplicate memory consumption for parameters that already have been initialized.