### PR TITLE
Adds an fs abstraction and optimizes checkpoint glob.

### DIFF
--- a/axlearn/cloud/gcp/storage.py
+++ b/axlearn/cloud/gcp/storage.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 """Utilities to interact with Google Cloud Storage (GCS)."""
+# TODO(markblee): Deprecate and remove.
 
 import json
 import os

--- a/axlearn/cloud/gcp/tpu.py
+++ b/axlearn/cloud/gcp/tpu.py
@@ -23,8 +23,8 @@ from axlearn.cloud.common.types import ResourceMap
 from axlearn.cloud.common.utils import Table
 from axlearn.cloud.gcp.config import gcp_settings
 from axlearn.cloud.gcp.scopes import DEFAULT_TPU_SCOPES
-from axlearn.cloud.gcp.storage import list_blobs
 from axlearn.cloud.gcp.utils import validate_resource_name
+from axlearn.common import file_system as fs
 
 
 class TPUCreationError(RuntimeError):
@@ -191,7 +191,7 @@ def get_tpu_node_status(name: str, *, node: dict[str, Any]) -> dict[str, Union[s
             f"gs://{gcp_settings('ttl_bucket')}/axlearn/jobs/{name}/tpu_vm_ready_flags"
         )
         ready_flags_path = f"{ready_flags_base_path}/{node['metadata']['create_request_time']}/"
-        num_booted = len(list_blobs(ready_flags_path))
+        num_booted = len(fs.listdir(ready_flags_path))
     return dict(state=state, num_booted=num_booted)
 
 
@@ -425,7 +425,7 @@ def get_queued_tpu_node_status(name: str, *, node: dict[str, Any]) -> dict[str, 
         # Only one node spec is permitted (even though it's a list).
         create_request_time = node["tpu"]["nodeSpec"][0]["node"]["metadata"]["create_request_time"]
         ready_flags_path = f"{ready_flags_base_path}/{create_request_time}/"
-        num_booted = len(list_blobs(ready_flags_path))
+        num_booted = len(fs.listdir(ready_flags_path))
     return dict(state=state, num_booted=num_booted)
 
 

--- a/axlearn/cloud/gcp/tpu_test.py
+++ b/axlearn/cloud/gcp/tpu_test.py
@@ -23,6 +23,7 @@ from axlearn.cloud.gcp.tpu import (
     queued_resource_info_table,
     tpu_info_table,
 )
+from axlearn.common import file_system as fs
 
 
 class TpuUtilsTest(parameterized.TestCase):
@@ -233,13 +234,15 @@ class TpuUtilsTest(parameterized.TestCase):
             get_queued_tpu_node=mock.Mock(side_effect=nodes),
             _execute_create_tpu_request=mock.Mock(),
             delete_queued_tpu=mock.Mock(),
-            list_blobs=mock.Mock(side_effect=[list(range(x)) for x in list_blobs]),
+        )
+        mock_fs = mock.patch.multiple(
+            fs.__name__, listdir=mock.Mock(side_effect=[list(range(x)) for x in list_blobs])
         )
         mock_settings = mock_gcp_settings(
             module,
             settings={"project": "project", "zone": "zone", "ttl_bucket": "ttl_bucket"},
         )
-        with mock_sleep, mock_settings, mock_gcp:
+        with mock_sleep, mock_settings, mock_gcp, mock_fs:
             if isinstance(expected, Exception):
                 ctx = self.assertRaisesRegex(type(expected), str(expected))
             else:

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -29,6 +29,7 @@ from jax import numpy as jnp
 from jax.experimental import mesh_utils
 from jax.experimental.array_serialization import serialization as array_serialization
 
+from axlearn.common import file_system as fs
 from axlearn.common import serialization, test_utils, utils
 from axlearn.common.array_serialization import BoundedDataShardedAsyncCheckpointManager
 from axlearn.common.checkpointer import (
@@ -217,7 +218,7 @@ class CheckpointerTest(test_utils.TestCase):
                     )
                 else:
                     raise NotImplementedError(checkpointer_cls)
-                tf.io.gfile.makedirs(ckpt_dir)
+                fs.makedirs(ckpt_dir)
 
                 if checkpointer_cls is OrbaxCheckpointer:
                     assert not ocp.step.is_checkpoint_finalized(ckpt_dir)
@@ -928,7 +929,7 @@ def _write_shards(lines: Iterable[str], *, path_prefix, num_shards) -> list[str]
     filenames = [
         f"{path_prefix}-{shard_id:05d}-of-{num_shards:05d}" for shard_id in range(num_shards)
     ]
-    files = [tf.io.gfile.GFile(filename, "w") for filename in filenames]
+    files = [fs.open(filename, "w") for filename in filenames]
     for i, line in enumerate(lines):
         files[i % num_shards].write(line + "\n")
     return filenames

--- a/axlearn/common/eval_retrieval.py
+++ b/axlearn/common/eval_retrieval.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 """Retrieval evaluation pipeline."""
+
 import csv
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
@@ -9,11 +10,11 @@ from typing import Any, Callable, Optional
 
 import jax
 import numpy as np
-import tensorflow as tf
 from absl import logging
 from jax import numpy as jnp
 from jax.sharding import PartitionSpec
 
+from axlearn.common import file_system as fs
 from axlearn.common import utils
 from axlearn.common.attention import NEG_INF
 from axlearn.common.base_model import BaseModel
@@ -528,7 +529,7 @@ class CxcImageRetrievalMetricCalculator(EmbeddingRetrievalMetricCalculator):
 
 
 def _load_cxc_relevance(path: str) -> tuple[Tensor, dict[str, int]]:
-    with tf.io.gfile.GFile(path) as fin:
+    with fs.open(path) as fin:
         rows = list(csv.DictReader(fin))
     image_ids = sorted({row[k] for row in rows for k in ["image1", "image2"]})
     image_id_to_pos = {k: i for i, k in enumerate(image_ids)}

--- a/axlearn/common/evaler_test.py
+++ b/axlearn/common/evaler_test.py
@@ -4,6 +4,7 @@
 
 Some tests are intended to be run on TPU.
 """
+
 # pylint: disable=no-self-use
 import graphlib
 import json
@@ -24,6 +25,7 @@ from tensorflow.python.summary.summary_iterator import (  # pylint: disable=no-n
     summary_iterator,
 )
 
+from axlearn.common import file_system as fs
 from axlearn.common import param_init, test_utils
 from axlearn.common.base_layer import BaseLayer
 from axlearn.common.base_model import BaseModel
@@ -399,7 +401,7 @@ class EvalerTest(TestCase):
                     else:
                         assert sink == JsonlExampleRecordSink
                         num_output_records = 0
-                        with tf.io.gfile.GFile(actual_output_path) as f:
+                        with fs.open(actual_output_path) as f:
                             for line in f:
                                 record = json.loads(line)
                                 self.assertIsInstance(record["logits"], list)

--- a/axlearn/common/file_system.py
+++ b/axlearn/common/file_system.py
@@ -1,0 +1,167 @@
+# Copyright © 2024 Apple Inc.
+
+"""A file system interface supporting multiple cloud environments.
+
+Several libraries exist today to abstract file system management, including general purpose
+libraries like `tf.io` and `fsspec`, or specific libraries like `google-cloud-storage` SDK.
+
+This module provides a common interface between these options.
+"""
+# TODO(markblee): Consider supporting a pathlib-like interface.
+
+import contextlib
+import functools
+import os
+from typing import IO, TypeVar, Union
+from urllib.parse import urlparse
+
+import tensorflow as tf
+from absl import logging
+from tensorflow import errors as tf_errors
+
+
+@contextlib.contextmanager
+def _wrap_exception(
+    source_exc: Union[type[Exception], tuple[type[Exception], ...]], target_exc: type[Exception]
+):
+    """Surfaces any `source_exc` as `target_exc` instead.
+
+    Users can use multiple contexts to wrapping different `target_exc`, e.g:
+    ```
+    with (
+        _wrap_exception(tf_errors.OpError, OpError),
+        _wrap_exception(tf_errors.NotFound, NotFoundError),
+    ):
+        ...
+    ```
+
+    Note that contexts are entered in order and exited in reverse order, so more general exceptions
+    should be wrapped first.
+
+    Args:
+        source_exc: One or more exceptions to catch.
+        target_exc: Exception to raise instead.
+    """
+    try:
+        yield
+    except source_exc as e:
+        raise target_exc(str(e)) from e
+
+
+class OpError(Exception):
+    """FileSystem-level error."""
+
+
+class NotFoundError(OpError):
+    """Resource not found error."""
+
+
+_F = TypeVar("_F")
+
+
+# Wrapping errors allows us to change implementations without requiring callsites to change
+# exception handling behavior.
+def _wrap_tf_errors(fn: _F) -> _F:
+    @functools.wraps(fn)
+    def wrapped(*args, **kwargs):
+        with (
+            _wrap_exception(tf_errors.OpError, OpError),
+            _wrap_exception(tf_errors.NotFoundError, NotFoundError),
+        ):
+            return fn(*args, **kwargs)
+
+    return wrapped
+
+
+@functools.cache
+def _gs_client():
+    """Creates or retrieves the GCS client."""
+    # pylint: disable=import-outside-toplevel
+    # Avoid introducing a global dependency on `gcp`.
+    from google.cloud import storage  # pytype: disable=import-error
+
+    from axlearn.cloud.gcp.config import gcp_settings
+    from axlearn.cloud.gcp.utils import get_credentials
+
+    return storage.Client(project=gcp_settings("project"), credentials=get_credentials())
+
+
+@_wrap_tf_errors
+def isdir(path: str) -> bool:
+    """Analogous to tf.io.gfile.isdir."""
+    return tf.io.gfile.isdir(path)
+
+
+@_wrap_tf_errors
+def listdir(path: str) -> list[str]:
+    """Analogous to tf.io.gfile.listdir."""
+    return tf.io.gfile.listdir(path)
+
+
+@_wrap_tf_errors
+def glob(pattern: str) -> list[str]:
+    """Analogous to tf.io.gfile.glob."""
+    parsed = urlparse(pattern)
+
+    # tf.io.gfile.glob is prohibitively slow for gs paths containing many prefixes.
+    if parsed.scheme == "gs":
+        # https://googleapis.github.io/google-api-python-client/docs/dyn/storage_v1.objects.html#list
+        try:
+            # pylint: disable=import-outside-toplevel
+            from google.api_core.exceptions import GoogleAPIError
+            from google.api_core.exceptions import NotFound as GoogleAPINotFound
+
+            client = _gs_client()
+        except (ModuleNotFoundError, ImportError, RuntimeError, SystemExit) as e:
+            logging.warning("Failed to initialize gs client: %s. Falling back to slow glob.", e)
+        else:
+            bucket, prefix = parsed.netloc, parsed.path.lstrip("/")
+            # TODO(markblee): gsutil/gcloud storage seem to have custom logic for handling wildcards
+            # which is even more performant, but introduces extra complexity.
+            with (
+                _wrap_exception(GoogleAPIError, OpError),
+                _wrap_exception(GoogleAPINotFound, NotFoundError),
+            ):
+                return [
+                    os.path.join(f"gs://{bucket}", blob.name)
+                    for blob in client.list_blobs(bucket_or_name=bucket, match_glob=prefix)
+                ]
+
+    return tf.io.gfile.glob(pattern)
+
+
+@_wrap_tf_errors
+def exists(path: str) -> bool:
+    """Analogous to tf.io.gfile.exists."""
+    return tf.io.gfile.exists(path)
+
+
+@_wrap_tf_errors
+def remove(path: str):
+    """Analogous to tf.io.gfile.remove."""
+    return tf.io.gfile.remove(path)
+
+
+@_wrap_tf_errors
+def copy(src: str, dst: str, overwrite: bool = False):
+    """Analogous to tf.io.gfile.copy."""
+    return tf.io.gfile.copy(src, dst, overwrite=overwrite)
+
+
+@_wrap_tf_errors
+# pylint: disable-next=redefined-builtin
+def open(path: str, mode: str = "r") -> IO:
+    """Analogous to tf.io.gfile.GFile."""
+    return tf.io.gfile.GFile(path, mode)
+
+
+@_wrap_tf_errors
+def makedirs(path: str):
+    """Analogous to tf.io.gfile.makedirs."""
+    return tf.io.gfile.makedirs(path)
+
+
+@_wrap_tf_errors
+def rmtree(path: str):
+    """Analogous to tf.io.gfile.rmtree."""
+    return tf.io.gfile.rmtree(path)

--- a/axlearn/common/file_system_test.py
+++ b/axlearn/common/file_system_test.py
@@ -1,0 +1,249 @@
+# Copyright © 2024 Apple Inc.
+
+"""Tests fs utils."""
+# pylint: disable=protected-access
+
+import os
+from unittest import mock
+
+import pytest
+import tensorflow as tf
+from absl.testing import parameterized
+
+from axlearn.common import file_system as fs
+from axlearn.common.test_utils import TestWithTemporaryCWD
+
+
+def _make_paths(paths: list[str]):
+    for path in paths:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(path)
+
+
+class UtilsTest(parameterized.TestCase):
+    """Tests utils."""
+
+    def test_wrap_exception(self):
+        class CustomException(Exception):
+            pass
+
+        def fn():
+            raise ValueError("test")
+
+        with (
+            self.assertRaisesRegex(CustomException, "test"),
+            fs._wrap_exception(ValueError, CustomException),
+        ):
+            fn()
+
+    def test_wrap_tf_errors(self):
+        @fs._wrap_tf_errors
+        def fn():
+            raise tf.errors.NotFoundError("node_def", None, "test")
+
+        with self.assertRaisesRegex(fs.NotFoundError, "test"):
+            fn()
+
+
+class LocalTest(TestWithTemporaryCWD):
+    """Tests against local fs."""
+
+    def test_isdir(self):
+        dummy_file = os.path.join(self._temp_root.name, "test_file")
+        _make_paths([dummy_file])
+        self.assertTrue(fs.isdir(self._temp_root.name))
+        self.assertFalse(fs.isdir(dummy_file))
+
+    def test_listdir(self):
+        with self.assertRaisesRegex(fs.NotFoundError, "directory"):
+            fs.listdir(os.path.join(self._temp_root.name, "fake"))
+
+        self.assertEqual([], fs.listdir(self._temp_root.name))
+
+        dummy_file = os.path.join(self._temp_root.name, "test_file")
+        _make_paths([dummy_file])
+        self.assertCountEqual([os.path.basename(dummy_file)], fs.listdir(self._temp_root.name))
+
+    def test_glob(self):
+        _make_paths(
+            [
+                os.path.join(self._temp_root.name, "test_file"),
+                os.path.join(self._temp_root.name, "test_dir", "other_file"),
+                os.path.join(self._temp_root.name, "other_file"),
+            ]
+        )
+        self.assertCountEqual(
+            [
+                os.path.join(self._temp_root.name, "test_file"),
+                os.path.join(self._temp_root.name, "other_file"),
+            ],
+            fs.glob(os.path.join(self._temp_root.name, "*_file")),
+        )
+        self.assertCountEqual(
+            [
+                os.path.join(self._temp_root.name, "test_dir", "other_file"),
+            ],
+            fs.glob(os.path.join(self._temp_root.name, "test_dir/*_file")),
+        )
+        # Globbing a non-existent path is different from listdir.
+        self.assertEqual([], fs.glob(os.path.join(self._temp_root.name, "fake_dir")))
+        self.assertEqual([], fs.glob(os.path.join(self._temp_root.name, "fake_dir/*_file")))
+
+    def test_exists(self):
+        dummy_file = os.path.join(self._temp_root.name, "test_file")
+        self.assertFalse(fs.exists(dummy_file))
+        _make_paths([dummy_file])
+        self.assertTrue(fs.exists(dummy_file))
+
+    def test_remove(self):
+        dummy_file = os.path.join(self._temp_root.name, "test_file")
+        with self.assertRaises(fs.NotFoundError):
+            fs.remove(dummy_file)
+        _make_paths([dummy_file])
+        fs.remove(dummy_file)
+        with self.assertRaises(fs.NotFoundError):
+            fs.remove(dummy_file)
+
+    def test_copy(self):
+        src = os.path.join(self._temp_root.name, "src_file")
+        dst = os.path.join(self._temp_root.name, "dst_file")
+
+        with self.assertRaises(fs.NotFoundError):
+            fs.copy(src, dst)
+
+        _make_paths([src])
+        fs.copy(src, dst)
+
+        with fs.open(src) as sf, fs.open(dst) as df:
+            self.assertEqual(sf.read(), df.read())
+
+        src2 = os.path.join(self._temp_root.name, "src_file2")
+        _make_paths([src2])
+
+        with self.assertRaises(fs.OpError):
+            fs.copy(src2, dst, overwrite=False)
+        fs.copy(src2, dst, overwrite=True)
+
+        with fs.open(src2) as sf, fs.open(dst) as df:
+            self.assertEqual(sf.read(), df.read())
+
+    def test_open(self):
+        src = os.path.join(self._temp_root.name, "src_file")
+        _make_paths([src])
+        with fs.open(src) as f:
+            self.assertIn("src_file", f.read())
+
+    def test_makedirs(self):
+        test_dir = os.path.join(self._temp_root.name, "src_dir")
+        self.assertFalse(fs.exists(test_dir))
+        fs.makedirs(test_dir)
+        self.assertTrue(fs.isdir(test_dir))
+
+        test_file = os.path.join(self._temp_root.name, "src_file")
+        _make_paths([test_file])
+        with self.assertRaisesRegex(fs.OpError, "src_file"):
+            fs.makedirs(test_file)
+
+    def test_rmtree(self):
+        paths = [
+            os.path.join(self._temp_root.name, "dir", "nested_dir", "nested_file"),
+            os.path.join(self._temp_root.name, "dir", "test_file"),
+            os.path.join(self._temp_root.name, "top_file"),
+        ]
+        base_dir = os.path.join(self._temp_root.name, "dir")
+        self.assertFalse(fs.exists(base_dir))
+
+        with self.assertRaises(fs.NotFoundError):
+            fs.rmtree(base_dir)
+        _make_paths(paths)
+        self.assertTrue(fs.isdir(base_dir))
+        fs.rmtree(base_dir)
+
+        self.assertFalse(fs.exists(base_dir))
+        self.assertTrue(fs.exists(os.path.join(self._temp_root.name, "top_file")))
+
+
+class GsTest(TestWithTemporaryCWD):
+    """Tests against gs."""
+
+    def test_glob_mocked(self):
+        try:
+            # pylint: disable-next=import-outside-toplevel
+            from google.api_core.exceptions import GoogleAPIError, NotFound
+        except (ImportError, ModuleNotFoundError) as e:
+            pytest.skip(reason=f"Missing dependencies: {e}")
+
+        self.assertIsInstance(GoogleAPIError("test"), Exception)
+        self.assertIsInstance(NotFound("test"), Exception)
+
+        # Test a case where we fail to init the client.
+        with (
+            mock.patch("tensorflow.io.gfile.glob", return_value="mocked_tfio"),
+            mock.patch(f"{fs.__name__}._gs_client", side_effect=RuntimeError()),
+        ):
+            self.assertEqual("mocked_tfio", fs.glob("gs://dummy/path"))
+
+        # Test a happy case with `client.list_blobs`.
+        bucket_name = "test-bucket"
+        _make_paths(
+            [
+                os.path.join(self._temp_root.name, "dummy/file1"),
+                os.path.join(self._temp_root.name, "dummy/file2"),
+            ]
+        )
+
+        def list_blobs(bucket_or_name, match_glob):
+            self.assertEqual(bucket_name, bucket_or_name)
+            blobs = []
+            for path in fs.glob(os.path.join(self._temp_root.name, match_glob)):
+                blob = mock.Mock()
+                blob.name = path.replace(self._temp_root.name, "").lstrip("/")
+                blobs.append(blob)
+            return blobs
+
+        mock_client = mock.Mock()
+        mock_client.list_blobs.side_effect = list_blobs
+
+        with mock.patch(f"{fs.__name__}._gs_client", return_value=mock_client):
+            self.assertCountEqual(
+                ["gs://test-bucket/dummy/file2", "gs://test-bucket/dummy/file1"],
+                fs.glob(f"gs://{bucket_name}/dummy/file*"),
+            )
+            self.assertCountEqual(
+                ["gs://test-bucket/dummy/file1"],
+                fs.glob(f"gs://{bucket_name}/dummy/file1"),
+            )
+
+        # Test a case where `client.list_blobs` raises.
+        def raise_api_error(*args, **kwargs):
+            raise GoogleAPIError("test")
+
+        mock_client = mock.Mock()
+        mock_client.list_blobs.side_effect = raise_api_error
+
+        with (
+            self.assertRaises(fs.OpError),
+            mock.patch(f"{fs.__name__}._gs_client", return_value=mock_client),
+        ):
+            fs.glob(f"gs://{bucket_name}/dummy")
+
+        # Test a case where `client.list_blobs` raises NotFound.
+        def raise_not_found(*args, **kwargs):
+            raise NotFound("test")
+
+        mock_client = mock.Mock()
+        mock_client.list_blobs.side_effect = raise_not_found
+
+        with (
+            self.assertRaises(fs.NotFoundError),
+            mock.patch(f"{fs.__name__}._gs_client", return_value=mock_client),
+        ):
+            fs.glob(f"gs://{bucket_name}/dummy")
+
+    @pytest.mark.gs_login
+    def test_glob(self):
+        self.assertCountEqual(
+            fs.glob("gs://axlearn-public/testdata/gcp_test/tmp"),
+            tf.io.gfile.glob("gs://axlearn-public/testdata/gcp_test/tmp"),
+        )

--- a/axlearn/common/inference_output.py
+++ b/axlearn/common/inference_output.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 """A library to support writing inference outputs."""
+
 import json
 import os.path
 from typing import Optional, Union
@@ -10,6 +11,7 @@ import numpy as np
 import tensorflow as tf
 from jax import numpy as jnp
 
+from axlearn.common import file_system as fs
 from axlearn.common.config import REQUIRED, Required, config_class
 from axlearn.common.module import Module
 from axlearn.common.utils import (
@@ -71,7 +73,7 @@ def _tf_feature(value: Union[Tensor, tf.Tensor]) -> tf.train.Feature:
 
 
 def _json_feature(
-    value: Union[Tensor, tf.Tensor]
+    value: Union[Tensor, tf.Tensor],
 ) -> Union[int, float, bool, str, list[Union[int, float, bool, str]]]:
     if isinstance(value, tf.Tensor):
         value = value.numpy()
@@ -113,7 +115,7 @@ class TfExampleRecordSink(BaseRecordSink):
             process_count=jax.process_count(),
         )
 
-        tf.io.gfile.makedirs(os.path.dirname(output_path))
+        fs.makedirs(os.path.dirname(output_path))
         self._writer = tf.io.TFRecordWriter(output_path)
 
     def write(self, record: NestedTensor):
@@ -154,8 +156,8 @@ class JsonlExampleRecordSink(BaseRecordSink):
             process_index=jax.process_index(),
             process_count=jax.process_count(),
         )
-        tf.io.gfile.makedirs(os.path.dirname(output_path))
-        self._writer = tf.io.gfile.GFile(output_path, "w")
+        fs.makedirs(os.path.dirname(output_path))
+        self._writer = fs.open(output_path, "w")
 
     def write(self, record: NestedTensor):
         feature_dict = {path: _json_feature(value) for path, value in flatten_items(record)}

--- a/axlearn/common/input_tf_data.py
+++ b/axlearn/common/input_tf_data.py
@@ -7,6 +7,7 @@
 
 # pylint: disable=too-many-lines
 """Input generator based on tf.data."""
+
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, Callable, Optional, Union
 
@@ -28,6 +29,7 @@ from jax.experimental import multihost_utils
 from seqio import map_over_dataset
 from typing_extensions import Protocol
 
+from axlearn.common import file_system as fs
 from axlearn.common.config import (
     REQUIRED,
     ConfigBase,
@@ -358,7 +360,7 @@ def tfrecord_dataset(
 
     def fn() -> tf.data.Dataset:
         num_parallel_calls_for_read = read_parallelism if is_training else 1
-        glob_files = tf.io.gfile.glob(glob_path)
+        glob_files = fs.glob(glob_path)
         # Shuffle files to avoid deterministic loading.
         filenames = tf.data.Dataset.from_tensor_slices(glob_files)
         if is_training and shuffle_buffer_size > 0:

--- a/axlearn/common/launch_trainer.py
+++ b/axlearn/common/launch_trainer.py
@@ -7,9 +7,9 @@ import os
 from typing import Any, Optional
 
 import jax
-import tensorflow as tf
 from absl import flags, logging
 
+from axlearn.common import file_system as fs
 from axlearn.common import measurement
 from axlearn.common.trainer import SpmdTrainer, select_mesh_config
 from axlearn.common.utils import MeshShape, get_data_dir, infer_mesh_shape
@@ -113,11 +113,11 @@ def run_trainer(trainer_config: SpmdTrainer.Config) -> Any:
     logging.info("Trainer config:\n%s", trainer_config_debug_string)
     if jax.process_index() == 0:
         trainer_config_file = os.path.join(trainer_config.dir, "trainer_config")
-        with tf.io.gfile.GFile(trainer_config_file, "w") as f:
+        with fs.open(trainer_config_file, "w") as f:
             f.write(trainer_config_debug_string)
 
         config_file = os.path.join(trainer_config.dir, "launch_trainer_flags")
-        with tf.io.gfile.GFile(config_file, "w") as f:
+        with fs.open(config_file, "w") as f:
             json.dump(
                 {
                     **FLAGS.flag_values_dict(),

--- a/axlearn/common/summary_writer.py
+++ b/axlearn/common/summary_writer.py
@@ -12,11 +12,11 @@ from typing import Any, Callable, Optional
 
 import jax
 import numpy as np
-import tensorflow as tf
 from absl import logging
 from jax import numpy as jnp
 from tensorflow import summary as tf_summary
 
+from axlearn.common import file_system as fs
 from axlearn.common.config import REQUIRED, ConfigBase, Required, RequiredFieldValue, config_class
 from axlearn.common.module import Module
 from axlearn.common.summary import AudioSummary, ImageSummary, Summary
@@ -336,13 +336,13 @@ class WandBWriter(BaseWriter):
         wandb_file = os.path.join(cfg.dir, "wandb_id")
         if cfg.resume == "never":
             exp_id = None
-        elif tf.io.gfile.exists(wandb_file):  # pytype: disable=module-attr
-            with tf.io.gfile.GFile(wandb_file, "r") as f:  # pytype: disable=module-attr
+        elif fs.exists(wandb_file):  # pytype: disable=module-attr
+            with fs.open(wandb_file, "r") as f:  # pytype: disable=module-attr
                 exp_id = f.read().strip()
         else:
             exp_id = wandb.util.generate_id()
-            tf.io.gfile.makedirs(cfg.dir)  # pytype: disable=module-attr
-            with tf.io.gfile.GFile(wandb_file, "w") as f:  # pytype: disable=module-attr
+            fs.makedirs(cfg.dir)  # pytype: disable=module-attr
+            with fs.open(wandb_file, "w") as f:  # pytype: disable=module-attr
                 f.write(exp_id)
 
         wandb.init(

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -12,12 +12,12 @@ from collections.abc import Sequence
 from typing import Any, Callable, ContextManager, Literal, NamedTuple, Optional, Union
 
 import jax
-import tensorflow as tf
 from absl import logging
 from jax import numpy as jnp
 from jax.experimental import multihost_utils
 from jax.experimental.pjit import pjit
 
+from axlearn.common import file_system as fs
 from axlearn.common import measurement, utils
 from axlearn.common.base_layer import ParameterSpec
 from axlearn.common.base_model import BaseModel
@@ -719,7 +719,7 @@ class SpmdTrainer(Module):
 
             # Log trainer state tree.
             if jax.process_index() == 0:
-                with tf.io.gfile.GFile(os.path.join(cfg.dir, "trainer_state_tree.txt"), "w") as f:
+                with fs.open(os.path.join(cfg.dir, "trainer_state_tree.txt"), "w") as f:
                     f.write(str(jax.tree_util.tree_structure(self._trainer_state)))
 
         self._log_trainer_state_stats()

--- a/axlearn/experiments/text/train_spm.py
+++ b/axlearn/experiments/text/train_spm.py
@@ -48,6 +48,7 @@ import seqio
 import tensorflow as tf
 from absl import app, flags, logging
 
+from axlearn.common import file_system as fs
 from axlearn.common import input_tf_data
 
 
@@ -187,10 +188,10 @@ def main(_):
         logging.info("Decoded: %s", vocab.decode(ids))
     # Copy the files to the output dir.
     output_dir = FLAGS.output_dir or os.path.join(FLAGS.data_dir, "tokenizers", "sentencepiece")
-    for vocab_file in tf.io.gfile.glob(f"{model_name}*"):
+    for vocab_file in fs.glob(f"{model_name}*"):
         output_file = os.path.join(output_dir, os.path.basename(vocab_file))
         logging.info("Copying %s to %s", vocab_file, output_file)
-        tf.io.gfile.copy(vocab_file, output_file, overwrite=True)
+        fs.copy(vocab_file, output_file, overwrite=True)
 
 
 if __name__ == "__main__":

--- a/axlearn/huggingface/hf_module.py
+++ b/axlearn/huggingface/hf_module.py
@@ -10,11 +10,11 @@ from typing import Any, Callable, Optional
 
 import jax.numpy as jnp
 import jax.random
-import tensorflow as tf
 from absl import logging
 from transformers.configuration_utils import PretrainedConfig
 from transformers.modeling_flax_utils import FlaxPreTrainedModel
 
+from axlearn.common import file_system as fs
 from axlearn.common.adapter_flax import config_for_flax_module
 from axlearn.common.base_layer import ParameterSpec
 from axlearn.common.base_model import BaseModel
@@ -55,13 +55,13 @@ def download_hf_models_from_remote(remote_path: str) -> str:
     local_pretrained_model_path = cache_dir / model_name
     if not local_pretrained_model_path.exists():
         local_pretrained_model_path.mkdir(parents=True)
-        for filename in tf.io.gfile.listdir(remote_path):
+        for filename in fs.listdir(remote_path):
             logging.info(
                 "Downloading %s to %s",
                 os.path.join(remote_path, filename),
                 local_pretrained_model_path / filename,
             )
-            tf.io.gfile.copy(
+            fs.copy(
                 os.path.join(remote_path, filename),
                 str(local_pretrained_model_path / filename),
             )


### PR DESCRIPTION
- Add a thin fs wrapper on top of `tf.io.gfile`, which allows us to plug-in a native google-cloud-sdk implementation for glob (this is significantly more efficient than `tf.io.gfile` for paths with many objects, but still has a gap with `gsutil`).
- Update `checkpointer_paths` to use list+exists, which does not need to assume an efficient glob implementation on the fs.