### PR TITLE
Only donate `prebuilt_model_state` to `init_computation`.

### DIFF
--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -618,7 +618,7 @@ class SpmdTrainer(Module):
             _init_state,
             in_shardings=(None, prebuilt_model_state_partition_spec),
             out_shardings=self._trainer_state_partition_specs,
-            donate_argnums=(0, 1),  # donate both prng_key and prebuilt_model_state
+            donate_argnums=(1,),  # donate prebuilt_model_state to reduce memory usage.
         )
         self._step_log("Initializing trainer state.")
         with self.mesh():


### PR DESCRIPTION
Do not donate `prng_key` to simplify the behavior as some callers reuse the `prng_key` buffer passed to `SpmdTrainer.run`.