### PR TITLE
Configurable concurrent restore gb

### DIFF
--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -336,9 +336,7 @@ class TensorStoreStateStorage(StateStorage):
                 max_data_shard_degree=cfg.max_data_shard_degree,
             )
         else:
-            self._manager = array_serialization.GlobalAsyncCheckpointManager(
-                timeout_secs=cfg.timeout_secs
-            )
+            self._manager = GlobalAsyncCheckpointManager(timeout_secs=cfg.timeout_secs)
         if cfg.max_concurrent_restore_gb is not None and cfg.max_concurrent_restore_gb <= 0:
             raise ValueError(
                 f"max_concurrent_restore_gb must be strictly positive. "

--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -344,7 +344,7 @@ class TensorStoreStateStorage(StateStorage):
                 f"max_concurrent_restore_gb must be strictly positive. "
                 f"Got {cfg.max_concurrent_restore_gb}"
             )
-        self._max_concurrent_restore_gb = cfg.max_concurrent_restore_gb
+        self._max_concurrent_restore_gb = cfg.max_concurrent_restore_gb or 32
         self._executor = futures.ThreadPoolExecutor()
 
     @dataclasses.dataclass
@@ -462,7 +462,6 @@ class TensorStoreStateStorage(StateStorage):
         *,
         ckpt_dir: str,
         validation: CheckpointValidationType = CheckpointValidationType.EXACT,
-        concurrent_gb: int = 32,
     ) -> NestedTensor:
         spec = self._get_spec(step, state, ckpt_dir)
         logging.info("Restoring checkpoint from directory %s", ckpt_dir)
@@ -478,8 +477,7 @@ class TensorStoreStateStorage(StateStorage):
             tensorstore_specs=spec.tensorstore_specs,
             global_shapes=spec.shapes,
             dtypes=spec.dtypes,
-            # self._max_concurrent_restore_gb takes priority over concurrent_gb
-            concurrent_gb=self._max_concurrent_restore_gb or concurrent_gb,
+            concurrent_gb=self._max_concurrent_restore_gb,
         )
         state_leaves = []
         for path, value in spec.index:

--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -321,6 +321,7 @@ class TensorStoreStateStorage(StateStorage):
 
         timeout_secs: float = 3600
         max_data_shard_degree: Optional[int] = None
+        # TODO(hanzhi-zhou): rename this to max_concurrent_save_gb.
         max_concurrent_gb: Optional[int] = None
         max_concurrent_restore_gb: Optional[int] = None
 

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -856,7 +856,7 @@ class TensorStoreStateStorageTest(test_utils.TestCase):
             TensorStoreStateStorage.default_config().set(max_concurrent_restore_gb=-2).instantiate()
         t = TensorStoreStateStorage.default_config().instantiate()
         # Test default value.
-        self.assertEqual(t._max_concurrent_restore_gb, None)
+        self.assertEqual(t._max_concurrent_restore_gb, 32)
 
     def test_stop(self):
         storage = TensorStoreStateStorage.default_config().instantiate()

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -851,6 +851,13 @@ class TensorStoreStateStorageTest(test_utils.TestCase):
                 storage._manager, array_serialization.GlobalAsyncCheckpointManager
             )
 
+    def test_max_concurrent_restore_gb_setting(self):
+        with self.assertRaisesRegex(ValueError, "strictly positive"):
+            TensorStoreStateStorage.default_config().set(max_concurrent_restore_gb=-2).instantiate()
+        t = TensorStoreStateStorage.default_config().instantiate()
+        # Test default value.
+        self.assertEqual(t._max_concurrent_restore_gb, 32)
+
     def test_stop(self):
         storage = TensorStoreStateStorage.default_config().instantiate()
         worker_result = None

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -856,7 +856,7 @@ class TensorStoreStateStorageTest(test_utils.TestCase):
             TensorStoreStateStorage.default_config().set(max_concurrent_restore_gb=-2).instantiate()
         t = TensorStoreStateStorage.default_config().instantiate()
         # Test default value.
-        self.assertEqual(t._max_concurrent_restore_gb, 32)
+        self.assertEqual(t._max_concurrent_restore_gb, None)
 
     def test_stop(self):
         storage = TensorStoreStateStorage.default_config().instantiate()

--- a/axlearn/common/state_builder.py
+++ b/axlearn/common/state_builder.py
@@ -400,7 +400,8 @@ class TensorStoreStateStorageBuilder(Builder):
         Returns:
             The restored state.
         """
-        cfg = self.config
+        cfg: Builder.Config = self.config
+        cfg.storage.max_concurrent_restore_gb = cfg.concurrent_gb
         storage = cfg.storage.instantiate()
         step = parse_step_from_dir(cfg.dir)
         restored_state = storage.restore_from_dir(
@@ -408,7 +409,6 @@ class TensorStoreStateStorageBuilder(Builder):
             state=state.trainer_state,
             ckpt_dir=cfg.dir,
             validation=cfg.validation,
-            concurrent_gb=cfg.concurrent_gb,
         )
         built_keys = state.built_keys.union({key for key, _ in flatten_items(restored_state)})
         return Builder.State(step=step, trainer_state=restored_state, built_keys=built_keys)


### PR DESCRIPTION
The default value of 32GB is too small when restoring some large MOE model. Currently, there's no way to specify the `concurrent_gb` arg of `restore_from_dir` when resuming training from a checkpoint. 

Configs here are quite messed-up because there's a `concurrent_gb` in `TensorStoreStateStorageBuilder`, which is only used for inference but not for restoring training checkpoints. Thus, a separate config entry is needed in `TensorStoreStateStorage`.
