### PR TITLE
Fix submission of Dataflow jobs

### DIFF
--- a/axlearn/cloud/gcp/jobs/dataflow.py
+++ b/axlearn/cloud/gcp/jobs/dataflow.py
@@ -177,7 +177,8 @@ class DataflowJob(GCPJob):
             sorted(flags.flag_dict_to_args(dataflow_spec, multi_flags=multi_flags))
         )
         cfg.setup_command = f"{docker_setup_cmd} && {docker_auth_cmd} && {bundle_cmd}"
-        cfg.command = f"{cfg.command.strip('\'\"')} {dataflow_flags}"
+        cfg.command = cfg.command.strip('\'\"')
+        cfg.command = f"{cfg.command} {dataflow_flags}"
         return cfg
 
     @classmethod

--- a/axlearn/cloud/gcp/jobs/dataflow.py
+++ b/axlearn/cloud/gcp/jobs/dataflow.py
@@ -177,7 +177,7 @@ class DataflowJob(GCPJob):
             sorted(flags.flag_dict_to_args(dataflow_spec, multi_flags=multi_flags))
         )
         cfg.setup_command = f"{docker_setup_cmd} && {docker_auth_cmd} && {bundle_cmd}"
-        cfg.command = cfg.command.strip('\'\"')
+        cfg.command = cfg.command.strip("'\"")
         cfg.command = f"{cfg.command} {dataflow_flags}"
         return cfg
 

--- a/axlearn/cloud/gcp/jobs/dataflow.py
+++ b/axlearn/cloud/gcp/jobs/dataflow.py
@@ -177,7 +177,7 @@ class DataflowJob(GCPJob):
             sorted(flags.flag_dict_to_args(dataflow_spec, multi_flags=multi_flags))
         )
         cfg.setup_command = f"{docker_setup_cmd} && {docker_auth_cmd} && {bundle_cmd}"
-        cfg.command = f"{cfg.command} {dataflow_flags}"
+        cfg.command = f"{cfg.command.strip('\'\"')} {dataflow_flags}"
         return cfg
 
     @classmethod


### PR DESCRIPTION
Today, if you try to submit dataflow jobs with a mix of normal pipeline options and dataflow pipeline options, it does not get submitted correctly.

This is because `cfg.command` is quoted, so the final command ends up looking like this after adding `dataflow_flags`:

```
'
    python3 -m apache_beam.examples.wordcount             --input=gs://dataflow-samples/shakespeare/kinglear.txt         --output=gs://ttl-30d-us-central2/axlearn/users/remyw/dataflow/wordcount' --dataflow_service_options=enable_google_cloud_heap_sampling --dataflow_service_options=enable_secure_boot --experiments=use_network_tags=allow-internet-egress --experiments=use_runner_v2 --machine_type=n2-standard-8 --no_use_public_ips --project=abc --region=us-central1 --runner=DataflowRunner --sdk_container_image=my_container
```

Note the leading quote as well as the trailing quote after `output=gs://ttl-30d-us-central2/axlearn/users/remyw/dataflow/wordcount'`

This breaks the processing of this command, and all the subsequent `dataflow_flags` are ignored, so it gets run locally instead of on Dataflow.

To fix this, we just need to strip the quotes around cfg.command before adding it to our full command.