### PR TITLE
Don't inherit from protocol.

### DIFF
--- a/axlearn/common/metrics.py
+++ b/axlearn/common/metrics.py
@@ -2,7 +2,6 @@
 
 """Metrics."""
 
-import typing
 from typing import Any, Optional, Union
 
 import jax
@@ -10,7 +9,6 @@ import jax.numpy as jnp
 from absl import logging
 
 from axlearn.common.config import Configurable
-from axlearn.common.module import Summable
 from axlearn.common.summary import Summary
 from axlearn.common.utils import NestedTensor, Tensor
 
@@ -25,8 +23,7 @@ class WeightedScalarValue(Summary):
         return self.mean
 
 
-@typing.runtime_checkable  # Needed for isinstance checks to work.
-class WeightedScalar(WeightedScalarValue, Summable):
+class WeightedScalar(WeightedScalarValue):
     """A weighted scalar represents a weighted Summable value.
 
     Weight should be a scalar and is assumed to be non-negative.

--- a/axlearn/common/metrics_test.py
+++ b/axlearn/common/metrics_test.py
@@ -10,6 +10,7 @@ import jax.numpy as jnp
 from absl.testing import parameterized
 
 from axlearn.common import metrics, summary, test_utils, utils
+from axlearn.common.module import Summable
 
 
 class TestMetricAccumulator(test_utils.TestCase):
@@ -124,3 +125,6 @@ class TestMetricAccumulator(test_utils.TestCase):
         # Test with and without jit.
         self.assertNestedAllClose(expected, add(weight))
         self.assertNestedAllClose(expected, jax.jit(add)(weight))
+
+        # Test isinstance check.
+        self.assertIsInstance(metrics.WeightedScalar(1.0, 1.0), Summable)

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -44,6 +44,7 @@ import inspect
 import os.path
 import re
 import threading
+import typing
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Callable, NamedTuple, Optional, TypeVar, Union
@@ -181,6 +182,7 @@ def propagate_repeated_output_collections(
 T = TypeVar("T")
 
 
+@typing.runtime_checkable  # Needed for isinstance checks to work.
 class Summable(Protocol):
     # Objects of the same type which adhere to this protocol may be added.
     def __add__(self, other: T) -> T:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ core = [
     "tensorflow_text==2.16.1; platform_machine == 'x86_64'", # implied by seqio, but also used directly for text processing
     "tensorstore>=0.1.63",  # used for supporting GDA checkpoints
     "toml",  # for config management
-    "typing-extensions==4.9.0",  # needed for typing.Protocol. >4.9.0 runs into attribute error `__non_callable_proto_members__`.
+    "typing-extensions==4.11.0",
     "scipy==1.12.0",  # to avoid "module 'scipy.linalg' has no attribute 'tril'"
     "seqio==0.0.18",  # used for inputs
     "aqtp==0.4.0", # aqtp>=0.5.0 requires python>=3.10 due to the use of Union shorthand "|" in type hints.


### PR DESCRIPTION
Avoids "attribute error `__non_callable_proto_members__`."