### PR TITLE
Add CuDNN fused MHA kernel to axlearn

### DIFF
--- a/axlearn/common/flash_attention/gpu_attention.py
+++ b/axlearn/common/flash_attention/gpu_attention.py
@@ -38,11 +38,16 @@ import jax.numpy as jnp
 
 # pytype: disable=import-error  # pylint: disable=import-error
 from jax import lax
+from jax._src.cudnn.fused_attention_stablehlo import (
+    MaskType,
+    _dot_product_attention,
+    _normalize_layout,
+    check_cudnn_version,
+)
+from jax._src.lib import cuda_versions
 from jax.experimental import pallas as pl
 
 from axlearn.common.attention import NEG_INF
-
-# pytype: enable=import-error  # pylint: enable=import-error
 
 Tensor = jax.Array
 
@@ -185,6 +190,8 @@ def _mha_forward_kernel(
     pl.store(o_ref, (curr_q_slice, pl.dslice(None)), acc)
 
 
+# TODO(kelvin-zou): may decide to deprecate the triton backend if we can fully move to
+# more low-level CUDA kernels.
 @functools.partial(jax.custom_vjp, nondiff_argnums=[4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
 @functools.partial(
     jax.jit,
@@ -666,3 +673,96 @@ def _mha_backward(
 
 
 flash_attention.defvjp(_mha_forward, _mha_backward)
+
+
+def check_local_compute_capability(cc):
+    if cuda_versions is None:
+        raise RuntimeError("cuDNN is not detected.")
+    for i in range(jax.local_device_count()):
+        compute_cap = cuda_versions.cuda_compute_capability(i)
+        if compute_cap not in cc:
+            raise RuntimeError("Require compute capability in " + str(cc))
+
+
+# Interface to cuDNN's dot product attention.
+# TODO(kelvin-zou): Verify dropout rate functions.
+# TODO(kelvin-zou): Add support for segment IDs.
+def cudnn_dot_product_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    bias: Optional[Tensor] = None,
+    mask: Optional[Tensor] = None,
+    causal: bool = False,
+    *,
+    softmax_scale: float = 1.0,
+    seed: int = 42,
+    dropout_rate: float = 0.0,
+    qkv_layout: str = "BTNH",
+):
+    """Computes dot-product attention given query (Q), key (K), and value (V).
+
+    Reference implementation:
+    https://github.com/google/jax/blob/f4158ace933482844c145a6b919bf5dc86e084ba/jax/_src/cudnn/fused_attention_stablehlo.py#L927.
+    https://github.com/openxla/xla/blob/536ba0b7d74f6637a7a772471a99ecf4f578aef2/xla/service/gpu/cublas_cudnn.cc#L77.
+
+    We override the Jax fused multihead attention(fMHA) interface in axlearn
+    due to following reasons:
+    1. Original Jax implementation has a bug to support multi-node training (fixed in jax 0.4.32).
+    2. We may want to leverage more lower level CuDNN capabilities from xla and expose to users.
+
+    Args:
+        query: Query of shape [batch_size, target_length, num_heads, per_head_dim].
+        key: Key of shape [batch_size, source_length, num_heads, per_head_dim].
+        value: Value of shape [batch_size, source_length, num_heads, per_head_dim].
+        bias: Optional logit biases of shape [batch_size, num_heads, target_length, source_length].
+        mask: Optional logit mask of shape [batch_size, num_heads, target_length, source_length].
+        softmax_scale: Optional scale to apply to softmax. Defaults to 1/sqrt(per_head_dim).
+        seed: Random seed for dropout.
+        dropout_rate: Dropout rate.
+        qkv_layout: Layout string, with supported formats being BTNH, BNTH, BSNH,
+                    BNSH. Now it only supports BTNH.
+
+    Returns:
+        Output of the same shape as the query.
+
+    Raises:
+        NotImplementedError: If qkv_layout is not supported.
+    """
+
+    if qkv_layout != "BTNH":
+        raise NotImplementedError(f"Unsupported qkv_layout: {qkv_layout}")
+    # check if cuDNN is installed.
+    cudnn_version = check_cudnn_version()
+    # only support Ampere and Hopper for now.
+    check_local_compute_capability((80, 90))
+    mask_type = MaskType.NO_MASK if not causal else MaskType.CAUSAL
+    layout = _normalize_layout(qkv_layout)
+
+    has_bias = bias is not None
+    has_mask = mask is not None
+    has_dbias = False
+    variadic_args = (has_bias, has_mask, has_dbias)
+    if bias is None:
+        bias = jnp.zeros(0, dtype=query.dtype)
+    if mask is None:
+        mask = jnp.zeros(0, dtype=query.dtype)
+    q_seqlen = jnp.zeros(0, dtype=query.dtype)
+    kv_seqlen = jnp.zeros(0, dtype=query.dtype)
+    output = _dot_product_attention(
+        query,
+        key,
+        value,
+        bias,
+        mask,
+        q_seqlen,
+        kv_seqlen,
+        softmax_scale,
+        seed,
+        dropout_rate,
+        variadic_args,
+        mask_type,
+        layout.value,
+        cudnn_version,
+    )
+    return output

--- a/axlearn/common/flash_attention/gpu_attention.py
+++ b/axlearn/common/flash_attention/gpu_attention.py
@@ -675,7 +675,16 @@ def _mha_backward(
 flash_attention.defvjp(_mha_forward, _mha_backward)
 
 
-def check_local_compute_capability(cc):
+def _check_local_compute_capability(cc: Any):
+    """Check if the local devices meet the required compute capability.
+
+    Args:
+        cc: Required compute capability.
+
+    Raises:
+        RuntimeError: cuDNN is not detected.
+        RuntimeError: compute capability does not match the target.
+    """
     if cuda_versions is None:
         raise RuntimeError("cuDNN is not detected.")
     for i in range(jax.local_device_count()):
@@ -735,7 +744,7 @@ def cudnn_dot_product_attention(
     # Check if cuDNN is installed.
     cudnn_version = check_cudnn_version()
     # Support Ampere and Hopper only for now.
-    check_local_compute_capability((80, 90))
+    _check_local_compute_capability((80, 90))
     mask_type = MaskType.NO_MASK if not causal else MaskType.CAUSAL
     layout = _normalize_layout(qkv_layout)
 

--- a/axlearn/common/flash_attention/gpu_attention.py
+++ b/axlearn/common/flash_attention/gpu_attention.py
@@ -231,7 +231,7 @@ def flash_attention(
         key: Key of shape [batch_size, source_length, num_heads, per_head_dim].
         value: Value of shape [batch_size, source_length, num_heads, per_head_dim].
         bias: Optional logit biases of shape [batch_size, num_heads, target_length, source_length].
-        softmax_scale: Optional scale to apply to softmax. Defaults to 1/sqrt(per_head_dim).
+        softmax_scale: Optional scale to apply to softmax. Defaults to 1.
         causal: Whether to apply causal mask.
         **kwargs: Pallas/triton kwargs.
 
@@ -717,7 +717,7 @@ def cudnn_dot_product_attention(
         value: Value of shape [batch_size, source_length, num_heads, per_head_dim].
         bias: Optional logit biases of shape [batch_size, num_heads, target_length, source_length].
         mask: Optional logit mask of shape [batch_size, num_heads, target_length, source_length].
-        softmax_scale: Optional scale to apply to softmax. Defaults to 1/sqrt(per_head_dim).
+        softmax_scale: Optional scale to apply to softmax. Defaults to 1.
         seed: Random seed for dropout.
         dropout_rate: Dropout rate.
         qkv_layout: Layout string, with supported formats being BTNH, BNTH, BSNH,
@@ -732,9 +732,9 @@ def cudnn_dot_product_attention(
 
     if qkv_layout != "BTNH":
         raise NotImplementedError(f"Unsupported qkv_layout: {qkv_layout}")
-    # check if cuDNN is installed.
+    # Check if cuDNN is installed.
     cudnn_version = check_cudnn_version()
-    # only support Ampere and Hopper for now.
+    # Support Ampere and Hopper only for now.
     check_local_compute_capability((80, 90))
     mask_type = MaskType.NO_MASK if not causal else MaskType.CAUSAL
     layout = _normalize_layout(qkv_layout)

--- a/axlearn/common/flash_attention/gpu_attention_benchmark.py
+++ b/axlearn/common/flash_attention/gpu_attention_benchmark.py
@@ -73,7 +73,10 @@ import jax.numpy as jnp
 import triton  # pytype: disable=import-error
 from jax.experimental.pallas.ops.gpu.attention import mha as pallas_mha
 
-from axlearn.common.flash_attention.gpu_attention import flash_attention
+from axlearn.common.flash_attention.gpu_attention import (
+    cudnn_dot_product_attention,
+    flash_attention,
+)
 from axlearn.common.flash_attention.utils import mha_reference
 
 
@@ -86,9 +89,9 @@ def _perf_report(prefix: str):
         x_names=["batch_size"],
         x_vals=[2, 4, 8, 16],
         line_arg="library",
-        line_vals=["jax", "jax-triton", "jax-pallas"],
-        line_names=["Jax", "Jax Triton", "Pallas"],
-        styles=[("blue", "-"), ("purple", "-"), ("green", "-")],
+        line_vals=["jax", "jax-triton", "jax-pallas", "jax-cudnn"],
+        line_names=["Jax", "Jax Triton", "Pallas", "jax-cudnn"],
+        styles=[("blue", "-"), ("purple", "-"), ("green", "-"), ("red", "-")],
         ylabel="ms",
         plot_name=f"{prefix}-head{num_heads}-seq1024-d{per_head_dim}",
         args={"num_heads": num_heads, "seq_len": 1024, "per_head_dim": per_head_dim},
@@ -98,9 +101,9 @@ def _perf_report(prefix: str):
         x_names=["num_heads"],
         x_vals=[12, 16, 32, 48, 72],
         line_arg="library",
-        line_vals=["jax", "jax-triton", "jax-pallas"],
-        line_names=["Jax", "Jax Triton", "Pallas"],
-        styles=[("blue", "-"), ("purple", "-"), ("green", "-")],
+        line_vals=["jax", "jax-triton", "jax-pallas", "jax-cudnn"],
+        line_names=["Jax", "Jax Triton", "Pallas", "jax-cudnn"],
+        styles=[("blue", "-"), ("purple", "-"), ("green", "-"), ("red", "-")],
         ylabel="ms",
         plot_name=f"{prefix}-batch{batch_size}-seq{seq_len}-d{per_head_dim}",
         args={"batch_size": batch_size, "seq_len": seq_len, "per_head_dim": per_head_dim},
@@ -110,9 +113,9 @@ def _perf_report(prefix: str):
         x_names=["seq_len"],
         x_vals=[2**i for i in range(7, 12)],  # 128 to 2048.
         line_arg="library",
-        line_vals=["jax", "jax-triton", "jax-pallas"],
-        line_names=["Jax", "Jax Triton", "Pallas"],
-        styles=[("blue", "-"), ("purple", "-"), ("green", "-")],
+        line_vals=["jax", "jax-triton", "jax-pallas", "jax-cudnn"],
+        line_names=["Jax", "Jax Triton", "Pallas", "jax-cudnn"],
+        styles=[("blue", "-"), ("purple", "-"), ("green", "-"), ("red", "-")],
         ylabel="ms",
         plot_name=f"{prefix}-batch{batch_size}-head{num_heads}-d{per_head_dim}",
         args={"batch_size": batch_size, "num_heads": num_heads, "per_head_dim": per_head_dim},
@@ -122,9 +125,9 @@ def _perf_report(prefix: str):
         x_names=["per_head_dim"],
         x_vals=[16, 32, 64, 128],
         line_arg="library",
-        line_vals=["jax", "jax-triton", "jax-pallas"],
-        line_names=["Jax", "Jax Triton", "Pallas"],
-        styles=[("blue", "-"), ("purple", "-"), ("green", "-")],
+        line_vals=["jax", "jax-triton", "jax-pallas", "jax-cudnn"],
+        line_names=["Jax", "Jax Triton", "Pallas", "jax-cudnn"],
+        styles=[("blue", "-"), ("purple", "-"), ("green", "-"), ("red", "-")],
         ylabel="ms",
         plot_name=f"{prefix}-batch{batch_size}-head{num_heads}-seq{seq_len}",
         args={"batch_size": batch_size, "num_heads": num_heads, "seq_len": seq_len},
@@ -158,6 +161,8 @@ def bench_flash_attention(
             fn = lambda: flash_attention(q, k, v, bias, causal=True)
         elif "pallas" in library:
             fn = lambda: pallas_mha(q, k, v, segment_ids=None, causal=True)
+        elif "cudnn" in library:
+            fn = lambda: cudnn_dot_product_attention(q, k, v, bias=bias, causal=True)
         else:
             fn = lambda: mha_reference(q, k, v, bias, causal=True)
         ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
@@ -203,6 +208,14 @@ def bench_flash_attention_backward(
 
             pallas_bwd = jax.grad(pallas_fn, argnums=(0, 1, 2))
             fn = lambda: pallas_bwd(q, k, v)
+        elif "cudnn" in library:
+
+            @jax.jit
+            def cudnn_fn(q, k, v):
+                return cudnn_dot_product_attention(q, k, v, bias=bias, causal=True).sum()
+
+            cudnn_bwd = jax.grad(cudnn_fn, argnums=(0, 1, 2))
+            fn = lambda: cudnn_bwd(q, k, v)
         else:
 
             @jax.jit

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -21,9 +21,11 @@ import chex
 import jax
 import jax.numpy as jnp
 import pytest
-from jax.experimental.pallas.ops.gpu.attention import mha as pallas_mha
 
-from axlearn.common.flash_attention.gpu_attention import flash_attention
+from axlearn.common.flash_attention.gpu_attention import (
+    cudnn_dot_product_attention,
+    flash_attention,
+)
 from axlearn.common.flash_attention.utils import mha_reference
 
 
@@ -174,56 +176,59 @@ def test_bwd_against_ref(
     chex.assert_trees_all_close(jax_grads, jax_ref_grads, atol=0.05)
 
 
-# We also include a test for Triton with Pallas, to cross validate the triton
-# compatibility with our own implementation.
+# We test the cudnn_dot_product_attention against the reference flash_attention.
+# Due to its algorithmic equivalence, the outputs should be close in both fp16 and bfloat16.
 @pytest.mark.parametrize(
     "batch_size,num_heads,seq_len,per_head_dim",
     [
-        (2, 2, 384, 64),
+        (1, 2, 2048, 128),
+        (2, 2, 2048, 128),
+        (1, 4, 4096, 128),
+        (2, 8, 4096, 128),
     ],
 )
 @pytest.mark.parametrize("causal", [True, False])
-@pytest.mark.parametrize("bias_type", ["none", "vector"])
+@pytest.mark.parametrize("dtype", [jnp.bfloat16, jnp.float16])
 @pytest.mark.skipif(jax.devices()[0].platform != "gpu", reason="Test only runs on GPU.")
-def test_mha_against_pallas_ref(
+def test_cudnn_against_triton_ref(
     batch_size: int,
     num_heads: int,
     seq_len: int,
     per_head_dim: int,
     causal: bool,
-    bias_type: str,
+    dtype: jnp.dtype,
 ):
     q = jax.random.normal(
-        jax.random.PRNGKey(0), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+        jax.random.PRNGKey(0), (batch_size, seq_len, num_heads, per_head_dim), dtype=dtype
     )
     k = jax.random.normal(
-        jax.random.PRNGKey(1), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+        jax.random.PRNGKey(1), (batch_size, seq_len, num_heads, per_head_dim), dtype=dtype
     )
     v = jax.random.normal(
-        jax.random.PRNGKey(2), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
+        jax.random.PRNGKey(2), (batch_size, seq_len, num_heads, per_head_dim), dtype=dtype
     )
     # Make sure that it is running on GPU.
     assert str(q.devices()) == "{cuda(id=0)}"
 
     sm_scale = q.shape[-1] ** -0.5
-    if bias_type == "vector":
-        segment_left = jnp.ones((batch_size, seq_len // 2), dtype=jnp.int32)
-        segment_right = jnp.zeros((batch_size, seq_len // 2), dtype=jnp.int32)
-        segment_ids = jnp.concatenate([segment_left, segment_right], axis=-1)
-    else:
-        segment_ids = None
+
     # Compare outputs.
-    jax_out = mha_reference(q, k, v, bias=segment_ids, causal=causal, softmax_scale=sm_scale)
-    jax_ref_out = pallas_mha(q, k, v, segment_ids=segment_ids, causal=causal, sm_scale=sm_scale)
-    chex.assert_trees_all_close(jax_out, jax_ref_out, atol=0.005, rtol=1e-5)
+    jax_out = cudnn_dot_product_attention(q, k, v, bias=None, causal=causal, softmax_scale=sm_scale)
+    jax_ref_out = flash_attention(q, k, v, bias=None, causal=causal, softmax_scale=sm_scale)
+    # We relax the atol to support both fp16 and bf16 in the unit test.
+    chex.assert_trees_all_close(jax_out, jax_ref_out, atol=0.02, rtol=1e-5)
 
     def fn(q, k, v):
-        return mha_reference(q, k, v, bias=segment_ids, causal=causal, softmax_scale=sm_scale).sum()
+        return cudnn_dot_product_attention(
+            q, k, v, bias=None, causal=causal, softmax_scale=sm_scale
+        ).sum()
 
     def ref_fn(q, k, v):
-        return pallas_mha(q, k, v, segment_ids=segment_ids, causal=causal, sm_scale=sm_scale).sum()
+        return flash_attention(q, k, v, bias=None, causal=causal, softmax_scale=sm_scale).sum()
 
     # Compare gradients.
     jax_grads = jax.grad(fn, argnums=(0, 1, 2))(q, k, v)
     jax_ref_grads = jax.grad(ref_fn, argnums=(0, 1, 2))(q, k, v)
-    chex.assert_trees_all_close(jax_grads, jax_ref_grads, atol=0.05, rtol=1e-5)
+    # We relax the rtol to support both fp16 and bf16 in the unit test.
+    # The diff between grads are expected to be larger than the forward pass.
+    chex.assert_trees_all_close(jax_grads, jax_ref_grads, atol=0.05, rtol=1e-2)

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -220,6 +220,8 @@ def test_cudnn_against_triton_ref(
         chex.assert_trees_all_close(jax_out, jax_ref_out, atol=0.02, rtol=1e-5)
     elif dtype == jnp.float16:
         chex.assert_trees_all_close(jax_out, jax_ref_out, atol=0.005, rtol=1e-5)
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")
 
     def fn(q, k, v):
         return cudnn_dot_product_attention(
@@ -238,3 +240,5 @@ def test_cudnn_against_triton_ref(
         chex.assert_trees_all_close(jax_grads, jax_ref_grads, atol=0.05, rtol=1e-2)
     elif dtype == jnp.float16:
         chex.assert_trees_all_close(jax_grads, jax_ref_grads, atol=0.05, rtol=1e-5)
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -74,6 +74,7 @@ class FlashAttention(GroupedQueryAttention):
         _check_bias_recursively(cfg)  # Bias not supported.
         if getattr(cfg, "atten_logit_cap", None) is not None:
             raise NotImplementedError("cfg.atten_logit_cap is not supported.")
+        # TODO(kelvinzou): enable dropout for flash attention.
         if cfg.dropout.rate:
             raise NotImplementedError("cfg.dropout.rate is not supported.")
         if cfg.tpu_block_size % 128 != 0:

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -238,6 +238,8 @@ def get_trainer_kwargs(
                 # Maximum per-node batch size = 64, hence need >= 32 nodes.
                 # Without sequence sharding, the maximum number of devices <= batch_size,
                 # so at most 512 GPUs (64 nodes) for training 7B-v3.
+                # v2 on gpu-p5.48xlarge-256, step time: 1.78s/step, MFU 39%.
+                # TODO(kelvin-zou): need to match 1.5s/step perf on TransformerEngine.
                 (
                     "gpu-(p5.48xlarge|p4de.24xlarge|a3-highgpu-8g)-(256|512|1024)",
                     mesh_shape_from_axes(data=-1, fsdp=8),


### PR DESCRIPTION
Porting the jax._src.cudnn.fused_attention_stablehlo kernel and change flash attention to cudnn backend for GPU.

Quality check passed.
Training speed for fuji-7b-v2:
2.3s/step (with triton flash attention kernel)  -> 1.78s/step 