### PR TITLE
Fix precision_recall_curve to correctly handle masked examples

### DIFF
--- a/axlearn/common/metrics_classification.py
+++ b/axlearn/common/metrics_classification.py
@@ -141,9 +141,8 @@ def binary_clf_curve(
         A dict with keys "fps", "tps", and "thresholds".
             Each is a scalar Tensor with values of shape [num_samples].
             fps, tps have values in [0, inf) and thresholds have values in (-inf, inf).
-            The order is based on descending order of thresholds. Because samples of weight 0 are
-            ignored during calculation, returned thresholds only contain valid thresholds that are
-            used for tps and fps calculation.
+            The order is based on descending order of thresholds for unmasked examples. The
+            jax.numpy.finfo(jnp.float32).max value in thresholds should be ignored.
             Element i in fps/tps are the tps/fps of predictions with score >= thresholds[i].
     """
     # Sort scores and corresponding truth unmasked values descending.
@@ -177,9 +176,6 @@ def binary_clf_curve(
     fps = jnp.where(y_pred_diff, fps, jnp.iinfo(jnp.int32).max)
     fps = jax.lax.cummin(fps, reverse=True)
 
-    # Masked entries at the end of thresholds are set to jnp.finfo(jnp.float32).max.
-    # Reset them to the rightmost unmasked threshold value.
-    thresholds = jnp.where(weight, thresholds, thresholds[jnp.argsort(weight)[-1]])
     return dict(fps=fps, tps=tps, thresholds=thresholds)
 
 

--- a/axlearn/common/metrics_classification_test.py
+++ b/axlearn/common/metrics_classification_test.py
@@ -173,6 +173,65 @@ class TestMetrics(TestWithTemporaryCWD):
             "batch_size": 2,
         },
         {
+            # Test case where we have float weights that sum up less than 1 with 1 positive.
+            "y_score": jnp.array([0.25, 0.75]),
+            "y_true": jnp.array([1, 1]),
+            "weights": jnp.array([0.5, 0.0]),
+            "batch_size": 2,
+        },
+        {
+            # Test case where we have float weights that sum up less than 1 with 1 pos and 1 neg.
+            "y_score": jnp.array([0.25, 0.5, 0.75]),
+            "y_true": jnp.array([1, 0, 1]),
+            "weights": jnp.array([0.5, 0.25, 0.0]),
+            "batch_size": 3,
+        },
+        {
+            # Test case where we have only one example.
+            "y_score": jnp.array([0.25]),
+            "y_true": jnp.array([1]),
+            "weights": jnp.ones(1),
+            "batch_size": 1,
+        },
+        {
+            # Test case where some examples are masked out.
+            "y_score": jnp.repeat(
+                jnp.array(
+                    [
+                        [9.9655354e-01, 3.7714792e-04, 3.7637529e-01],
+                        [1.7892958e-01, 3.9876872e-01, 9.9247831e-01],
+                    ]
+                ),
+                5,
+                axis=-1,
+            ).reshape(-1),
+            "y_true": jnp.array(
+                [
+                    [[0, 1, 1, 0, 1], [1, 0, 0, 1, 0], [0, 0, 1, 0, 0]],
+                    [[1, 1, 0, 0, 0], [1, 0, 1, 0, 1], [1, 1, 1, 1, 1]],
+                ]
+            )
+            .reshape(-1)
+            .astype(jnp.float32),
+            "weights": jnp.array(
+                [
+                    [
+                        [True, True, True, True, True],
+                        [True, False, True, True, True],
+                        [True, True, True, False, True],
+                    ],
+                    [
+                        [True, True, True, True, False],
+                        [True, True, True, True, True],
+                        [False, False, False, False, False],
+                    ],
+                ]
+            )
+            .reshape(-1)
+            .astype(jnp.float32),
+            "batch_size": 30,
+        },
+        {
             # Test case where we have non-integer y_score and all true negatives.
             "y_score": jnp.array([0.25, 0.75]),
             "y_true": jnp.array([0, 0]),
@@ -228,6 +287,7 @@ class TestMetrics(TestWithTemporaryCWD):
         assert_allclose(fps[valid_sample_idx], ref_fps)
         assert_allclose(tps[valid_sample_idx], ref_tps)
         assert_allclose(thresholds[valid_sample_idx], ref_thresholds)
+        assert_allclose(thresholds[-1], ref_thresholds[-1])
 
     @parameterized.parameters(
         {

--- a/axlearn/common/metrics_classification_test.py
+++ b/axlearn/common/metrics_classification_test.py
@@ -287,7 +287,6 @@ class TestMetrics(TestWithTemporaryCWD):
         assert_allclose(fps[valid_sample_idx], ref_fps)
         assert_allclose(tps[valid_sample_idx], ref_tps)
         assert_allclose(thresholds[valid_sample_idx], ref_thresholds)
-        assert_allclose(thresholds[-1], ref_thresholds[-1])
 
     @parameterized.parameters(
         {


### PR DESCRIPTION
The current precision_recall_curve computation is incorrect for weight=0 or masked examples.
The fix is to ignoring masked examples when computing tp, fp, and thresholds in binary_clf_curve.
Added more tests for checking masked examples are handled correctly.

In addition, fix precision_recall_curve to correctly handle weights and added tests as well.