### PR TITLE
Speed up Axlearn CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
   build-and-test-job:
     executor: build-and-test-executor
     parallelism: 5
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
   build-and-test-job:
     executor: build-and-test-executor
     parallelism: 5
-    resource_class: xlarge
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   pre-commit:
     docker:
       - image: cimg/python:3.10
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - setup_remote_docker:
@@ -77,4 +77,3 @@ workflows:
       - build-and-test-job:
           requires:
             - hold
-            - pre-commit

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -51,12 +51,13 @@ if [[ "${SKIP_PRECOMMIT:-false}" = "false" ]] ; then
 fi
 
 UNQUOTED_PYTEST_FILES=$(echo $1 |  tr -d "'")
-pytest --durations=100 -n logical -v \
+pytest --durations=100 -v -n auto \
   -m "not (gs_login or tpu or high_cpu or fp64)" ${UNQUOTED_PYTEST_FILES} \
   --dist worksteal &
 TEST_PIDS[$!]=1
 
-JAX_ENABLE_X64=1 pytest -n auto -v -m "fp64" --dist worksteal &
+JAX_ENABLE_X64=1 pytest --duration=100 -v \
+    -n auto -v -m "fp64" ${UNQUOTED_PYTEST_FILES} --dist worksteal &
 TEST_PIDS[$!]=1
 
 # Use Bash 5.1's new wait -p feature to quit immediately if any subprocess fails to make error

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -51,7 +51,7 @@ if [[ "${SKIP_PRECOMMIT:-false}" = "false" ]] ; then
 fi
 
 UNQUOTED_PYTEST_FILES=$(echo $1 |  tr -d "'")
-pytest --durations=100 -n auto -v \
+pytest --durations=100 -n logical -v \
   -m "not (gs_login or tpu or high_cpu or fp64)" ${UNQUOTED_PYTEST_FILES} \
   --dist worksteal &
 TEST_PIDS[$!]=1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -56,7 +56,7 @@ pytest --durations=100 -v -n auto \
   --dist worksteal &
 TEST_PIDS[$!]=1
 
-JAX_ENABLE_X64=1 pytest --duration=100 -v \
+JAX_ENABLE_X64=1 pytest --durations=100 -v \
     -n auto -v -m "fp64" ${UNQUOTED_PYTEST_FILES} --dist worksteal &
 TEST_PIDS[$!]=1
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -56,8 +56,7 @@ pytest --durations=100 -v -n auto \
   --dist worksteal &
 TEST_PIDS[$!]=1
 
-JAX_ENABLE_X64=1 pytest --durations=100 -v \
-    -n auto -v -m "fp64" ${UNQUOTED_PYTEST_FILES} --dist worksteal &
+JAX_ENABLE_X64=1 pytest --durations=100 -v -n auto -v -m "fp64" --dist worksteal &
 TEST_PIDS[$!]=1
 
 # Use Bash 5.1's new wait -p feature to quit immediately if any subprocess fails to make error

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -59,7 +59,7 @@ TEST_PIDS[$!]=1
 JAX_ENABLE_X64=1 pytest -n auto -v -m "fp64" --dist worksteal &
 TEST_PIDS[$!]=1
 
-# Use Bash 5.2's new wait -p feature to quit immediately if any subprocess fails to make error
+# Use Bash 5.1's new wait -p feature to quit immediately if any subprocess fails to make error
 # finding a bit easier.
 while [ ${#TEST_PIDS[@]} -ne 0 ]; do
   wait -n -p PID ${!TEST_PIDS[@]} || exit_if_error $? "Test failed."

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -e -x
 
 # Install the package (necessary for CLI tests).
 # Requirements should already be cached in the docker image.
@@ -18,6 +18,7 @@ exit_if_error() {
 }
 
 download_assets() {
+  set -e -x
   mkdir -p axlearn/data/tokenizers/sentencepiece
   mkdir -p axlearn/data/tokenizers/bpe
   curl https://huggingface.co/t5-base/resolve/main/spiece.model -o axlearn/data/tokenizers/sentencepiece/t5-base
@@ -25,20 +26,42 @@ download_assets() {
   curl https://huggingface.co/FacebookAI/roberta-base/raw/main/vocab.json -o axlearn/data/tokenizers/bpe/roberta-base-vocab.json
 }
 
-set -o xtrace
-if [[ "${1:-x}" = "--skip-pre-commit" ]] ; then
-  SKIP_PRECOMMIT=true
-  shift
-fi
-UNQUOTED_PYTEST_FILES=$(echo $1 |  tr -d "'")
+precommit_checks() {
+  set -e -x
 
-# Skip pre-commit on parallel CI because it is run as a separate job.
-if [[ "${SKIP_PRECOMMIT:-false}" = "false" ]] ; then
-  pre-commit install
-  pre-commit run --all-files || exit_if_error $? "pre-commit failed."
-  # Run pytype separately to utilize all cpus and for better output.
-  pytype -j auto . || exit_if_error $? "pytype failed."
-fi
+  if [[ "${1:-x}" = "--skip-pre-commit" ]] ; then
+    SKIP_PRECOMMIT=true
+    shift
+  fi
+
+  # Skip pre-commit on parallel CI because it is run as a separate job.
+  if [[ "${SKIP_PRECOMMIT:-false}" = "false" ]] ; then
+    pre-commit install
+    pre-commit run --all-files || exit_if_error $? "pre-commit failed."
+    # Run pytype separately to utilize all cpus and for better output.
+    pytype -j auto . || exit_if_error $? "pytype failed."
+  fi
+}
+
+# Collect all background PIDs explicitly.
+TEST_PIDS=()
+
 download_assets
-pytest --durations=10 -n auto -v -m "not (gs_login or tpu or high_cpu or fp64)" ${UNQUOTED_PYTEST_FILES} || exit_if_error $? "pytest failed."
-JAX_ENABLE_X64=1 pytest -n auto -v -m "fp64" || exit_if_error $? "pytest failed."
+precommit_checks &
+TEST_PIDS[$!]=1
+
+UNQUOTED_PYTEST_FILES=$(echo $1 |  tr -d "'")
+pytest --durations=100 -n auto -v \
+  -m "not (gs_login or tpu or high_cpu or fp64)" ${UNQUOTED_PYTEST_FILES} \
+  --dist worksteal &
+TEST_PIDS[$!]=1
+
+JAX_ENABLE_X64=1 pytest -n auto -v -m "fp64" --dist worksteal &
+TEST_PIDS[$!]=1
+
+# Use Bash 5.2's new wait -p feature to quit immediately if any subprocess fails to make error
+# finding a bit easier.
+while [ ${#TEST_PIDS[@]} -ne 0 ]; do
+  wait -n -p PID ${!TEST_PIDS[@]} || exit_if_error $? "Test failed."
+  unset TEST_PIDS[$PID]
+done


### PR DESCRIPTION
Make a few minor tweaks to make Axlearn CI faster:
  * Use async mode to run different parts of the test
  * Use worksteal to more evenly distribute the workload

This should cut CI time by roughly half.