### PR TITLE
Fix race condition while doing async tf save.

### DIFF
--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -330,6 +330,42 @@ class _CommitFuture:
         return self._t.join(timeout=timeout)
 
 
+class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
+    """Similar to GlobalAsyncCheckpointManager but allows passing additional futures to wait while
+    asynchronously serializing tensors.
+    """
+
+    def serialize(
+        self,
+        arrays: list[Tensor],
+        tensorstore_specs: list[dict],
+        *,
+        on_commit_callback: Callable[[], None],
+        additional_futures: Optional[list[futures.Future]] = None,
+    ):
+        logging.info("Waiting for previous serialization to finish.")
+        self.wait_until_finished()
+
+        commit_futures = [[] for _ in range(len(tensorstore_specs))]
+
+        # pylint: disable-next=redefined-outer-name
+        async def _run_serializer():
+            future_writer = jax.tree_util.tree_map(
+                serialization.async_serialize, arrays, tensorstore_specs, commit_futures
+            )
+            return await asyncio.gather(*future_writer)
+
+        asyncio.run(_run_serializer())
+
+        self._add_futures(
+            jax.tree_util.tree_flatten(commit_futures)[0] + (additional_futures or [])
+        )
+
+        # Used in wait_until_finished to check on process != 0, if the checkpoint
+        # has finished writing.
+        self._start_async_commit(on_commit_callback)
+
+
 class BoundedDataShardedAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
     """Similar to GlobalAsyncCheckpointManager but with few improvements:
 
@@ -387,6 +423,7 @@ class BoundedDataShardedAsyncCheckpointManager(serialization.GlobalAsyncCheckpoi
         tensorstore_specs: list[dict],
         *,
         on_commit_callback: Callable[[], None],
+        additional_futures: Optional[list[futures.Future]] = None,
     ):
         """See JAX `GlobalAsyncCheckpointManager` docstring."""
 
@@ -428,6 +465,7 @@ class BoundedDataShardedAsyncCheckpointManager(serialization.GlobalAsyncCheckpoi
                     )
                 )
             ]
+            + (additional_futures or [])
         )
 
         # Block until D2H is complete and get shard_info for logging.

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -331,8 +331,8 @@ class _CommitFuture:
 
 
 class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
-    """Similar to GlobalAsyncCheckpointManager but allows passing additional futures to wait while
-    asynchronously serializing tensors.
+    """Similar to GlobalAsyncCheckpointManager but allows passing additional futures to be awaited
+    while asynchronously serializing tensors.
     """
 
     def serialize(


### PR DESCRIPTION
We fix the race condition by allowing tf save futures to be waited along side with tensor serialization futures. This works because futures are awaited before `on_commit_callback` is run. No fix is needed for orbax checkpointer code path since orbax should've taken care of future awaiting internally.

An alternative fix would be using jax's distributed client as a barrier, but I think it's better to avoid adding another synchronization point. 