### PR TITLE
Data-sharded and zero-copy async checkpoints

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -65,6 +65,7 @@ Summary:
 * [tylin coco-caption](#tylin-coco-caption)
 * [Yet-Another-EfficientDet-Pytorch](#yet-another-efficientdet-pytorch)
 * [zihangdai xlnet](#zihangdai-xlnet)
+* [Orbax] (#orbax)
 
 ---
 ### [AI21Labs Jamba](https://huggingface.co/ai21labs/Jamba-v0.1)
@@ -9338,3 +9339,207 @@ Summary:
        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
        See the License for the specific language governing permissions and
        limitations under the License.
+
+### [Orbax](https://github.com/google/orbax)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -5,169 +5,404 @@
 # google/jax:
 # Copyright 2021 The JAX Authors.
 # Licensed under the Apache License, Version 2.0 (the "License").
+#
+# google/orbax:
+# Copyright [2024] The Orbax Authors.
+# Licensed under the Apache License, Version 2.0 (the "License").
 
 """Array serialization utilities.
 
 Reference:
+https://github.com/google/orbax/blob/3cc343c63c769e4b2df44f3e57f6b5b43569df32/checkpoint/orbax/checkpoint/serialization.py
 https://github.com/google/jax/blob/595a620804e810335a870e93975a78504b2e95e5/jax/experimental/array_serialization/serialization.py
 """
 
 import asyncio
 import functools
-from typing import Callable, Dict, List, Set
+import threading
+import time
+from collections import defaultdict
+from concurrent import futures
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import jax
+import numpy as np
 from absl import logging
-from jax._src.array import Shard
+from jax._src import array, config
 from jax.experimental.array_serialization import serialization
 
 from axlearn.common.utils import Tensor
 
 
-def _proxy(fut: asyncio.Future) -> asyncio.Future:
-    """Returns a proxy that can be used to await (but does not cancel) `fut`."""
-    loop = asyncio.get_event_loop()
-    proxy = loop.create_future()
+@dataclass
+class _ShardInfo:
+    """Stores information for a maybe sliced jax.Shard.
 
-    def callback(_):
-        # Callback may be invoked from a separate event loop.
-        if not loop.is_closed():
-            loop.call_soon_threadsafe(proxy.set_result, None)
-
-    fut.add_done_callback(callback)
-    return proxy
-
-
-async def _release(
-    limiter: serialization._LimitInFlightBytes,
-    commit: asyncio.Future,
-    nbytes: int,
-):
-    """Releases resources when `commit` completes."""
-    await _proxy(commit)
-    await limiter.release_bytes(nbytes)
-
-
-async def _acquire_and_write(
-    t,
-    *,
-    limiter: serialization._LimitInFlightBytes,
-    shard: Shard,
-    nbytes: int,
-    release_tasks: Set,
-):
-    """Initiates a write for the given shard.
-
-    This waits until `limiter` admits the shard, and blocks until the device-host copy is complete
-    before returning. The shard may be committed in an async fashion; the commit future is returned
-    so that the caller can await it at a later point in time.
+    Attributes:
+        data: The actual data of the shard.
+        index: The index of the shard.
+        slice_arg: Arguments for `lax.slice_in_dim` in the form of (start_idx, limit_idx, axis).
+            If `None`, it indicates that this shard doesn't need to be sliced.
+        replica_count: The replication count for this shard.
     """
-    await limiter.wait_for_bytes(nbytes)
-    # TODO(markblee): Investigate can_reference_source_data_indefinitely after updating tensorstore.
-    write_future = t[shard.index].write(shard.data)
-    await write_future.copy
-    # Release without blocking the event loop (commits can complete asynchronously).
-    release_task = asyncio.create_task(_release(limiter, write_future.commit, nbytes))
-    release_tasks.add(release_task)
-    release_task.add_done_callback(release_tasks.discard)
-    return write_future.commit
+
+    data: Tensor
+    index: Tuple[slice, ...]
+    slice_arg: Optional[Tuple[int, int, int]]
+    replica_count: int
 
 
-def _local_shards(array: Tensor) -> List[Shard]:
-    """Returns addressable shards with replica_id=0."""
-    return [shard for shard in array.addressable_shards if shard.replica_id == 0]
+# Tuple (and thus hashable) representation of a slice object (start, end, step).
+_SliceTuple = Tuple[Optional[int], Optional[int], Optional[int]]
 
 
-async def async_serialize(
-    array: Tensor,
-    tensorstore_spec: Dict,
+def _slices_to_tuple(slices: List[slice]) -> Tuple[_SliceTuple, ...]:
+    """Converts a list of slices to a hashable representation."""
+    return tuple(((s.start, s.stop, s.step) for s in slices))
+
+
+def _num_replicas_per_shard(arr: Tensor) -> Dict[Tuple[_SliceTuple, ...], int]:
+    """Gets the global replication count for each unique shard."""
+    replica_count = defaultdict(int)
+    for slices in arr.sharding.devices_indices_map(arr.shape).values():
+        # Slice() object is not hashable before python 3.12.
+        # Manually convert it to hashable types.
+        replica_count[_slices_to_tuple(slices)] += 1
+    return dict(replica_count)
+
+
+def _get_shard_infos(arr_inp: Tensor, *, max_data_shard_degree: int) -> List[_ShardInfo]:
+    """Returns a list of _ShardInfo for addressable shards that need to be saved.
+
+    If replica count for the shards are greater than 0, all replicas will save slices of the
+    shard provided that any dim of the shard is divisible by the replica count. If no such
+    dim exists, we fallback to only replica 0 saving the shard.
+    """
+    shard_infos: List[_ShardInfo] = []
+    replica_count_map = _num_replicas_per_shard(arr_inp)
+    for shard in arr_inp.addressable_shards:
+        replica_count = replica_count_map[_slices_to_tuple(shard.index)]
+        assert replica_count > 0
+        for axis, size in enumerate(shard.data.shape):
+            # Find the first dim divisible by partial replication size.
+            if max_data_shard_degree == 1 or replica_count == 1 or size % replica_count != 0:
+                continue
+            part_size = size // replica_count
+            slice_obj = shard.index[axis]
+            assert slice_obj.step is None
+            start_offset = shard.replica_id * part_size
+            end_offset = start_offset + part_size
+            # When an axis of a tensor is not sharded, the slice object corresponding to
+            # that axis will be (None, None, None).
+            slice_start = slice_obj.start or 0
+            shard_infos.append(
+                _ShardInfo(
+                    shard.data,
+                    shard.index[:axis]
+                    + (slice(slice_start + start_offset, slice_start + end_offset),)
+                    + shard.index[axis + 1 :],
+                    (start_offset, end_offset, axis),
+                    replica_count,
+                )
+            )
+            break
+        else:
+            # We only have 1 replica or shard is not evenly divisible across replicas.
+            # Assign replica=0 only.
+            if shard.replica_id == 0:
+                shard_infos.append(_ShardInfo(shard.data, shard.index, None, 1))
+    return shard_infos
+
+
+def _transfer_to_host(data: Tensor) -> Tensor:
+    """Asynchronously transfers a shard to host memory. Does not block.
+
+    modified from
+    https://github.com/google/orbax/blob/ebb3e6d75f9ccb52bf862f1740943a45b18f4dac/checkpoint/orbax/checkpoint/serialization.py#L268
+    """
+    device = list(data.devices())[0]
+    has_pinned_host = any(m.kind == "pinned_host" for m in device.addressable_memories())
+    if config.enable_memories.value and has_pinned_host:
+        # If available, transfer to pinned host memory.
+        data = jax.device_put(
+            data, jax.sharding.SingleDeviceSharding(device, memory_kind="pinned_host")
+        )
+    else:
+        data.copy_to_host_async()
+    return data
+
+
+async def _slice_shard_and_copy_to_host(shard_infos: List[_ShardInfo], d2h_future: futures.Future):
+    """Slices each shard according to shard info and then copy the sliced result to host.
+
+    The .data field of each shard_info is modified in-place.
+    """
+    # Note: jax.lax.slice_in_dim in _slice_fn will be cached in jit cache after first call.
+    shard_data = jax.tree_map(_slice_fn, shard_infos)
+    shard_data = jax.tree_map(_transfer_to_host, shard_data)
+
+    await asyncio.sleep(0)  # Allow other D2Hs to launch.
+
+    # No need to call jax.block_until_ready since np array conversion is blocking.
+    for info, data in zip(shard_infos, shard_data):
+        # Ensure that jax.Array's internal numpy array can be zero-copied. This guards
+        # against consumers like tensorstore that would otherwise copy silently.
+        info.data = np.array(data, copy=False)
+
+    d2h_future.set_result(shard_infos)
+    await asyncio.sleep(0)  # Allow other D2Hs to set result.
+
+
+def _slice_fn(info: _ShardInfo) -> Tensor:
+    """Performs slicing according to a shard_info and returns the sliced array."""
+    s = info.slice_arg
+    if s is not None:
+        return jax.lax.slice_in_dim(info.data, start_index=s[0], limit_index=s[1], axis=s[2])
+    return info.data
+
+
+def _local_size(arr_inp: Tensor) -> int:
+    """Calculates the size of a Tensor in bytes in the local process."""
+    return sum(shard.data.nbytes for shard in arr_inp.addressable_shards)
+
+
+def _fix_metadata(tspec: Dict[str, Any], shard_infos: List[_ShardInfo]):
+    """Revises the medadata of a tensorspec based on `shard_infos`."""
+    if len(shard_infos) != 0:
+        # All shards have the same shape after data-sharding, so using [0] is sufficient.
+        tspec["chunks"] = np.array(np.maximum(1, shard_infos[0].data.shape))
+    return tspec
+
+
+async def _async_serialize(
+    arr_inp: Tensor,
+    tensorstore_spec: Dict[str, Any],
+    d2h_future: futures.Future,
     *,
-    limiter: serialization._LimitInFlightBytes,
-) -> List[asyncio.Future]:
-    """Similar to `serialization.async_serialize`, but limiting peak host memory usage.
+    limiter: Optional[serialization._LimitInFlightBytes] = None,
+    max_data_shard_degree: Optional[int] = None,
+):
+    """Similar to `serialization.async_serialize`, but limiting peak host memory usage and sharding
+    along data-parallel axis.
 
     Specifically, TensorStores are opened only for shards which correspond to the current host, and
-    only if the current in-flight writes are below a user-supplied limit.
+    only if
+    1. Replica id of the shards is less than max_data_shard_degree or max_data_shard_degree is -1
+    2. Current in-flight writes are below a user-supplied limit.
 
-    We also simplify the API slightly by assuming replica_id=0 and primary_host=0, and by returning
-    commit futures rather than mutating an input array.
-
+    We also simplify the API slightly by assuming replica_id=0 and primary_host=0.
     Reference:
     https://github.com/google/jax/blob/595a620804e810335a870e93975a78504b2e95e5/jax/experimental/array_serialization/serialization.py#L188
     """
-    # pylint: disable=protected-access
+    shard_infos = _get_shard_infos(arr_inp, max_data_shard_degree=max_data_shard_degree)
+    if not shard_infos:
+        d2h_future.set_result(shard_infos)
+        return
+
+    nbytes = sum(info.data.nbytes // info.replica_count for info in shard_infos)
+    # Await for limiter before D2H.
+    if limiter is not None:
+        await limiter.wait_for_bytes(nbytes)
 
     # Fully addressable arrays lead to races between multiple writing hosts.
     assert not (
-        isinstance(array, serialization.array.ArrayImpl)
+        isinstance(arr_inp, array.ArrayImpl)
         and jax.process_count() > 1
-        and array.is_fully_addressable
+        and arr_inp.is_fully_addressable
     )
+    # pylint: disable-next=protected-access
     if not serialization._spec_has_metadata(tensorstore_spec):
-        tensorstore_spec["metadata"] = serialization._get_metadata(array)
+        # pylint: disable-next=protected-access
+        tensorstore_spec["metadata"] = serialization._get_metadata(arr_inp)
     if "dtype" not in tensorstore_spec:
-        tensorstore_spec["dtype"] = jax.numpy.dtype(array.dtype).name
+        tensorstore_spec["dtype"] = jax.numpy.dtype(arr_inp.dtype).name
 
+    # Original `arr_inp` might be deleted after this point.
+    await _slice_shard_and_copy_to_host(shard_infos, d2h_future)
+    # Fix metadata after slicing to get the right shape.
+    _fix_metadata(tensorstore_spec["metadata"], shard_infos)
+
+    # `ts.open` runs twice for process 0 because for the first time, we just get the future to be
+    # awaited upon in the background thread. The second one runs with `assume_metadata=True` which
+    # does no I/O operation and returns the tensorstore object. For every process other than `0`,
+    # we open with `assume_metadata=True`.
     if jax.process_index() == 0:
         await serialization.ts.open(
             serialization.ts.Spec(tensorstore_spec),
             create=True,
             open=True,
+            context=serialization.TS_CONTEXT,
         )
-
-    local_shards = _local_shards(array)
-    if not local_shards:
-        return []
-
-    # Opening with assume_metadata=True should incur no IO ops.
     t = await serialization.ts.open(
         serialization.ts.Spec(tensorstore_spec),
         open=True,
         assume_metadata=True,
         context=serialization.TS_CONTEXT,
     )
-    # Keep references to release() calls, since asyncio only keeps weak references to tasks:
-    # https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
-    release_tasks = set()
-    return await asyncio.gather(
+
+    # Avoid additional copy of input array into the TensorStore chunk cache. If `arr_inp` is a
+    # jax.Array, the result of converting it to a NumPy array, as is done internally by TensorStore,
+    # is guaranteed to be immutable and therefore it is safe to retain reference indefinitely.
+    is_jax_array = isinstance(arr_inp, jax.Array)
+    await asyncio.gather(
         *(
-            # Memory usage seems to be proportional to the array size rather than shard sizes.
-            # TODO(markblee): Investigate why this is the case.
-            _acquire_and_write(
-                t, limiter=limiter, shard=shard, nbytes=array.nbytes, release_tasks=release_tasks
-            )
-            for shard in local_shards
+            t[info.index].write(info.data, can_reference_source_data_indefinitely=is_jax_array)
+            for info in shard_infos
         )
     )
+    if limiter is not None:
+        await limiter.release_bytes(nbytes)
 
 
-class BoundedAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
-    """A concurrency-bounded implementation of JAX array serialization.
+async def _run_serializer(
+    arrays: List[Tensor],
+    tensorstore_specs: List[Dict[str, Any]],
+    d2h_futures: List[futures.Future],
+    *,
+    max_concurrent_bytes: Optional[int] = None,
+    max_data_shard_degree: Optional[int] = None,
+):
+    """Asynchronously serializes a list of tensors with _async_serialize."""
+    # We add 1 because LimitInFlightBytes expects a limit strictly greater than any request.
+    # pylint: disable=protected-access
+    limiter = (
+        serialization._LimitInFlightBytes(max_concurrent_bytes + 1)
+        if max_concurrent_bytes
+        else None
+    )
+    # pylint: enable=protected-access
+    future_writer = jax.tree_util.tree_map(
+        functools.partial(
+            _async_serialize, limiter=limiter, max_data_shard_degree=max_data_shard_degree
+        ),
+        arrays,
+        tensorstore_specs,
+        d2h_futures,
+    )
+    try:
+        await asyncio.gather(*future_writer)
+    # pylint: disable-next=broad-exception-caught
+    except Exception as e:
+        # If any _async_serialize call gives an exception, set future so the caller won't be
+        # blocked by future.result(). This handling is sufficient because other tasks cannot
+        # call set_result after set_exception in _run_serializer. The reason is that exception
+        # in asyncio.gather will yield to the awaiter immediately, and the exception handling
+        # code is fully synchronous. Therefore, no other synchronous code, including set_result,
+        # will be called during exception handling. Event loop will cancel immediately after
+        # _run_serializer exits, canceling all pending tasks.
+        for fut in d2h_futures:
+            if not fut.done():
+                fut.set_exception(e)
+        raise e
 
-    The main difference is that we attempt to keep at most `max_concurrent_gb` bytes in memory.
+
+# Reference:
+# https://github.com/google/orbax/blob/ebb3e6d75f9ccb52bf862f1740943a45b18f4dac/checkpoint/orbax/checkpoint/future.py#L49
+class _ThreadRaisingException(threading.Thread):
+    """Thread that raises an exception if it encounters an error."""
+
+    _exception: Optional[Exception] = None
+
+    def run(self):
+        try:
+            super().run()
+        # pylint: disable-next=broad-exception-caught
+        except Exception as e:
+            self._exception = e
+
+    def join(self, timeout=None):
+        super().join(timeout=timeout)
+        if self._exception is not None:
+            raise self._exception
+
+
+# Reference:
+# https://github.com/google/orbax/blob/ebb3e6d75f9ccb52bf862f1740943a45b18f4dac/checkpoint/orbax/checkpoint/type_handlers.py#L670
+class _CommitFuture:
+    """Represents the result of a background commit."""
+
+    def __init__(self, coro):
+        self._t = _ThreadRaisingException(target=lambda: asyncio.run(coro))
+        self._t.start()
+
+    def result(self, timeout: Optional[int] = None) -> Any:
+        return self._t.join(timeout=timeout)
+
+
+class BoundedDataShardedAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
+    """Similar to GlobalAsyncCheckpointManager but with few improvements:
+
+    1. Writing to tensorstore requires no host-to-host copy most of the time. This reduces host
+    memory usage while also reduces blocking time of the checkpointing process.
+    2. Tensorstore calls now run in a background event loop, hiding the cost of `ts.open` and
+    `ts.copy`. Now, only D2H blocks training while serialization is fully asynchronous.
+    3. Added additional sharding along data-parallel axis during save to further reduce host memory
+    overhead and improves D2H time. It's achieved by sharding the first dim that's divisible by the
+    data-parallel dim. We manipulate shard.index to match the sliced shard, so to tensorstore it
+    behaves as if we're sharding along the data-parallel axis. If no such dim is found, we use the
+    old way to save-restore, i.e. using the first (0th) replica to do the save only.
+    4. Optionally one can specify max_concurrent_gb to limit in-flight host memory during
+    device-to-host transfers and tensorstore writes.
+
+    Args:
+        max_concurrent_gb: Max concurrent shards (in GB) to write.
+        max_data_shard_degree: Max sharding degree of model weights along data-parallel axis.
+            `None` and `1` means no sharding. `-1` means fully shard along data-parallel
+            replicas. `>1` means custom sharding degree (currently not implemented).
+        timeout_secs: Barrier timeout in seconds.
     """
 
-    def __init__(self, *, max_concurrent_gb: int, timeout_secs: int = 300):
+    def __init__(
+        self,
+        *,
+        max_concurrent_gb: Optional[int] = None,
+        timeout_secs: int = 300,
+        max_data_shard_degree: Optional[int] = None,
+    ):
         super().__init__(timeout_secs)
-        if max_concurrent_gb <= 0:
-            raise ValueError("max_concurrent_gb must be strictly positive.")
-        self._max_concurrent_bytes = int(max_concurrent_gb * 10**9)
+        self._logged_spec = False
+
+        if max_concurrent_gb is None:
+            self._max_concurrent_bytes = None
+        else:
+            if max_concurrent_gb <= 0:
+                raise ValueError("max_concurrent_gb must be strictly positive.")
+            self._max_concurrent_bytes = int(max_concurrent_gb * 10**9)
+
+        self._max_data_shard_degree = max_data_shard_degree or 1
+        if self._max_data_shard_degree not in (1, -1):
+            raise NotImplementedError(
+                "max_data_shard_degree is not implemented for values other than 1 and -1"
+            )
+
+        # Required for pinned host memory to work correctly.
+        # TODO(hanzhi-zhou): Pinned host memory for GPU doesn't work until jax 0.4.32.
+        # Fix this after jax upgrade.
+        jax.config.update("jax_enable_memories", jax.default_backend() == "tpu")
 
     def serialize(
         self,
         arrays: List[Tensor],
-        tensorstore_specs: List[Dict],
+        tensorstore_specs: List[Dict[str, Any]],
         *,
         on_commit_callback: Callable[[], None],
     ):
         """See JAX `GlobalAsyncCheckpointManager` docstring."""
 
-        logging.info("Waiting for previous serialization to finish.")
+        start_t = time.time()
         self.wait_until_finished()
+        elapsed = time.time() - start_t
+        if elapsed > 1:
+            logging.warning(
+                "Waiting time on previous serialization to finish is %f > 1s. "
+                "Decreasing checkpointing frequency may improve performance.",
+                elapsed,
+            )
 
-        max_shard_bytes = max((0, *(array.nbytes for array in arrays)))
+        max_shard_bytes = max((0, *(_local_size(array) for array in arrays)))
         max_concurrent_bytes = self._max_concurrent_bytes
-        if max_shard_bytes > max_concurrent_bytes:
+        if max_concurrent_bytes is not None and max_shard_bytes > max_concurrent_bytes:
             logging.warning(
                 "Max shard size %s exceeds max_concurrent_bytes %s. "
                 "Will adjust max_concurrent_bytes to fit.",
@@ -176,25 +411,39 @@ class BoundedAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
             )
             max_concurrent_bytes = max_shard_bytes
 
-        async def _run_serializer(*, arrays, tensorstore_specs, max_concurrent_bytes):
-            # We add 1 because LimitInFlightBytes expects a limit strictly greater than any request.
-            # pylint: disable-next=protected-access
-            limiter = serialization._LimitInFlightBytes(max_concurrent_bytes + 1)
-            future_writer = jax.tree_util.tree_map(
-                functools.partial(async_serialize, limiter=limiter),
-                arrays,
-                tensorstore_specs,
-            )
-            return await asyncio.gather(*future_writer)
-
-        commit_futures = asyncio.run(
-            _run_serializer(
-                arrays=arrays,
-                tensorstore_specs=tensorstore_specs,
-                max_concurrent_bytes=max_concurrent_bytes,
-            ),
+        start_t = time.time()
+        d2h_futures = [futures.Future() for _ in arrays]
+        # Opens tensorstore and write data. This whole process happens in a
+        # different thread and is fully async, except D2H because we wait for
+        # then here.
+        self._add_futures(
+            [
+                _CommitFuture(
+                    _run_serializer(
+                        arrays,
+                        tensorstore_specs,
+                        d2h_futures,
+                        max_concurrent_bytes=max_concurrent_bytes,
+                        max_data_shard_degree=self._max_data_shard_degree,
+                    )
+                )
+            ]
         )
-        commit_futures = jax.tree_util.tree_flatten(commit_futures)[0]
-        self._add_futures(commit_futures)
-        logging.info("Starting async commit.")
+
+        # Block until D2H is complete and get shard_info for logging.
+        # Training can only proceed after D2H finishes.
+        shard_infos = [f.result() for f in d2h_futures]
+
+        if not self._logged_spec:
+            # Log this only once.
+            for arr, infos, spec in zip(arrays, shard_infos, tensorstore_specs):
+                logging.info(
+                    "Addressable shard shape: %s, saving shard shape: %s, spec: %s",
+                    str(arr.addressable_data(0).shape),
+                    "None" if len(infos) == 0 else str(infos[0].data.shape),
+                    str(spec),
+                )
+            self._logged_spec = True
+
+        logging.info("D2H during save took %fs. Starting async commit.", time.time() - start_t)
         self._start_async_commit(on_commit_callback)

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -27,7 +27,7 @@ from jax.experimental import mesh_utils
 from jax.experimental.array_serialization import serialization as array_serialization
 
 from axlearn.common import serialization, test_utils, utils
-from axlearn.common.array_serialization import BoundedAsyncCheckpointManager
+from axlearn.common.array_serialization import BoundedDataShardedAsyncCheckpointManager
 from axlearn.common.checkpointer import (
     BaseCheckpointer,
     BestMetricPolicy,
@@ -829,12 +829,14 @@ class CheckpointerTest(test_utils.TestCase):
 
 
 class TensorStoreStateStorageTest(test_utils.TestCase):
-    @parameterized.parameters(None, 1)
-    def test_max_concurrent_gb(self, max_concurrent_gb: Optional[int]):
-        cfg = TensorStoreStateStorage.default_config().set(max_concurrent_gb=max_concurrent_gb)
+    @parameterized.product(max_concurrent_gb=[None, 1], max_data_shard_degree=[None, 1, -1])
+    def test_max_concurrent_gb(self, max_concurrent_gb: Optional[int], max_data_shard_degree: int):
+        cfg = TensorStoreStateStorage.default_config().set(
+            max_concurrent_gb=max_concurrent_gb, max_data_shard_degree=max_data_shard_degree
+        )
         storage = cfg.instantiate()
-        if max_concurrent_gb is not None:
-            self.assertIsInstance(storage._manager, BoundedAsyncCheckpointManager)
+        if max_concurrent_gb is not None or max_data_shard_degree:
+            self.assertIsInstance(storage._manager, BoundedDataShardedAsyncCheckpointManager)
         else:
             self.assertIsInstance(
                 storage._manager, array_serialization.GlobalAsyncCheckpointManager


### PR DESCRIPTION
Similar to GlobalAsyncCheckpointManager but with few improvements:

1. Writing to tensorstore requires no host-to-host copy most of the time. This reduces host
memory usage while also reduces blocking time of the checkpointing process.
2. Tensorstore calls now run in a background event loop, hiding the cost of `ts.open` and `ts.copy`.
Now, only D2H blocks training while serialization is fully asynchronous.
3. Added additional sharding along data-parallel axis during save to further reduce host memory
overhead and improves D2H time. It's achieved by sharding the first dim that's divisible by the
data-parallel dim. We manipulate shard.index to match the sliced shard, so to tensorstore it
behaves as if we're sharding along the data-parallel axis. If no such dim is found, we use the
old way to save-restore, i.e. using the first (0th) replica to do the save only.
4. Optionally one can specify max_concurrent_gb to limit in-flight host memory during
device-to-host transfers and tensorstore writes.

Overall, this PR reduces the blocking time during checkpoint save by 10~60s (depending on how the model is sharded) and can reduce the host memory usage by N-fold where N is the replication count (=data parallel). Experiments show that this PR can solve OOM issues when training some large models.