### PR TITLE
Set TF_FORCE_GPU_ALLOW_GROWTH=true by default

### DIFF
--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -41,6 +41,10 @@ os.environ["LIBTPU_INIT_ARGS"] = " ".join(libtpu_init_args)
 # Note: this will disable other TF_CPP info and warnnings.
 os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
 
+# Prevent GPU OOM issues due to TF taking up all the GPU memory.
+# Reference: https://stackoverflow.com/a/54927279
+os.environ.setdefault("TF_FORCE_GPU_ALLOW_GROWTH", "true")
+
 # Import jax before tensorflow else to avoid problems such as:
 # tpu_library_init_fns.inc:98] TpuEmbeddingEngine_ExecutePartitioner not available in this library.
 import jax  # jax must be imported before tensorflow!


### PR DESCRIPTION
This is needed to be able to run Fuji v2 70B on GPU without GPU memory OOMs.