### PR TITLE
Publish Job Event from Bastion and GKE Runner

### DIFF
--- a/axlearn/cloud/common/bastion.py
+++ b/axlearn/cloud/common/bastion.py
@@ -77,6 +77,7 @@ except ModuleNotFoundError:
     logging.warning("tensorflow_io is not installed -- tf_io may not work with s3://")
 
 from axlearn.cloud.common.cleaner import Cleaner
+from axlearn.cloud.common.event_queue import BaseQueueClient, Event
 from axlearn.cloud.common.quota import QuotaFn
 from axlearn.cloud.common.scheduler import BaseScheduler, JobMetadata, JobScheduler, ResourceMap
 from axlearn.cloud.common.types import JobSpec
@@ -88,6 +89,7 @@ from axlearn.common.config import (
     Required,
     config_class,
     config_for_function,
+    maybe_instantiate,
 )
 from axlearn.common.utils import Nested
 
@@ -151,6 +153,64 @@ class JobStatus(str, enum.Enum):
     CLEANING = "CLEANING"
     # Job is complete.
     COMPLETED = "COMPLETED"
+
+
+# Subclass str to be JSON serializable: https://stackoverflow.com/a/51976841
+class JobLifecycleState(str, enum.Enum):
+    """Represents a lifecycle state for a job.
+
+    The lifecycle state is meant for fine-grained reporting and tracking of job state transitions.
+    For the states corresponding to bastion's internal state machine, see `JobStatus`.
+    """
+
+    # Job is queued. Bastion detects the new job's jobspec.
+    QUEUED = "QUEUED"
+    # Job is starting. Command is start to run.
+    STARTING = "STARTING"
+    # Job is running.
+    RUNNING = "RUNNING"
+    # Job is pre-empting.
+    PREEMPTING = "PREEMPTING"
+    # Job is rescheduling.
+    RESCHEDULING = "RESCHEDULING"
+    # Job is cancelling. Command is terminating.
+    CANCELLING = "CANCELLING"
+    # Job has completed/terminated the command, is running cleanup command (if any).
+    CLEANING = "CLEANING"
+    # Job is failed.
+    FAILED = "FAILED"
+    # Job finished successfully.
+    SUCCEEDED = "SUCCEEDED"
+    # Job is complete.
+    COMPLETED = "COMPLETED"
+
+
+@dataclasses.dataclass
+class JobLifecycleEvent(Event):
+    """Represents a lifecycle event for a job.
+
+    Attributes:
+        job_name: The name of the job associated with this event.
+        state: The state of the job.
+        details: The details of the state info.
+        job_id: An optional identifier for the job. Defaults to None.
+    """
+
+    job_name: str
+    state: JobLifecycleState
+    details: str
+    job_id: Optional[str] = None
+
+    def serialize(self) -> str:
+        """Serializes the job lifecycle event into a JSON string."""
+        job_event = {
+            "job_name": self.job_name,
+            "job_id": self.job_id,
+            "message": self.details,
+            "state": self.state,
+            "timestamp": time.time_ns(),
+        }
+        return json.dumps(job_event)
 
 
 class ValidationError(ValueError):
@@ -605,6 +665,8 @@ class Bastion(Configurable):
         output_dir: Required[str] = REQUIRED
         # The quota function to use for getting user group membership and group quota.
         quota: Required[QuotaFn] = REQUIRED
+        # The event publisher sends events into queue.
+        event_publisher: Optional[BaseQueueClient.Config] = None
 
     def __init__(self, cfg: Config):
         super().__init__(cfg)
@@ -646,11 +708,22 @@ class Bastion(Configurable):
         ).instantiate()
         self._cleaner: Cleaner = cfg.cleaner.instantiate()
         self._uploader = cfg.uploader.set(src_dir=_LOG_DIR, dst_dir=self._log_dir).instantiate()
+        self._event_publisher = maybe_instantiate(cfg.event_publisher)
 
-    def _append_to_job_history(self, job: Job, msg: str):
+    def _append_to_job_history(self, job: Job, *, msg: str, state: JobLifecycleState):
         with tf_io.gfile.GFile(os.path.join(self._job_history_dir, f"{job.spec.name}"), "a") as f:
             curr_time = datetime.now(timezone.utc).strftime("%m%d %H:%M:%S")
             f.write(f"{curr_time} {msg}\n")
+        # Publish event into queue.
+        if self._event_publisher:
+            self._event_publisher.publish(
+                JobLifecycleEvent(
+                    job_name=job.spec.name,
+                    job_id=job.spec.metadata.job_id,
+                    state=state,
+                    details=msg,
+                )
+            )
 
     def _append_to_project_history(
         self, jobs: dict[str, JobMetadata], schedule_results: BaseScheduler.ScheduleResults
@@ -784,7 +857,13 @@ class Bastion(Configurable):
             if job_name not in self._active_jobs:
                 logging.info("Detected new job %s.", job_name)
                 self._active_jobs[job_name] = active_jobs[job_name]
-                self._append_to_job_history(active_jobs[job_name], "PENDING: detected jobspec")
+                self._append_to_job_history(
+                    active_jobs[job_name],
+                    msg="PENDING: detected jobspec",
+                    # When Bastion restarts, we will see this for every job.
+                    # Leave to consumer to handle this case.
+                    state=JobLifecycleState.QUEUED,
+                )
             # Detected removed job: exists locally, but not in remote.
             elif job_name not in active_jobs:
                 job = self._active_jobs[job_name]
@@ -826,7 +905,9 @@ class Bastion(Configurable):
             # 2. Any job logs are sync'ed to remote log dir. The local log file cannot reliably be
             #    expected to be present if/when the job is resumed.
             if job.command_proc is not None:
-                self._append_to_job_history(job, "PENDING: pre-empting")
+                self._append_to_job_history(
+                    job, msg="PENDING: pre-empting", state=JobLifecycleState.PREEMPTING
+                )
                 logging.info("Pre-empting job: %s", job.spec.name)
                 self._wait_and_close_proc(job.command_proc, kill=True)
                 job.command_proc = None
@@ -838,8 +919,9 @@ class Bastion(Configurable):
             if job.command_proc is None:
                 self._append_to_job_history(
                     job,
-                    f"ACTIVE: start process command: {job.spec.command} "
+                    msg=f"ACTIVE: start process command: {job.spec.command} "
                     f"with metadata: {job.state.metadata}",
+                    state=JobLifecycleState.STARTING,
                 )
             env_vars = {f"BASTION_{k.upper()}": v for k, v in job.state.metadata.items()}
             serialized_jobspec = io.StringIO()
@@ -854,7 +936,9 @@ class Bastion(Configurable):
 
             # If command is completed, move to CLEANING. Otherwise, it's still RUNNING.
             if _is_proc_complete(job.command_proc):
-                self._append_to_job_history(job, "CLEANING: process finished")
+                self._append_to_job_history(
+                    job, msg="CLEANING: process finished", state=JobLifecycleState.CLEANING
+                )
                 logging.info(
                     "Job %s stopped gracefully: %s.",
                     job.spec.name,
@@ -866,11 +950,17 @@ class Bastion(Configurable):
             # If job is still running, terminate it. We stay in CANCELLING until it has fully
             # exited, after which we move to CLEANING.
             if job.command_proc is not None and not _is_proc_complete(job.command_proc):
-                self._append_to_job_history(job, "CANCELLING: terminating the process")
+                self._append_to_job_history(
+                    job,
+                    msg="CANCELLING: terminating the process",
+                    state=JobLifecycleState.CANCELLING,
+                )
                 logging.info("Sending SIGTERM to job: %s", job.spec.name)
                 job.command_proc.popen.terminate()
             else:
-                self._append_to_job_history(job, "CLEANING: process terminated")
+                self._append_to_job_history(
+                    job, msg="CLEANING: process terminated", state=JobLifecycleState.CLEANING
+                )
                 job.state.status = JobStatus.CLEANING
 
         elif job.state.status == JobStatus.CLEANING:
@@ -886,14 +976,18 @@ class Bastion(Configurable):
             # every time, in case bastion got pre-empted.
             if job.spec.cleanup_command and not job.cleanup_proc:
                 self._append_to_job_history(
-                    job, f"CLEANING: start cleanup command: {job.spec.cleanup_command}"
+                    job,
+                    msg=f"CLEANING: start cleanup command: {job.spec.cleanup_command}",
+                    state=JobLifecycleState.CLEANING,
                 )
             _start_cleanup_command(job)
 
             # If job has no cleanup command, or cleanup command is complete, transition to
             # COMPLETED.
             if job.cleanup_proc is None or _is_proc_complete(job.cleanup_proc):
-                self._append_to_job_history(job, "COMPLETED: cleanup finished")
+                self._append_to_job_history(
+                    job, msg="COMPLETED: cleanup finished", state=JobLifecycleState.COMPLETED
+                )
                 logging.info("Job %s finished running cleanup.", job.spec.name)
                 if job.cleanup_proc is not None:
                     self._wait_and_close_proc(job.cleanup_proc)
@@ -973,7 +1067,9 @@ class Bastion(Configurable):
                         # see whether this is necessary.
                         assert job.state.status == JobStatus.ACTIVE and changed_tiers
                         self._append_to_job_history(
-                            job, f"Rescheduling at a different tier from {old_tier} to {new_tier}"
+                            job,
+                            msg=f"Rescheduling at a different tier from {old_tier} to {new_tier}",
+                            state=JobLifecycleState.RESCHEDULING,
                         )
                         job.state.status = JobStatus.PENDING
                 else:

--- a/axlearn/cloud/common/event_queue.py
+++ b/axlearn/cloud/common/event_queue.py
@@ -1,0 +1,253 @@
+# Copyright © 2024 Apple Inc.
+
+"""Tools to publish events."""
+
+import logging
+import os
+import time
+import uuid
+from typing import Optional, Protocol
+
+from absl import flags
+
+try:
+    import pika
+
+    _PIKA_INSTALLED = True
+except (ImportError, ModuleNotFoundError):
+    _PIKA_INSTALLED = False
+
+from axlearn.common.config import REQUIRED, Configurable, Required, config_class
+
+# Suppress Pika logs.
+logging.getLogger("pika").setLevel(logging.WARNING)
+
+# Configured key name of queue id.
+CONFIGURED_KEY_JOB_EVENT_QUEUE_ID = "job_event_queue_id"
+# Configured key name of queue connection host.
+CONFIGURED_KEY_EVENT_QUEUE_HOST = "job_event_queue_host"
+# Configured key name of queue connection port.
+CONFIGURED_KEY_EVENT_QUEUE_PORT = "job_event_queue_port"
+# Configured num of tries.
+CONFIGURED_KEY_EVENT_QUEUE_NUM_TRIES = "job_event_queue_num_tries"
+# Default RabbitMQ connection host.
+DEFAULT_EVENT_QUEUE_HOST = "rabbitmq"
+# Default RabbitMQ connection port.
+DEFAULT_EVENT_QUEUE_PORT = 5672
+
+
+class EventQueueInvalidCredentialsError(RuntimeError):
+    """A non-recoverable error in EventQueue connection creation."""
+
+
+class EventQueueConnectionError(RuntimeError):
+    """A recoverable connection error in EventQueue connection creation."""
+
+
+def is_publish_job_event_configured(job_queue_id: Optional[str]) -> bool:
+    """Checks the config to see whether Event Publishing should be enabled."""
+    return _PIKA_INSTALLED and job_queue_id is not None
+
+
+class Event(Protocol):
+    """An event that can be published via `BaseQueueClient.publish`."""
+
+    def serialize(self) -> str:
+        """Serializes the job lifecycle event into a JSON string."""
+        raise NotImplementedError(type(self))
+
+
+class BaseQueueClient(Configurable):
+    """Interface for event queue management with retry and error handling logic."""
+
+    @config_class
+    class Config(Configurable.Config):
+        """Configuration for BaseQueueClient."""
+
+        # Queue id.
+        queue_id: Required[str] = REQUIRED
+        # Queue client host name. Default connection to use RabbitMQ solution.
+        host: str = DEFAULT_EVENT_QUEUE_HOST
+        # Queue client port name. Default connection to RabbitMQ port 5672.
+        port: int = DEFAULT_EVENT_QUEUE_PORT
+        # The number of attempts to publish an event.
+        num_tries: int = 1
+
+    def __init__(self, cfg: Config):
+        """Init client instance."""
+        super().__init__(cfg)
+        cfg = self.config
+        self._queue_id = cfg.queue_id
+        self._host = cfg.host
+        self._port = cfg.port
+        self._num_tries = cfg.num_tries
+        self._channel = None
+        self._connection = None
+
+    @classmethod
+    def define_flags(cls, fv: flags.FlagValues):
+        """Defines absl flags to be read by `from_flags()`."""
+        common_kwargs = dict(flag_values=fv, allow_override=True)
+        flags.DEFINE_string(
+            CONFIGURED_KEY_JOB_EVENT_QUEUE_ID, None, "Event Queue Id.", **common_kwargs
+        )
+        flags.DEFINE_string(
+            CONFIGURED_KEY_EVENT_QUEUE_HOST,
+            DEFAULT_EVENT_QUEUE_HOST,
+            "Event queue connection host.",
+            **common_kwargs,
+        )
+        flags.DEFINE_integer(
+            CONFIGURED_KEY_EVENT_QUEUE_PORT,
+            DEFAULT_EVENT_QUEUE_PORT,
+            "Event queue connection port.",
+            **common_kwargs,
+        )
+        flags.DEFINE_integer(
+            CONFIGURED_KEY_EVENT_QUEUE_NUM_TRIES,
+            1,
+            "Event publish number of tries.",
+            **common_kwargs,
+        )
+
+    def connect(self):
+        """Connect to the message broker."""
+        raise NotImplementedError(type(self))
+
+    def close(self):
+        """Close the connection to the message broker."""
+        raise NotImplementedError(type(self))
+
+    def publish(self, event: Event):
+        """Publish an event to the specified queue with retry logic.
+
+        Args:
+            event: The event content to be published.
+        """
+        raise NotImplementedError(type(self))
+
+
+class RabbitMQClient(BaseQueueClient):
+    """Implementation of BaseQueueClient using RabbitMQ.
+
+    This class provides methods to connect to a RabbitMQ server, publish messages to queues,
+    and manage the RabbitMQ connection and channel. It is a concrete implementation of the
+    `BaseQueueClient` interface.
+    """
+
+    def connect(self):
+        """Establishes a connection to the RabbitMQ server."""
+        # Secret is stored in the Env variable.
+        user = os.getenv("RABBITMQ_USER", None)
+        password = os.getenv("RABBITMQ_PASSWORD", None)
+        if not user or not password:
+            raise EventQueueInvalidCredentialsError(
+                "The RabbitMQ connection username and password "
+                "environment secrets are not configured."
+            )
+
+        try:
+            credentials = pika.PlainCredentials(user, password)
+            parameters = pika.ConnectionParameters(
+                host=self._host,
+                port=self._port,
+                credentials=credentials,
+                # Heartbeat interval to keep the connection alive.
+                heartbeat=600,
+                # Timeout for blocked connection.
+                blocked_connection_timeout=300,
+            )
+            self._connection = pika.BlockingConnection(parameters)
+            self._channel = self._connection.channel()
+            logging.info(
+                "Connected RabbitMQ at host: %s, port: %s to publish events.",
+                self._host,
+                self._port,
+            )
+        except pika.exceptions.ProbableAuthenticationError as e:
+            raise EventQueueInvalidCredentialsError(
+                "Authentication with RabbitMQ failed. Please check your username and password."
+            ) from e
+        except pika.exceptions.AMQPConnectionError as e:
+            raise EventQueueConnectionError(
+                "An unexpected error occurred while connecting to RabbitMQ."
+            ) from e
+        except ConnectionResetError as e:
+            raise e
+
+    def close(self):
+        """Closes the RabbitMQ connection."""
+        if self._connection and not self._connection.is_closed:
+            self._connection.close()
+            self._connection = None
+            logging.info("Closed RabbitMQ connection.")
+        if self._channel and not self._channel.is_closed:
+            self._channel.close()
+            self._channel = None
+            logging.info("Closed RabbitMQ channel.")
+
+    def publish(self, event: Event):
+        """Publishes an event to the queue."""
+        logging.info("Publishing event: %s", event)
+        message = event.serialize()
+        attempt = 0
+        while attempt <= self._num_tries:
+            try:
+                # Ensure connection is established before publishing.
+                if not self._channel or not self._connection:
+                    logging.error("RabbitMQ publisher channel is closed, reconnecting...")
+                    self.connect()
+
+                # Setting durable=True ensures that the queue will survive.
+                # a RabbitMQ server restart.
+                self._channel.queue_declare(queue=self._queue_id, durable=True)
+                self._channel.basic_publish(
+                    # Set exchange empty refers to the default exchange,
+                    # which directly routes messages to the queue specified by the routing_key
+                    exchange="",
+                    routing_key=self._queue_id,
+                    body=message,
+                    properties=pika.BasicProperties(
+                        delivery_mode=2,
+                        # Generate a unique correlation ID.
+                        correlation_id=str(uuid.uuid4()),
+                    ),
+                )
+                logging.info("Published event in queue: %s. message: %s", self._queue_id, message)
+                return
+            except EventQueueInvalidCredentialsError as e:
+                # Throws for un-recoverable errors.
+                raise e
+            except (EventQueueConnectionError, ConnectionResetError) as e:
+                # Only retry on recoverable exceptions.
+                # AMQPConnectionError is assumed to be related to network issues,
+                # or temporary unavailable host.
+                logging.error(
+                    "Failed to publish event: %s. Error: %s. Attempt: %d",
+                    message,
+                    str(e),
+                    attempt,
+                )
+                self._handle_publish_error()
+                attempt += 1
+                if attempt <= self._num_tries:
+                    time.sleep(2**attempt)
+            except Exception as e:  # pylint: disable=broad-except
+                # Unknown errors. Don't retry. Log to avoid crashing clients.
+                logging.error(
+                    "Unknown error. Failed to publish event: %s. Error: %s.", message, str(e)
+                )
+                self._handle_publish_error()
+                attempt += 1
+                if attempt <= self._num_tries:
+                    time.sleep(2**attempt)
+
+    def _handle_publish_error(self):
+        """Handle publish errors with retrying on connection issue."""
+        try:
+            self.close()
+        # pylint: disable=broad-exception-caught.
+        except Exception as handling_error:
+            logging.error(
+                "RabbitMQ event client failed in _handle_publish_error: %s", str(handling_error)
+            )

--- a/axlearn/cloud/common/event_queue.py
+++ b/axlearn/cloud/common/event_queue.py
@@ -179,12 +179,12 @@ class RabbitMQClient(BaseQueueClient):
         """Closes the RabbitMQ connection."""
         if self._connection and not self._connection.is_closed:
             self._connection.close()
-            self._connection = None
             logging.info("Closed RabbitMQ connection.")
         if self._channel and not self._channel.is_closed:
             self._channel.close()
-            self._channel = None
             logging.info("Closed RabbitMQ channel.")
+        self._connection = None
+        self._channel = None
 
     def publish(self, event: Event):
         """Publishes an event to the queue."""

--- a/axlearn/cloud/common/event_queue_test.py
+++ b/axlearn/cloud/common/event_queue_test.py
@@ -1,0 +1,95 @@
+# Copyright © 2024 Apple Inc.
+
+"""Tests event queue."""
+# pylint: disable=redefined-outer-name, protected-access
+
+import os
+import uuid
+from unittest import TestCase, mock
+from unittest.mock import MagicMock
+
+import pika
+
+from axlearn.cloud.common.event_queue import (
+    Event,
+    EventQueueConnectionError,
+    EventQueueInvalidCredentialsError,
+    RabbitMQClient,
+)
+
+
+class TestRabbitMQClient(TestCase):
+    """Tests for the RabbitMQClient class."""
+
+    @mock.patch("pika.BlockingConnection")
+    @mock.patch("pika.BasicProperties")
+    @mock.patch("os.getenv")
+    def test_publish_success(self, mock_getenv, mock_basic_properties, mock_block_connection):
+        """Test successful message publishing."""
+        # Mock environment variables for RabbitMQ credentials
+        mock_getenv.side_effect = lambda key, default=None: {
+            "RABBITMQ_USER": "test_user",
+            "RABBITMQ_PASSWORD": "test_password",
+        }.get(key, default)
+
+        # Mock the PlainCredentials and ConnectionParameters
+        mock_uuid = str(uuid.uuid4())
+        mock_basic_properties.return_value = mock.Mock(delivery_mode=2, correlation_id=mock_uuid)
+        mock_connection = mock_block_connection.return_value
+        mock_channel = mock_connection.channel.return_value
+        mock_event = MagicMock(spec=Event)
+        mock_event.serialize.return_value = "serialized_event"
+        rabbitmq_client = (
+            RabbitMQClient.default_config()
+            .set(host="rabbitmq", port=5672, queue_id="test_queue")
+            .instantiate()
+        )
+        rabbitmq_client.publish(mock_event)
+        mock_channel.queue_declare.assert_called_once_with(queue="test_queue", durable=True)
+        mock_channel.basic_publish.assert_called_once_with(
+            exchange="",
+            routing_key="test_queue",
+            body="serialized_event",
+            properties=mock_basic_properties.return_value,
+        )
+
+    @mock.patch.dict(os.environ, {"RABBITMQ_USER": "test_user", "RABBITMQ_PASSWORD": "test_pass"})
+    @mock.patch("pika.BlockingConnection")
+    def test_connect_success(self, mock_blocking_connection):
+        # Arrange
+        mock_channel = MagicMock()
+        mock_blocking_connection.return_value.channel.return_value = mock_channel
+        rabbitmq_client = (
+            RabbitMQClient.default_config()
+            .set(host="rabbitmq", port=5672, queue_id="test_queue")
+            .instantiate()
+        )
+
+        rabbitmq_client.connect()
+        mock_blocking_connection.assert_called_once()
+        self.assertIsNotNone(rabbitmq_client._connection)
+        self.assertIsNotNone(rabbitmq_client._channel)
+
+    @mock.patch.dict(os.environ, {"RABBITMQ_USER": "", "RABBITMQ_PASSWORD": ""})
+    def test_connect_missing_credentials(self):
+        rabbitmq_client = (
+            RabbitMQClient.default_config()
+            .set(host="rabbitmq", port=5672, queue_id="test_queue")
+            .instantiate()
+        )
+
+        with self.assertRaises(EventQueueInvalidCredentialsError):
+            rabbitmq_client.connect()
+
+    @mock.patch.dict(os.environ, {"RABBITMQ_USER": "test_user", "RABBITMQ_PASSWORD": "test_pass"})
+    @mock.patch("pika.BlockingConnection", side_effect=pika.exceptions.AMQPConnectionError)
+    def test_connect_amqp_connection_error(self, mock_blocking_connection):
+        rabbitmq_client = (
+            RabbitMQClient.default_config()
+            .set(host="rabbitmq", port=5672, queue_id="test_queue")
+            .instantiate()
+        )
+        mock_blocking_connection.assert_not_called()
+
+        with self.assertRaises(EventQueueConnectionError):
+            rabbitmq_client.connect()

--- a/axlearn/cloud/gcp/event_queue.py
+++ b/axlearn/cloud/gcp/event_queue.py
@@ -1,0 +1,57 @@
+# Copyright © 2024 Apple Inc.
+
+"""Tools to publish events in GCP."""
+
+from typing import Optional
+
+from absl import flags
+
+from axlearn.cloud.common.event_queue import (
+    CONFIGURED_KEY_EVENT_QUEUE_HOST,
+    CONFIGURED_KEY_EVENT_QUEUE_NUM_TRIES,
+    CONFIGURED_KEY_EVENT_QUEUE_PORT,
+    CONFIGURED_KEY_JOB_EVENT_QUEUE_ID,
+    DEFAULT_EVENT_QUEUE_HOST,
+    DEFAULT_EVENT_QUEUE_PORT,
+    BaseQueueClient,
+    RabbitMQClient,
+    is_publish_job_event_configured,
+)
+from axlearn.cloud.gcp.config import gcp_settings
+
+
+def event_queue_from_config(
+    flag_values: flags.FlagValues = flags.FLAGS,
+) -> Optional[BaseQueueClient.Config]:
+    """Create config for EventQueue.
+
+    Args:
+        flag_values: Flag configurations defined in gcp_settings.
+
+    Returns:
+        A configured `RabbitMQClient.Config` object if the event queue is configured.
+        Returns `None` if the event queue is not configured.
+    """
+    if not is_publish_job_event_configured(
+        gcp_settings(CONFIGURED_KEY_JOB_EVENT_QUEUE_ID, required=False, fv=flag_values)
+    ):
+        return None
+
+    return RabbitMQClient.default_config().set(
+        host=gcp_settings(
+            CONFIGURED_KEY_EVENT_QUEUE_HOST,
+            required=False,
+            default=DEFAULT_EVENT_QUEUE_HOST,
+            fv=flag_values,
+        ),
+        port=gcp_settings(
+            CONFIGURED_KEY_EVENT_QUEUE_PORT,
+            required=False,
+            default=DEFAULT_EVENT_QUEUE_PORT,
+            fv=flag_values,
+        ),
+        queue_id=gcp_settings(CONFIGURED_KEY_JOB_EVENT_QUEUE_ID, required=False, fv=flag_values),
+        num_tries=gcp_settings(
+            CONFIGURED_KEY_EVENT_QUEUE_NUM_TRIES, required=False, default=1, fv=flag_values
+        ),
+    )

--- a/axlearn/cloud/gcp/event_queue_test.py
+++ b/axlearn/cloud/gcp/event_queue_test.py
@@ -1,0 +1,71 @@
+# Copyright © 2024 Apple Inc.
+
+"""Test event queue publishing in GCP."""
+
+import os
+
+from absl import flags
+
+from axlearn.cloud.common import config
+from axlearn.cloud.common.config_test import _setup_fake_repo, create_default_config
+from axlearn.cloud.gcp import config as gcp_config
+from axlearn.cloud.gcp.event_queue import event_queue_from_config
+from axlearn.common.test_utils import TestWithTemporaryCWD
+
+
+class EventQueueTest(TestWithTemporaryCWD):
+    """Test Event Queue functions."""
+
+    def test_event_queue_from_config(self):
+        temp_dir = os.path.realpath(self._temp_root.name)
+        _setup_fake_repo(temp_dir)
+
+        flag_values = flags.FlagValues()
+        flags.DEFINE_string("project", None, "The project name.", flag_values=flag_values)
+        flags.DEFINE_string("zone", None, "The zone name.", flag_values=flag_values)
+        flag_values.project = "test"
+        flag_values.zone = "test"
+        flag_values.mark_as_parsed()
+
+        # No value is configured for job_event_queue_id.
+        base_queue_client_config = event_queue_from_config(flag_values)
+        self.assertIsNone(base_queue_client_config)
+
+        # Create a default config, which should get picked up.
+        default_config = create_default_config(temp_dir)
+
+        # Write job_event_queue_id to the config.
+        config.write_configs_with_header(
+            str(default_config),
+            {gcp_config.CONFIG_NAMESPACE: {"test:test": {"job_event_queue_id": "test-queue"}}},
+        )
+
+        base_queue_client_config = event_queue_from_config(flag_values)
+        self.assertIsNotNone(base_queue_client_config)
+        self.assertEqual(base_queue_client_config.queue_id, "test-queue")
+        # These fields are set as default values.
+        self.assertEqual(base_queue_client_config.host, "rabbitmq")
+        self.assertEqual(base_queue_client_config.port, 5672)
+        self.assertEqual(base_queue_client_config.num_tries, 1)
+
+        # Write job_event_queue_id to the config.
+        config.write_configs_with_header(
+            str(default_config),
+            {
+                gcp_config.CONFIG_NAMESPACE: {
+                    "test:test": {
+                        "job_event_queue_id": "test-queue",
+                        "job_event_queue_host": "test-host",
+                        "job_event_queue_port": 8000,
+                        "job_event_queue_num_tries": 2,
+                    }
+                }
+            },
+        )
+
+        base_queue_client_config = event_queue_from_config(flag_values)
+        self.assertIsNotNone(base_queue_client_config)
+        self.assertEqual(base_queue_client_config.queue_id, "test-queue")
+        self.assertEqual(base_queue_client_config.host, "test-host")
+        self.assertEqual(base_queue_client_config.port, 8000)
+        self.assertEqual(base_queue_client_config.num_tries, 2)

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -135,6 +135,7 @@ from axlearn.cloud.common.scheduler import JobScheduler
 from axlearn.cloud.common.uploader import Uploader, with_interval
 from axlearn.cloud.common.utils import configure_logging, parse_action
 from axlearn.cloud.gcp.config import default_project, default_zone, gcp_settings
+from axlearn.cloud.gcp.event_queue import event_queue_from_config
 from axlearn.cloud.gcp.job import CPUJob, docker_command
 from axlearn.cloud.gcp.tpu_cleaner import TPUCleaner
 from axlearn.cloud.gcp.utils import GCPAPI, catch_auth, common_flags
@@ -514,7 +515,9 @@ def main(argv: Sequence[str], *, flag_values: flags.FlagValues = FLAGS):
                 upload_fn=config_for_function(with_interval).set(upload_fn=_gcloud_storage_rsync),
             ),
             quota=config_for_function(_project_quotas_from_file).set(quota_file=quota_file()),
+            event_publisher=event_queue_from_config(flag_values=flag_values),
         )
+
         _with_retry(
             lambda: bastion_cfg.instantiate().execute(),
             interval=60,

--- a/axlearn/cloud/gcp/jobs/gke_runner.py
+++ b/axlearn/cloud/gcp/jobs/gke_runner.py
@@ -32,7 +32,9 @@ from typing import Optional, cast
 import kubernetes as k8s
 from absl import app, flags, logging
 
+from axlearn.cloud.common.bastion import JobLifecycleEvent, JobLifecycleState
 from axlearn.cloud.common.bundler import get_bundler_config
+from axlearn.cloud.common.event_queue import BaseQueueClient
 from axlearn.cloud.common.utils import (
     configure_logging,
     generate_job_name,
@@ -41,6 +43,7 @@ from axlearn.cloud.common.utils import (
 )
 from axlearn.cloud.gcp.bundler import ArtifactRegistryBundler
 from axlearn.cloud.gcp.config import gcp_settings
+from axlearn.cloud.gcp.event_queue import event_queue_from_config
 from axlearn.cloud.gcp.job import GCPJob, GKEJob, GPUGKEJob, TPUGKEJob
 from axlearn.cloud.gcp.jobs import runner_utils
 from axlearn.cloud.gcp.jobs.tpu_runner import with_tpu_training_defaults
@@ -60,7 +63,7 @@ from axlearn.cloud.gcp.utils import (
     running_from_vm,
 )
 from axlearn.cloud.gcp.vertexai_tensorboard import VertexAITensorboardUploader
-from axlearn.common.config import REQUIRED, Required, config_class
+from axlearn.common.config import REQUIRED, Required, config_class, maybe_instantiate
 
 FLAGS = flags.FLAGS
 
@@ -99,6 +102,7 @@ class GKERunnerJob(GCPJob):
             vertexai_tb_uploader: Optional VertexAI Tensorboard Uploader.
             enable_pre_provisioner: Whether to enable pre-provisioner.
             pre_provisioner: Optional pre-provisioner configuration.
+            event_publisher: Optional event publisher configuration.
         """
 
         inner: Required[GKEJob.Config] = REQUIRED
@@ -111,6 +115,8 @@ class GKERunnerJob(GCPJob):
         # This config is made Optional for backwards compatibility. Default is False.
         enable_pre_provisioner: Optional[bool] = None
         pre_provisioner: Optional[NodePoolProvisioner.Config] = None
+        # The event publisher sends events into queue.
+        event_publisher: Optional[BaseQueueClient.Config] = None
 
     @classmethod
     def validate_inner(cls):
@@ -166,6 +172,9 @@ class GKERunnerJob(GCPJob):
         )
         if cfg.enable_pre_provisioner:
             cfg.pre_provisioner = cast(NodePoolProvisioner, cls.pre_provisioner).from_flags(fv)
+
+        cfg.event_publisher = event_queue_from_config(flag_values=fv)
+
         return cfg
 
     @property
@@ -201,6 +210,8 @@ class GKERunnerJob(GCPJob):
             self._pre_provisioner: NodePoolProvisioner = cfg.pre_provisioner.set(
                 name=cfg.name,
             ).instantiate()
+
+        self._event_publisher = maybe_instantiate(cfg.event_publisher)
 
     class Status(enum.Enum):
         """GKE JobSet status.
@@ -392,16 +403,25 @@ class GKERunnerJob(GCPJob):
     def _execute(self):
         cfg: GKERunnerJob.Config = self.config
 
+        # Keep track of last status to prevent duplicate events.
+        last_job_status = None
+
         while True:
             status = self._get_status()
 
             # Don't retry if FAILED, since we ask GKE to handle retries.
             # Note that job remains ACTIVE until all retries are exhausted.
-            if status in {
-                GKERunnerJob.Status.FAILED,
+            if status == GKERunnerJob.Status.FAILED:
+                self._maybe_publish(
+                    cfg.name, msg="Job failed with error", state=JobLifecycleState.FAILED
+                )
+                logging.info("Task %s exited with status: %s.", cfg.name, status)
+                return
+            elif status in {
                 GKERunnerJob.Status.SUCCEEDED,
                 GKERunnerJob.Status.COMPLETED,
             }:
+                self._maybe_publish(cfg.name, msg="Job succeeds", state=JobLifecycleState.SUCCEEDED)
                 logging.info("Task %s exited with status: %s.", cfg.name, status)
                 return
             elif status == GKERunnerJob.Status.RESCHEDULED:
@@ -432,7 +452,20 @@ class GKERunnerJob(GCPJob):
                 if self._tb_uploader:
                     self._tb_uploader.upload()
                 logging.info("Task %s has status: %s", cfg.name, status)
+                # Only emit events when status changes.
+                if status == GKERunnerJob.Status.READY and status != last_job_status:
+                    self._maybe_publish(
+                        cfg.name, msg="Job is running", state=JobLifecycleState.RUNNING
+                    )
+                    last_job_status = status
             time.sleep(cfg.status_interval_seconds)
+
+    def _maybe_publish(self, job_name: str, *, msg: str, state: JobLifecycleState):
+        # Publish events to event queue.
+        if not self._event_publisher:
+            return
+
+        self._event_publisher.publish(JobLifecycleEvent(job_name, state, msg))
 
 
 class TPUGKERunnerJob(GKERunnerJob):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "einops",
     "evaluate",
     "isort",  # formatting
+    "pika==1.3.2",  # used by event queue
     "pre-commit",  # local pre commit hooks
     "pycocotools",  # COCO evaluation tools
     "pylint==2.17.7",
@@ -91,6 +92,7 @@ gcp = [
     "google-cloud-core==2.3.3",
     "google-cloud-build==3.24.1",
     "ml_goodput_measurement==0.0.2",
+    "pika==1.3.2",  # used by event queue
     "pyOpenSSL>=22.1.0",  # compat with cryptography version.
 ]
 # For TPU training.


### PR DESCRIPTION
This PR includes changes:
1. Introduce EventQueue interface and RabbitMQ implementation for GKE job events
2. Publish job events from Bastion to queue.
3. Publish job status from gke_runner.