### PR TITLE
set hostNetwork to True for TPUGKEJob

### DIFF
--- a/axlearn/cloud/gcp/job.py
+++ b/axlearn/cloud/gcp/job.py
@@ -474,7 +474,6 @@ class TPUGKEJob(GKEJob):
         annotations, selector, volumes, tolerations = {}, {}, [], []
 
         if cfg.gcsfuse_mount:
-            # GCS Fuse does not work with hostNetwork True.
             # Mount a GCS bucket as a volume.
             annotations.update(
                 {

--- a/axlearn/cloud/gcp/job.py
+++ b/axlearn/cloud/gcp/job.py
@@ -565,7 +565,6 @@ class TPUGKEJob(GKEJob):
         )
 
         pod_spec = dict(
-            # NOTE: Don't set hostNetwork or dnsPolicy for compat with Workload Identity.
             terminationGracePeriodSeconds=60,
             # Fail if any pod fails, and allow retries to happen at JobSet level.
             restartPolicy="Never",
@@ -580,6 +579,7 @@ class TPUGKEJob(GKEJob):
             volumes=volumes,
         )
 
+        # hostNetwork True and dnsPolicy do not work with Workload Identity and GCS Fuse.
         if not cfg.gcsfuse_mount:
             pod_spec["hostNetwork"] = True
             pod_spec["dnsPolicy"] = "ClusterFirstWithHostNet"


### PR DESCRIPTION
This helped increase v5e-512 performance from 50% MFU to 58% MFU. The gains could be more significant when going beyond 2 slices.

Majority of Google TPU benchmarks ran on GKE use hostNetwork=true. That's also what XPK sets by default.

The performance increase is due to being able to bypass container networking. Setting hostNetwork=true allows us to directly utilize the host NICs without having to first traverse container NIC and linux network bridges.