### PR TITLE
Adding support for Pathways proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Install dependencies.
 RUN pip install flit
 RUN pip install --upgrade pip
+COPY previewutilities-0.0.5-py3-none-any.whl previewutilities-0.0.5-py3-none-any.whl
+RUN pip install previewutilities-0.0.5-py3-none-any.whl
 
 ################################################################################
 # CI container spec.                                                           #

--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -113,7 +113,7 @@ def setup():
     logging.info("Devices: %s", devices)
     local_devices = jax.local_devices()
     logging.info("Local Devices: %s", local_devices)
-    if not devices or not all(device.platform == FLAGS.jax_backend for device in devices):
+    if FLAGS.jax_backend != "proxy" and (not devices or not all(device.platform == FLAGS.jax_backend for device in devices) ):
         raise RuntimeError(f"Expected backend {FLAGS.jax_backend}. Got {devices}.")
     if FLAGS.data_dir:
         # TODO(ruoming): Get rid of --data_dir and use only env var DATA_DIR.

--- a/axlearn/common/launch_trainer_main.py
+++ b/axlearn/common/launch_trainer_main.py
@@ -7,6 +7,7 @@ from absl import app, flags
 from axlearn.common import launch, launch_trainer, measurement
 from axlearn.common.config import config_for_function
 
+import previewutilities
 
 def main(_):
     measurement.initialize(flags.FLAGS)

--- a/axlearn/common/utils_spmd.py
+++ b/axlearn/common/utils_spmd.py
@@ -53,7 +53,7 @@ def setup(
         if initialization_timeout is not None:
             init_kwargs["initialization_timeout"] = initialization_timeout
 
-        if jax_backend == "tpu":
+        if jax_backend == "tpu" or jax_backend == "proxy":
             if not (
                 distributed_coordinator is None and num_processes is None and process_id is None
             ):
@@ -115,5 +115,6 @@ def setup(
                     f"({initialization_timeout} seconds)."
                 )
         else:
-            jax.distributed.initialize(**init_kwargs)
-            _jax_distributed_initialized = True
+            if jax_backend != "proxy":
+                jax.distributed.initialize(**init_kwargs)
+                _jax_distributed_initialized = True


### PR DESCRIPTION
Enable JAX+Pathways single-controller architecture for coordination of accelerators.
- Set jax_backend to "proxy"
- Additional logic to handle new jax_backend type
- Import previewutilities library to identify pathways-enabled workloads