### PR TITLE
Fix the signature of TransformerLayer

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -3823,6 +3823,8 @@ class _TransformerPipeline(Pipeline):
         carry_in = dict(data=data)
         return_aux = return_aux or set()
 
+        # Even though attention logit biases do not change across layers, we
+        # include them in the carry so that they are aligned with the microbatches.
         carry_in.update(kwargs)
         carry_in = self._to_microbatches(carry_in)
         self.vlog(3, "carry_in=%s", shapes(carry_in))

--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -3996,7 +3996,9 @@ class StackedTransformerTest(BaseTransformerTest):
                 def _loss(layer_params, data, mask, layer=layer):
                     layer_outputs, layer_output_collection = F(
                         layer,
-                        inputs=dict(data=data, self_attention_logit_biases=mask),
+                        inputs=dict(
+                            data=data, self_attention_logit_biases=mask, target_segment_ids=None
+                        ),
                         state=layer_params,
                         is_training=True,
                         prng_key=jax.random.PRNGKey(0),


### PR DESCRIPTION
#714 added an optional `target_segment_ids` argument to TransformerLayer. This PR fixes the remaining subclasses of `BaseTransformerLayer`.
