### PR TITLE
Asynchronous save_tf_savables

### DIFF
--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -128,8 +128,7 @@ def _upload_dir(src_dir_handle: tempfile.TemporaryDirectory, *, dst_dir: str):
     Temporary dir will be deleted after the upload is complete.
     """
     src_dir = src_dir_handle.name
-    if not tf.io.gfile.exists(dst_dir):
-        tf.io.gfile.makedirs(dst_dir)
+    tf.io.gfile.makedirs(dst_dir)
     for item in tf.io.gfile.listdir(src_dir):
         src_file = tf.io.gfile.join(src_dir, item)
         dst_file = tf.io.gfile.join(dst_dir, item)


### PR DESCRIPTION
Save 5~9s during a checkpoint save on TPU. Achieved by first saving to a temporary local directory and then async upload to remote using tf.io.gfile.