### PR TITLE
Asynchronous save_tf_savables

### DIFF
--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -10,7 +10,9 @@ import queue
 import re
 import tempfile
 import threading
+import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from typing import Iterable, List, Optional, Sequence, Type, cast
 from unittest import mock
 
@@ -35,12 +37,12 @@ from axlearn.common.checkpointer import (
     CheckpointValidationType,
     EvalMetric,
     TensorStoreStateStorage,
+    async_save_tf_savables,
     check_state_structure,
     every_n_steps_and_last_policy,
     every_n_steps_policy,
     read_state_spec,
     restore_tf_savables,
-    save_tf_savables,
 )
 from axlearn.common.checkpointer_orbax import OrbaxCheckpointer
 from axlearn.common.metrics import WeightedScalar
@@ -840,6 +842,22 @@ class TensorStoreStateStorageTest(test_utils.TestCase):
                 storage._manager, array_serialization.GlobalAsyncCheckpointManager
             )
 
+    def test_stop(self):
+        storage = TensorStoreStateStorage.default_config().instantiate()
+        worker_result = None
+
+        def worker():
+            nonlocal worker_result
+            time.sleep(1)
+            worker_result = True
+
+        storage._executor.submit(worker)
+        storage.stop()
+        self.assertTrue(worker_result, "storage.stop() should wait for executor to finish.")
+
+        with self.assertRaisesRegex(RuntimeError, "cannot schedule new futures after shutdown"):
+            storage._executor.submit(worker)
+
     @parameterized.parameters(jnp.float32, jnp.bfloat16, jnp.int32, jnp.int16)
     def test_save_and_restore_from_dir(self, restore_floats_as: jnp.dtype):
         mesh_shape = (1, 1)
@@ -915,6 +933,7 @@ def _write_shards(lines: Iterable[str], *, path_prefix, num_shards) -> List[str]
 
 class TfIteratorTest(test_utils.TestCase):
     def test_restored_iterator_resumes(self):
+        executor = ThreadPoolExecutor(1)
         num_examples = 30
         tempdir = tempfile.mkdtemp()
         lines = [str(id) for id in range(num_examples)]
@@ -933,9 +952,15 @@ class TfIteratorTest(test_utils.TestCase):
                 # Save and restore the iterator.
                 ckpt_path = os.path.join(tempdir, "ckpt")
                 prev_it = it
-                save_tf_savables({"it": it}, dir=ckpt_path)
+                # Manually increase the delay of executor to test `it` mutation after
+                # call to async_save_tf_savables doesn't affect saving.
+                blocker = executor.submit(lambda: time.sleep(2))
+                f = async_save_tf_savables({"it": it}, executor=executor, dir=ckpt_path)
+                next(it)  # modify it in place
                 it = iter(ds)  # reset `it`.
                 self.assertIsNot(it, prev_it)
+                blocker.result()
+                f.result()  # wait for async save
                 restore_tf_savables({"it": it}, dir=ckpt_path)
             line = next(it).numpy()
             seen.append(int(line))


### PR DESCRIPTION
Save 5~9s during a checkpoint save on TPU. Achieved by first saving to a temporary local directory and then async upload to remote using tf.io.gfile. Re-opened after conflict resolution.