### PR TITLE
Add job priority to k8s pod and node label

### DIFF
--- a/axlearn/cloud/gcp/node_pool_provisioner.py
+++ b/axlearn/cloud/gcp/node_pool_provisioner.py
@@ -2,12 +2,14 @@
 
 """Utilities to provision TPU node pools."""
 import hashlib
+import io
 import os
 import time
 from typing import Optional
 
 from absl import flags, logging
 
+from axlearn.cloud.common.bastion import _BASTION_SERIALIZED_JOBSPEC_ENV_VAR, deserialize_jobspec
 from axlearn.cloud.gcp.config import gcp_settings
 from axlearn.cloud.gcp.job import AcceleratorConfig, GKEJob, TPUGKEJob
 from axlearn.cloud.gcp.node_pool import (
@@ -96,6 +98,13 @@ class TPUNodePoolProvisioner(NodePoolProvisioner):
             use_spot_vm = True
             reservation = None
 
+        job_priority = None
+        if os.environ.get(_BASTION_SERIALIZED_JOBSPEC_ENV_VAR):
+            spec = deserialize_jobspec(
+                io.StringIO(os.environ.get(_BASTION_SERIALIZED_JOBSPEC_ENV_VAR))
+            )
+            job_priority = spec.metadata.priority
+
         node_pool_names = []
         additional_labels_list = []
         for i in range(num_node_pools):
@@ -113,6 +122,11 @@ class TPUNodePoolProvisioner(NodePoolProvisioner):
                 f"{job_cfg.namespace}/{job_cfg.name}-job-{i}".encode()
             ).hexdigest()
             additional_labels = {"job-key": job_key}
+
+            # Populate job-priority label to nodes.
+            if job_priority is not None:
+                additional_labels.update({"job-priority": str(job_priority)})
+
             additional_labels_list.append(additional_labels)
 
         start_time = time.perf_counter()

--- a/axlearn/cloud/gcp/node_pool_provisioner_test.py
+++ b/axlearn/cloud/gcp/node_pool_provisioner_test.py
@@ -3,11 +3,19 @@
 """Tests node_pool_provisioner module."""
 
 import contextlib
+import io
+from datetime import datetime
 from unittest import mock
 
 from absl import flags
 from absl.testing import parameterized
 
+from axlearn.cloud.common.bastion import (
+    _BASTION_SERIALIZED_JOBSPEC_ENV_VAR,
+    new_jobspec,
+    serialize_jobspec,
+)
+from axlearn.cloud.common.types import JobMetadata
 from axlearn.cloud.gcp import bundler, job, node_pool_provisioner
 from axlearn.cloud.gcp.bundler import ArtifactRegistryBundler
 from axlearn.cloud.gcp.job import TPUGKEJob
@@ -48,11 +56,38 @@ class TPUNodePoolProvisionerTest(parameterized.TestCase):
 
             yield job_cfg, provisioner_cfg
 
+    def _create_serialized_job_spec(self, job_priority):
+        test_spec = new_jobspec(
+            name="test_job",
+            command="test command",
+            metadata=JobMetadata(
+                user_id="test_id",
+                project_id="test_project",
+                # Make sure str timestamp isn't truncated even when some numbers are 0.
+                creation_time=datetime(1900, 1, 1, 0, 0, 0, 0),
+                resources={"test": 8},
+                priority=job_priority,
+            ),
+        )
+        serialized_jobspec = io.StringIO()
+        serialize_jobspec(test_spec, serialized_jobspec)
+        return serialized_jobspec.getvalue()
+
     @parameterized.parameters(
-        dict(num_replicas=1),
-        dict(num_replicas=2),
+        dict(num_replicas=1, job_priority=None),
+        dict(num_replicas=2, job_priority=1),
     )
-    def test_create_for(self, num_replicas: int):
+    def test_create_for(self, num_replicas: int, job_priority: int):
+        env = {}
+        if job_priority is not None:
+            env.update(
+                {
+                    _BASTION_SERIALIZED_JOBSPEC_ENV_VAR: self._create_serialized_job_spec(
+                        job_priority
+                    )
+                }
+            )  # pytype: disable=attribute-error
+
         mock_create_node_pools = mock.Mock()
         mock_construct_node_pool_name = mock.Mock()
 
@@ -62,7 +97,10 @@ class TPUNodePoolProvisionerTest(parameterized.TestCase):
             construct_node_pool_name=mock_construct_node_pool_name,
         )
 
-        with self._mock_configs(num_replicas) as [job_cfg, provisioner_cfg], mock_utils:
+        with self._mock_configs(num_replicas) as [
+            job_cfg,
+            provisioner_cfg,
+        ], mock_utils, mock.patch.dict("os.environ", env):
             tpu_gke_job = job_cfg.instantiate()
             provisioner = provisioner_cfg.set(name="pre-provisioner-0").instantiate()
 
@@ -70,6 +108,18 @@ class TPUNodePoolProvisionerTest(parameterized.TestCase):
 
             self.assertEqual(num_replicas, mock_construct_node_pool_name.call_count)
             self.assertEqual(1, mock_create_node_pools.call_count)
+
+            additional_labels_list = mock_create_node_pools.call_args.kwargs[
+                "additional_labels_list"
+            ]
+            self.assertEqual(num_replicas, len(additional_labels_list))
+
+            for additional_labels in additional_labels_list:
+                if job_priority is None:
+                    self.assertNotIn("job-priority", additional_labels.keys())
+                else:
+                    self.assertIn("job-priority", additional_labels.keys())
+                    self.assertEqual(str(job_priority), additional_labels.get("job-priority"))
 
     @parameterized.parameters(
         dict(num_replicas=1),


### PR DESCRIPTION
Adding job priority to k8s pod label so we can distinguish production jobs vs non-prod jobs while checking metrics