### PR TITLE
Expose segment_ids to _compute_attention in FlashAttention

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -3011,7 +3011,8 @@ class TransformerLayer(BaseTransformerLayer):
             )
         elif mode == ForwardMode.INIT_STATES:
             assert cached_states is not None
-            assert segment_ids is None
+            if segment_ids is not None:
+                raise ValueError("segment_ids is not supported in INIT_STATES.")
             self_atten_state, self_atten_outputs = self.self_attention.prefill_states(
                 time_step=cached_states["self_attention"],
                 target=data,
@@ -3021,7 +3022,8 @@ class TransformerLayer(BaseTransformerLayer):
             )
         elif mode == ForwardMode.EXTEND_STEP:
             assert cached_states is not None
-            assert segment_ids is None
+            if segment_ids is not None:
+                raise ValueError("segment_ids is not supported in EXTEND_STEP.")
             self_atten_state, self_atten_outputs = self.self_attention.extend_step(
                 cached_states=cached_states["self_attention"],
                 target=data,

--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -1836,8 +1836,8 @@ class MultiheadAttention(BaseLayer):
         """
         if segment_ids is not None:
             raise ValueError(
-                "segment_ids is not supported. To use segment_ids, construct attention_logit_biases using an "
-                "AttentionLogitBiasLayer."
+                "segment_ids is not supported. To use segment_ids, construct "
+                "attention_logit_biases using an AttentionLogitBiasLayer."
             )
 
         logits = self._compute_logits(q_proj, k_proj)
@@ -2094,11 +2094,10 @@ class SigmoidAttention(MultiheadAttention):
         segment_ids: Optional[Tensor] = None,
     ) -> tuple[Tensor, Tensor]:
         """See `MultiheadAttention._compute_attention` for details."""
-        if attention_logit_biases is not None and segment_ids is not None:
+        if segment_ids is not None:
             raise ValueError(
-                "Using both segment_ids and attention_logit_biases is not allowed. "
-                "If you have segment_ids, consider merging them into attention_logit_biases using "
-                "AttentionLogitBiasLayer."
+                "segment_ids is not supported. To use segment_ids, construct "
+                "attention_logit_biases using an AttentionLogitBiasLayer."
             )
 
         cfg = self.config

--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -1834,10 +1834,9 @@ class MultiheadAttention(BaseLayer):
             The context of shape [batch_size, target_length, num_heads, per_head_dim],
             and probs of shape [batch, num_heads, target_length, source_length].
         """
-        if attention_logit_biases is not None and segment_ids is not None:
+        if segment_ids is not None:
             raise ValueError(
-                "Using both segment_ids and attention_logit_biases is not allowed. "
-                "If you have segment_ids, consider merging them into attention_logit_biases using "
+                "segment_ids is not supported. To use segment_ids, construct attention_logit_biases using an "
                 "AttentionLogitBiasLayer."
             )
 

--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -3012,7 +3012,7 @@ class TransformerLayer(BaseTransformerLayer):
         elif mode == ForwardMode.INIT_STATES:
             assert cached_states is not None
             if segment_ids is not None:
-                raise ValueError("segment_ids is not supported in INIT_STATES.")
+                raise NotImplementedError("segment_ids is not supported in INIT_STATES.")
             self_atten_state, self_atten_outputs = self.self_attention.prefill_states(
                 time_step=cached_states["self_attention"],
                 target=data,
@@ -3023,7 +3023,7 @@ class TransformerLayer(BaseTransformerLayer):
         elif mode == ForwardMode.EXTEND_STEP:
             assert cached_states is not None
             if segment_ids is not None:
-                raise ValueError("segment_ids is not supported in EXTEND_STEP.")
+                raise NotImplementedError("segment_ids is not supported in EXTEND_STEP.")
             self_atten_state, self_atten_outputs = self.self_attention.extend_step(
                 cached_states=cached_states["self_attention"],
                 target=data,

--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -1758,14 +1758,6 @@ class MultiheadAttention(BaseLayer):
                     attention_logit_biases,
                 )
 
-        # Merge segment ids into attention_logit_biases if attention_logit_biases is already set.
-        if attention_logit_biases is not None and segment_ids is not None:
-            attention_logit_biases = apply_attention_logit_biases(
-                make_segment_mask(source_segments=segment_ids, target_segments=segment_ids),
-                attention_logit_biases,
-            )
-            segment_ids = None
-
         context, probs = self._compute_attention(
             q_proj=q_proj,
             k_proj=k_proj,
@@ -1834,10 +1826,11 @@ class MultiheadAttention(BaseLayer):
             The context of shape [batch_size, target_length, num_heads, per_head_dim],
             and probs of shape [batch, num_heads, target_length, source_length].
         """
+        # Merge segment ids into attention_logit_biases.
         if segment_ids is not None:
-            raise ValueError(
-                "segment_ids is not supported. To use segment_ids, construct "
-                "attention_logit_biases using an AttentionLogitBiasLayer."
+            attention_logit_biases = apply_attention_logit_biases(
+                make_segment_mask(source_segments=segment_ids, target_segments=segment_ids),
+                attention_logit_biases,
             )
 
         logits = self._compute_logits(q_proj, k_proj)
@@ -2094,10 +2087,11 @@ class SigmoidAttention(MultiheadAttention):
         segment_ids: Optional[Tensor] = None,
     ) -> tuple[Tensor, Tensor]:
         """See `MultiheadAttention._compute_attention` for details."""
+        # Merge segment ids into attention_logit_biases.
         if segment_ids is not None:
-            raise ValueError(
-                "segment_ids is not supported. To use segment_ids, construct "
-                "attention_logit_biases using an AttentionLogitBiasLayer."
+            attention_logit_biases = apply_attention_logit_biases(
+                make_segment_mask(source_segments=segment_ids, target_segments=segment_ids),
+                attention_logit_biases,
             )
 
         cfg = self.config

--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -1825,8 +1825,10 @@ class MultiheadAttention(BaseLayer):
             The context of shape [batch_size, target_length, num_heads, per_head_dim],
             and probs of shape [batch, num_heads, target_length, source_length].
         """
-        # Ignore segment_ids. attention_logit_biases should be used instead.
-        del segment_ids
+        # Caller must provide attention_logit_biases when segment_ids specified. segment_ids will
+        # be ignored.
+        if segment_ids is not None and attention_logit_biases is None:
+            raise ValueError("attention_logit_biases must be set in the presence of segment_ids.")
 
         logits = self._compute_logits(q_proj, k_proj)
         logits = self._cap_logits(logits)
@@ -2082,7 +2084,10 @@ class SigmoidAttention(MultiheadAttention):
         segment_ids: Optional[Tensor] = None,
     ) -> tuple[Tensor, Tensor]:
         """See `MultiheadAttention._compute_attention` for details."""
-        del segment_ids
+        # Caller must provide attention_logit_biases when segment_ids specified. segment_ids will
+        # be ignored.
+        if segment_ids is not None and attention_logit_biases is None:
+            raise ValueError("attention_logit_biases must be set in the presence of segment_ids.")
 
         cfg = self.config
         logits = self._compute_logits(q_proj, k_proj)

--- a/axlearn/common/decoder.py
+++ b/axlearn/common/decoder.py
@@ -479,7 +479,7 @@ class Decoder(DecodingMixin, BaseLayer):
             transformer_state, x = None, self.transformer(
                 x,
                 self_attention_logit_biases=self_attention_logit_biases,
-                segment_ids=input_segment_ids,
+                target_segment_ids=input_segment_ids,
                 cross_attention_data=cross_attention_data,
                 cross_attention_logit_biases=cross_attention_logit_biases,
             )
@@ -541,7 +541,7 @@ class Decoder(DecodingMixin, BaseLayer):
             input_ids: An int Tensor of shape [batch_size, target_len].
                 Values should be in the range [0, vocab_size).
             input_segment_ids: An optional Tensor of same shape as `input_ids` with values in
-                [0, num_segments). Tokens are only allowed to attend to other tokens within the same
+                [0, num_segments]. Tokens are only allowed to attend to other tokens within the same
                 segment. input_segment_ids == 0 represents paddings. If None, inferred from
                 input_ids != pad_token_id.
             token_type_ids: An optional int Tensor of shape [batch_size, target_len].

--- a/axlearn/common/decoder.py
+++ b/axlearn/common/decoder.py
@@ -485,7 +485,8 @@ class Decoder(DecodingMixin, BaseLayer):
             )
         elif mode == ForwardMode.INIT_STATES:
             assert cached_states is not None
-            assert input_segment_ids is None
+            if input_segment_ids is not None:
+                raise ValueError("input_segment_ids is not supported in INIT_STATES.")
             transformer_state, x = self.transformer.prefill_states(
                 time_step=cached_states["transformer_state"],
                 data=x,
@@ -495,7 +496,8 @@ class Decoder(DecodingMixin, BaseLayer):
             )
         elif mode == ForwardMode.EXTEND_STEP:
             assert cached_states is not None
-            assert input_segment_ids is None
+            if input_segment_ids is not None:
+                raise ValueError("input_segment_ids is not supported in EXTEND_STEP.")
             transformer_state, x = self.transformer.extend_step(
                 cached_states=cached_states["transformer_state"],
                 data=x,

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -44,7 +44,8 @@ from axlearn.common.flash_attention.utils import mha_reference
 @pytest.mark.parametrize("use_fwd", [True, False])
 @pytest.mark.parametrize("causal", [True, False])
 @pytest.mark.parametrize("sm_scale", [1.0, 0.123])
-@pytest.mark.parametrize("bias_type", ["none", "matrix", "vector"])
+@pytest.mark.parametrize("use_bias", [True, False])
+@pytest.mark.parametrize("use_segment_ids", [True, False])
 @pytest.mark.skipif(jax.devices()[0].platform != "gpu", reason="Test only runs on GPU.")
 def test_fwd_against_ref(
     batch_size: int,
@@ -55,28 +56,33 @@ def test_fwd_against_ref(
     use_fwd: bool,
     causal: bool,
     sm_scale: float,
-    bias_type: str,
+    use_bias: bool,
+    use_segment_ids: bool,
 ):
     k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(0), 4)
     q = jax.random.normal(k1, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16)
     k = jax.random.normal(k2, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16)
     v = jax.random.normal(k3, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16)
 
-    if bias_type == "matrix":
-        bias = jax.random.normal(k4, (batch_size, num_heads, seq_len, seq_len), dtype=jnp.float16)
-    elif bias_type == "vector":
-        segment_left = jnp.ones((batch_size, seq_len // 2), dtype=jnp.int32)
-        segment_right = jnp.zeros((batch_size, seq_len // 2), dtype=jnp.int32)
-        bias = jnp.concatenate([segment_left, segment_right], axis=-1)
-    else:
-        bias = None
+    bias = (
+        jax.random.normal(k4, (batch_size, num_heads, seq_len, seq_len), dtype=jnp.float16)
+        if use_bias
+        else None
+    )
+
+    segment_left = jnp.ones((batch_size, seq_len // 2), dtype=jnp.int32)
+    segment_right = jnp.zeros((batch_size, seq_len // 2), dtype=jnp.int32)
+    segment_ids = (
+        jnp.concatenate([segment_left, segment_right], axis=-1) if use_segment_ids else None
+    )
+
     # Make sure that it is running on GPU.
     assert str(q.devices()) == "{cuda(id=0)}"
 
     if use_fwd:
 
         @jax.jit
-        def impl(q, k, v, bias):
+        def impl(q, k, v, bias, segment_ids):
             fn = functools.partial(
                 flash_attention,
                 block_q=block_size,
@@ -84,7 +90,7 @@ def test_fwd_against_ref(
                 causal=causal,
                 softmax_scale=sm_scale,
             )
-            out, _ = jax.vjp(fn, q, k, v, bias)
+            out, _ = jax.vjp(fn, q, k, v, bias, segment_ids)
             return out
 
     else:
@@ -96,8 +102,8 @@ def test_fwd_against_ref(
             softmax_scale=sm_scale,
         )
 
-    o = impl(q, k, v, bias)
-    o_ref = mha_reference(q, k, v, bias, causal=causal, softmax_scale=sm_scale)
+    o = impl(q, k, v, bias, segment_ids)
+    o_ref = mha_reference(q, k, v, bias, segment_ids, causal=causal, softmax_scale=sm_scale)
     chex.assert_trees_all_close(o, o_ref, atol=0.05)
 
 
@@ -112,7 +118,8 @@ def test_fwd_against_ref(
         (2, 8, 384, 64),
     ],
 )
-@pytest.mark.parametrize("bias_type", ["none", "matrix", "vector"])
+@pytest.mark.parametrize("use_bias", [True, False])
+@pytest.mark.parametrize("use_segment_ids", [True, False])
 @pytest.mark.parametrize("block_size", [128, 64])
 @pytest.mark.parametrize("causal", [True, False])
 @pytest.mark.skipif(jax.devices()[0].platform != "gpu", reason="Test only runs on GPU.")
@@ -121,7 +128,8 @@ def test_bwd_against_ref(
     num_heads: int,
     seq_len: int,
     per_head_dim: int,
-    bias_type: str,
+    use_bias: bool,
+    use_segment_ids: bool,
     block_size: int,
     causal: bool,
 ):
@@ -135,40 +143,47 @@ def test_bwd_against_ref(
         jax.random.PRNGKey(2), (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.float16
     )
 
-    if bias_type == "matrix":
-        bias = jax.random.normal(
+    bias = (
+        jax.random.normal(
             jax.random.PRNGKey(3), (batch_size, num_heads, seq_len, seq_len), dtype=jnp.float16
         )
-    elif bias_type == "vector":
-        segment_left = jnp.ones((batch_size, seq_len // 2), dtype=jnp.int32)
-        segment_right = jnp.zeros((batch_size, seq_len // 2), dtype=jnp.int32)
-        bias = jnp.concatenate([segment_left, segment_right], axis=-1)
-    else:
-        bias = None
+        if use_bias
+        else None
+    )
+
+    segment_left = jnp.ones((batch_size, seq_len // 2), dtype=jnp.int32)
+    segment_right = jnp.zeros((batch_size, seq_len // 2), dtype=jnp.int32)
+    segment_ids = (
+        jnp.concatenate([segment_left, segment_right], axis=-1) if use_segment_ids else None
+    )
+
     # Make sure that it is running on GPU.
     assert str(q.devices()) == "{cuda(id=0)}"
 
     sm_scale = q.shape[-1] ** -0.5
 
     # Compare outputs.
-    jax_out = flash_attention(q, k, v, bias, causal=causal, softmax_scale=sm_scale)
-    jax_ref_out = mha_reference(q, k, v, bias, causal=causal, softmax_scale=sm_scale)
+    jax_out = flash_attention(q, k, v, bias, segment_ids, causal=causal, softmax_scale=sm_scale)
+    jax_ref_out = mha_reference(q, k, v, bias, segment_ids, causal=causal, softmax_scale=sm_scale)
     chex.assert_trees_all_close(jax_out, jax_ref_out, atol=0.005)
 
-    def fn(q, k, v, bias):
+    def fn(q, k, v, bias, segment_ids):
         return flash_attention(
             q,
             k,
             v,
             bias,
+            segment_ids,
             causal=causal,
             softmax_scale=sm_scale,
             block_q=block_size,
             block_k=block_size,
         ).sum()
 
-    def ref_fn(q, k, v, bias):
-        return mha_reference(q, k, v, bias, causal=causal, softmax_scale=sm_scale).sum()
+    def ref_fn(q, k, v, bias, segment_ids):
+        return mha_reference(
+            q, k, v, bias, segment_ids, causal=causal, softmax_scale=sm_scale
+        ).sum()
 
     # Compare gradients.
     jax_grads = jax.grad(fn, argnums=(0, 1, 2))(q, k, v, bias)

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -185,7 +185,7 @@ class FlashAttention(GroupedQueryAttention):
                 cfg.mha_dim_to_partition_spec["bsnh"],
                 # Bias [batch_size, num_heads, seq_len, seq_len].
                 cfg.mha_dim_to_partition_spec["bnts"],
-                # Segment IDs [batch_size, seq_len]
+                # Segment IDs [batch_size, seq_len].
                 cfg.mha_dim_to_partition_spec["bt"],
             ),
             # O [batch_size, seq_len, num_heads, per_head_dim].

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import jax
 import jax.numpy as jnp
+from absl import logging
 from jax.experimental.shard_map import shard_map
 from jax.interpreters.pxla import thread_resources
 from jax.sharding import PartitionSpec
@@ -131,9 +132,12 @@ class FlashAttention(GroupedQueryAttention):
         k_proj = self._repeat_kv_heads(k_proj)
         v_proj = self._repeat_kv_heads(v_proj)
 
-        assert (
-            attention_logit_biases is None or segment_ids is None
-        ), "Only one of attention_logit_biases and segment_ids can be set."
+        if attention_logit_biases is not None and segment_ids is not None:
+            logging.warning(
+                "Using both segment_ids and attention_logit_biases is not recommended. "
+                "If you have segment_ids, consider merging them into attention_logit_biases using "
+                "CausalAttentionLogitBiasLayer."
+            )
 
         if backend == "tpu":
             assert (

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -134,7 +134,7 @@ class FlashAttention(GroupedQueryAttention):
             raise ValueError(
                 "Using both segment_ids and attention_logit_biases is not allowed. "
                 "If you have segment_ids, consider merging them into attention_logit_biases using "
-                "CausalAttentionLogitBiasLayer."
+                "AttentionLogitBiasLayer."
             )
 
         if backend == "tpu":

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import jax
 import jax.numpy as jnp
-from absl import logging
 from jax.experimental.shard_map import shard_map
 from jax.interpreters.pxla import thread_resources
 from jax.sharding import PartitionSpec
@@ -133,8 +132,8 @@ class FlashAttention(GroupedQueryAttention):
         v_proj = self._repeat_kv_heads(v_proj)
 
         if attention_logit_biases is not None and segment_ids is not None:
-            logging.warning(
-                "Using both segment_ids and attention_logit_biases is not recommended. "
+            raise ValueError(
+                "Using both segment_ids and attention_logit_biases is not allowed. "
                 "If you have segment_ids, consider merging them into attention_logit_biases using "
                 "CausalAttentionLogitBiasLayer."
             )

--- a/axlearn/common/flash_attention/layer_test.py
+++ b/axlearn/common/flash_attention/layer_test.py
@@ -14,6 +14,7 @@ from axlearn.common.attention import (
     GroupedQueryAttention,
     apply_attention_logit_biases,
     make_causal_mask,
+    make_segment_mask,
 )
 from axlearn.common.base_layer import BaseLayer
 from axlearn.common.config import config_class
@@ -288,8 +289,17 @@ class TestFlashAttention(TestCase):
             if causal:
                 # Apply causal mask to ref_inputs.
                 ref_inputs["attention_logit_biases"] = apply_attention_logit_biases(
-                    make_causal_mask(seq_len), inputs["attention_logit_biases"]
+                    make_causal_mask(seq_len), ref_inputs["attention_logit_biases"]
                 )
+            if use_segment_ids:
+                ref_inputs["attention_logit_biases"] = apply_attention_logit_biases(
+                    make_segment_mask(
+                        source_segments=ref_inputs["segment_ids"],
+                        target_segments=ref_inputs["segment_ids"],
+                    ),
+                    ref_inputs["attention_logit_biases"],
+                )
+                ref_inputs["segment_ids"] = None
             if use_bias and use_segment_ids:
                 inputs["segment_ids"] = None
 
@@ -396,8 +406,17 @@ class TestFlashAttention(TestCase):
             if causal:
                 # Apply causal mask to ref_inputs.
                 ref_inputs["attention_logit_biases"] = apply_attention_logit_biases(
-                    make_causal_mask(seq_len), inputs["attention_logit_biases"]
+                    make_causal_mask(seq_len), ref_inputs["attention_logit_biases"]
                 )
+            if use_segment_ids:
+                ref_inputs["attention_logit_biases"] = apply_attention_logit_biases(
+                    make_segment_mask(
+                        source_segments=ref_inputs["segment_ids"],
+                        target_segments=ref_inputs["segment_ids"],
+                    ),
+                    ref_inputs["attention_logit_biases"],
+                )
+                ref_inputs["segment_ids"] = None
             if use_bias and use_segment_ids:
                 inputs["segment_ids"] = None
 

--- a/axlearn/common/flash_attention/layer_test.py
+++ b/axlearn/common/flash_attention/layer_test.py
@@ -14,7 +14,6 @@ from axlearn.common.attention import (
     GroupedQueryAttention,
     apply_attention_logit_biases,
     make_causal_mask,
-    make_segment_mask,
 )
 from axlearn.common.base_layer import BaseLayer
 from axlearn.common.config import config_class
@@ -291,17 +290,6 @@ class TestFlashAttention(TestCase):
                 ref_inputs["attention_logit_biases"] = apply_attention_logit_biases(
                     make_causal_mask(seq_len), ref_inputs["attention_logit_biases"]
                 )
-            if use_segment_ids:
-                ref_inputs["attention_logit_biases"] = apply_attention_logit_biases(
-                    make_segment_mask(
-                        source_segments=ref_inputs["segment_ids"],
-                        target_segments=ref_inputs["segment_ids"],
-                    ),
-                    ref_inputs["attention_logit_biases"],
-                )
-                ref_inputs["segment_ids"] = None
-            if use_bias and use_segment_ids:
-                inputs["segment_ids"] = None
 
             ref_out, _ = F(
                 ref_layer,
@@ -408,17 +396,6 @@ class TestFlashAttention(TestCase):
                 ref_inputs["attention_logit_biases"] = apply_attention_logit_biases(
                     make_causal_mask(seq_len), ref_inputs["attention_logit_biases"]
                 )
-            if use_segment_ids:
-                ref_inputs["attention_logit_biases"] = apply_attention_logit_biases(
-                    make_segment_mask(
-                        source_segments=ref_inputs["segment_ids"],
-                        target_segments=ref_inputs["segment_ids"],
-                    ),
-                    ref_inputs["attention_logit_biases"],
-                )
-                ref_inputs["segment_ids"] = None
-            if use_bias and use_segment_ids:
-                inputs["segment_ids"] = None
 
             def loss(params, inputs, layer):
                 loss, _ = F(

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -44,11 +44,19 @@ class TestFlashAttention(TestCase):
         _TEST_CONFIGS,
         causal=[False, True],
         with_attention_bias=[False, True],
+        with_segment_ids=[False, True],
     )
     def test_forward_and_backward(
-        self, batch_size, seq_len, num_heads, per_head_dim, causal, with_attention_bias
+        self,
+        batch_size,
+        seq_len,
+        num_heads,
+        per_head_dim,
+        causal,
+        with_attention_bias,
+        with_segment_ids,
     ):
-        k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(0), 4)
+        k1, k2, k3, k4, k5 = jax.random.split(jax.random.PRNGKey(0), 5)
         q = jax.random.normal(
             k1, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16
         )
@@ -63,25 +71,29 @@ class TestFlashAttention(TestCase):
             attention_bias = jax.random.normal(
                 k4, (batch_size, num_heads, seq_len, seq_len), dtype=jnp.bfloat16
             )
+        segment_ids = None
+        if with_segment_ids:
+            segment_ids = jax.random.bernoulli(k5, shape=(batch_size, seq_len)).astype(jnp.int32)
+            segment_ids = jnp.cumsum(segment_ids, axis=1)
 
         softmax_scale = q.shape[-1] ** -0.5
 
-        def ref_fn(q, k, v, bias):
-            return mha_reference(q, k, v, bias, causal=causal, softmax_scale=softmax_scale)
+        def ref_fn(q, k, v, bias, ids):
+            return mha_reference(q, k, v, bias, ids, causal=causal, softmax_scale=softmax_scale)
 
-        def fn(q, k, v, bias):
-            return flash_attention(q, k, v, bias, causal=causal, softmax_scale=softmax_scale)
+        def fn(q, k, v, bias, ids):
+            return flash_attention(q, k, v, bias, ids, causal=causal, softmax_scale=softmax_scale)
 
         # Compare outputs.
-        out = fn(q, k, v, attention_bias)
-        ref_out = ref_fn(q, k, v, attention_bias)
+        out = fn(q, k, v, attention_bias, segment_ids)
+        ref_out = ref_fn(q, k, v, attention_bias, segment_ids)
         self.assertNestedAllClose(out, ref_out, atol=0.05)
 
         # Compare grads.
-        grad_out = jax.grad(lambda q, k, v, b: fn(q, k, v, b).mean(), argnums=(0, 1, 2))(
-            q, k, v, attention_bias
+        grad_out = jax.grad(lambda q, k, v, b, s: fn(q, k, v, b, s).mean(), argnums=(0, 1, 2))(
+            q, k, v, attention_bias, segment_ids
         )
-        ref_grad_out = jax.grad(lambda q, k, v, b: ref_fn(q, k, v, b).mean(), argnums=(0, 1, 2))(
-            q, k, v, attention_bias
-        )
+        ref_grad_out = jax.grad(
+            lambda q, k, v, b, s: ref_fn(q, k, v, b, s).mean(), argnums=(0, 1, 2)
+        )(q, k, v, attention_bias, segment_ids)
         self.assertNestedAllClose(grad_out, ref_grad_out, atol=0.05)

--- a/axlearn/vision/attention.py
+++ b/axlearn/vision/attention.py
@@ -167,6 +167,7 @@ class WindowedAttention(MultiheadAttention):
         key: Optional[Tensor] = None,
         value: Optional[Tensor] = None,
         attention_logit_biases: Optional[Tensor] = None,
+        segment_ids: Optional[Tensor] = None,
         return_aux: Optional[set[str]] = None,
     ) -> MultiheadAttention.Output:
         """Computes self-windowed attention for the given query and attention logit biases.
@@ -178,6 +179,8 @@ class WindowedAttention(MultiheadAttention):
             key:   an optional Tensor of shape [batch, source_length, source_dim].
             value: an optional Tensor of shape [batch, source_length, source_dim].
             attention_logit_biases:  See ``On attention logit biases`` in the file comments.
+            segment_ids: Not used. See `On segment_ids` in
+                MultiheadAttention's file comments.
             return_aux: See comments in MultiheadAttention.Output.
 
         Returns:
@@ -187,7 +190,7 @@ class WindowedAttention(MultiheadAttention):
         Raises:
             ValueError: If key & value are an invalid combination.
         """
-
+        del segment_ids
         if key is not None or value is not None:
             raise ValueError("Both key and value must be None for WindowedAttention")
         cfg = self.config
@@ -255,6 +258,7 @@ class WindowedSelfAttentionLayer(TransformerAttentionLayer):
         target: Tensor,
         source: Optional[Tensor] = None,
         attention_logit_biases: Optional[Tensor] = None,
+        segment_ids: Optional[Tensor] = None,
         return_aux: Optional[set[str]] = None,
     ) -> TransformerAttentionLayer.Output:
         """Computes attention with target as query and source as key and value.
@@ -263,6 +267,7 @@ class WindowedSelfAttentionLayer(TransformerAttentionLayer):
             target: a Tensor of shape [batch, target_length, target_dim].
             source: None, uses norm(target) as source for self-attention
             attention_logit_biases: See ``On attention logit biases`` in the file comments.
+            segment_ids: Not used. See `On segment_ids` in MultiheadAttention's file comments.
             return_aux: See comments in TransformerAttentionLayer.Output.
 
         Returns:
@@ -288,6 +293,7 @@ class WindowedSelfAttentionLayer(TransformerAttentionLayer):
                 key=source,
                 value=source,
                 attention_logit_biases=attention_logit_biases,
+                segment_ids=segment_ids,
                 return_aux=return_aux,
             )
             x = atten_output.data

--- a/axlearn/vision/attention.py
+++ b/axlearn/vision/attention.py
@@ -20,6 +20,8 @@ from axlearn.common.attention import (
     KVState,
     MultiheadAttention,
     TransformerAttentionLayer,
+    apply_attention_logit_biases,
+    make_segment_mask,
     softmax_with_biases,
 )
 from axlearn.common.base_layer import ParameterSpec
@@ -190,10 +192,11 @@ class WindowedAttention(MultiheadAttention):
         Raises:
             ValueError: If key & value are an invalid combination.
         """
+        # Merge segment ids into attention_logit_biases.
         if segment_ids is not None:
-            raise ValueError(
-                "segment_ids is not supported. To use segment_ids, construct "
-                "attention_logit_biases using an AttentionLogitBiasLayer."
+            attention_logit_biases = apply_attention_logit_biases(
+                make_segment_mask(source_segments=segment_ids, target_segments=segment_ids),
+                attention_logit_biases,
             )
         if key is not None or value is not None:
             raise ValueError("Both key and value must be None for WindowedAttention")

--- a/axlearn/vision/attention.py
+++ b/axlearn/vision/attention.py
@@ -190,11 +190,10 @@ class WindowedAttention(MultiheadAttention):
         Raises:
             ValueError: If key & value are an invalid combination.
         """
-        if attention_logit_biases is not None and segment_ids is not None:
+        if segment_ids is not None:
             raise ValueError(
-                "Using both segment_ids and attention_logit_biases is not allowed. "
-                "If you have segment_ids, consider merging them into attention_logit_biases using "
-                "AttentionLogitBiasLayer."
+                "segment_ids is not supported. To use segment_ids, construct "
+                "attention_logit_biases using an AttentionLogitBiasLayer."
             )
         if key is not None or value is not None:
             raise ValueError("Both key and value must be None for WindowedAttention")

--- a/axlearn/vision/attention.py
+++ b/axlearn/vision/attention.py
@@ -190,7 +190,10 @@ class WindowedAttention(MultiheadAttention):
         Raises:
             ValueError: If key & value are an invalid combination.
         """
-        del segment_ids
+        # Caller must provide attention_logit_biases when segment_ids specified. segment_ids will
+        # be ignored.
+        if segment_ids is not None and attention_logit_biases is None:
+            raise ValueError("attention_logit_biases must be set in the presence of segment_ids.")
         if key is not None or value is not None:
             raise ValueError("Both key and value must be None for WindowedAttention")
         cfg = self.config

--- a/axlearn/vision/attention.py
+++ b/axlearn/vision/attention.py
@@ -190,10 +190,12 @@ class WindowedAttention(MultiheadAttention):
         Raises:
             ValueError: If key & value are an invalid combination.
         """
-        # Caller must provide attention_logit_biases when segment_ids specified. segment_ids will
-        # be ignored.
-        if segment_ids is not None and attention_logit_biases is None:
-            raise ValueError("attention_logit_biases must be set in the presence of segment_ids.")
+        if attention_logit_biases is not None and segment_ids is not None:
+            raise ValueError(
+                "Using both segment_ids and attention_logit_biases is not allowed. "
+                "If you have segment_ids, consider merging them into attention_logit_biases using "
+                "AttentionLogitBiasLayer."
+            )
         if key is not None or value is not None:
             raise ValueError("Both key and value must be None for WindowedAttention")
         cfg = self.config


### PR DESCRIPTION
In axlearn's current implementation, `segment_ids` is converted into `attention_logit_biases` in Decoder, and only `attention_logit_biases` is exposed to the underlying attention layers. However, although `attention_logit_biases` is more general than `segment_ids`, the materialized [bnts] tensor is often too large for most use cases (e.g. causal masking, segment masking, etc). Since flash attention supports segment_ids natively, we can provide `segment_ids` along with `attention_logit_biases` and use `segment_ids` whenever it is possible.

This change significantly reduces HBM usage of segment masking. `segment_ids` is also useful for implementing segment masking with SplashAttention as well.

I also updated the Triton kernel implementation so that it can take `bias` and `segment_ids` simultaneously.