### PR TITLE
Attention Logits Bias In-kernel Broadcasting

### DIFF
--- a/axlearn/common/flash_attention/gpu_attention.py
+++ b/axlearn/common/flash_attention/gpu_attention.py
@@ -48,16 +48,21 @@ from axlearn.common.attention import NEG_INF
 Tensor = jax.Array
 
 
-def _bias_mask(
-    q_bias_ids: Tensor,
-    kv_bias_ids: Tensor,
+def _segment_mask(
+    q_segment_ids: Tensor,
+    kv_segment_ids: Tensor,
 ):
-    """Build the segment mask for the given query and key bias ids."""
+    """
+    Build the segment mask for the given query and key bias ids.
+
+    If mask[..., i, j] == True, query position i and key position j
+    are in the same segment.
+    """
     # [B, T, 1] or [T, 1]
-    q_bias_ids = jnp.expand_dims(q_bias_ids, axis=-1)
+    q_segment_ids = jnp.expand_dims(q_segment_ids, axis=-1)
     # [B, 1, S] or [1, S]
-    kv_bias_ids = jnp.expand_dims(kv_bias_ids, axis=-2)
-    return jnp.equal(q_bias_ids, kv_bias_ids).astype(jnp.bool_)
+    kv_segment_ids = jnp.expand_dims(kv_segment_ids, axis=-2)
+    return jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
 
 
 def _mha_forward_kernel(
@@ -141,7 +146,7 @@ def _mha_forward_kernel(
 
         if s_ref is not None:
             kv_segment_ids = pl.load(s_ref, (curr_k_slice,))
-            mask = _bias_mask(q_segment_ids, kv_segment_ids)
+            mask = _segment_mask(q_segment_ids, kv_segment_ids)
             qk = jnp.where(mask, qk, NEG_INF)
 
         if causal:
@@ -185,7 +190,7 @@ def _mha_forward_kernel(
 
 # TODO(kelvin-zou): may decide to deprecate the triton backend if we can fully move to
 # more low-level CUDA kernels.
-@functools.partial(jax.custom_vjp, nondiff_argnums=[4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+@functools.partial(jax.custom_vjp, nondiff_argnums=[5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
 @functools.partial(
     jax.jit,
     static_argnames=[
@@ -246,7 +251,11 @@ def flash_attention(
     bias_block_spec = None
     if bias is not None:
         assert bias.ndim == 4
-        bias_block_spec = pl.BlockSpec(lambda _, j, k: (j, k, 0, 0), (None, None, seq_len, seq_len))
+
+        def bias_index_map(j, k):
+            return (j if bias.shape[0] != 1 else 0, k if bias.shape[1] != 1 else 0, 0, 0)
+
+        bias_block_spec = pl.BlockSpec(bias_index_map, (None, None, seq_len, seq_len))
     # Segment Ids
     segment_ids_block_spec = None
     if segment_ids is not None:
@@ -293,6 +302,7 @@ def _mha_forward(
     key: Tensor,
     value: Tensor,
     bias: Optional[Tensor],
+    segment_ids: Optional[Tensor],
     softmax_scale: float,
     causal: bool,
     block_q: int,
@@ -316,20 +326,20 @@ def _mha_forward(
         grid_ = (pl.cdiv(seq_len, block_q), batch_size, num_heads)
 
     # Bias.
-    bias_type = "none"
     bias_block_spec = None
     if bias is not None:
-        # If we have explicitly defined the bias type as a vector (segment ids).
-        if bias.ndim == 2:
-            bias_type = "vector"
-            bias_block_spec = pl.BlockSpec(lambda _, j, k: (j, 0), (None, seq_len))
-        elif bias.ndim == 4:
-            bias_type = "matrix"
-            bias_block_spec = pl.BlockSpec(
-                lambda _, j, k: (j, k, 0, 0), (None, None, seq_len, seq_len)
-            )
-        else:
-            raise ValueError(f"Invalid bias shape: {bias.shape}")
+        assert bias.ndim == 4
+
+        def bias_index_map(j, k):
+            return (j if bias.shape[0] != 1 else 0, k if bias.shape[1] != 1 else 0, 0, 0)
+
+        bias_block_spec = pl.BlockSpec(bias_index_map, (None, None, seq_len, seq_len))
+
+    # Segment Ids.
+    segment_ids_block_spec = None
+    if segment_ids is not None:
+        assert segment_ids.ndim == 2
+        segment_ids_block_spec = pl.BlockSpec(lambda _, j, k: (j, 0), (None, seq_len))
 
     num_warps_ = num_warps
     if num_warps_ is None:
@@ -340,7 +350,6 @@ def _mha_forward(
     kernel = functools.partial(
         _mha_forward_kernel,
         softmax_scale=softmax_scale,
-        bias_type=bias_type,
         causal=causal,
         block_q=block_q,
         block_k=block_k,
@@ -360,6 +369,7 @@ def _mha_forward(
             pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # key
             pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # value
             bias_block_spec,  # bias
+            segment_ids_block_spec,  # segment_ids
         ],
         out_specs=[
             pl.BlockSpec(lambda _, j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
@@ -371,8 +381,8 @@ def _mha_forward(
         debug=debug,
         interpret=interpret,
         name="mha_forward",
-    )(query, key, value, bias)
-    return out, (query, key, value, bias, out, l, m)
+    )(query, key, value, bias, segment_ids)
+    return out, (query, key, value, bias, segment_ids, out, l, m)
 
 
 def _preprocess_backward_kernel(
@@ -445,6 +455,7 @@ def _mha_backward_kernel(
     k_ref,
     v_ref,
     b_ref,
+    s_ref,
     out_ref,
     do_scaled_ref,
     l_ref,
@@ -457,7 +468,6 @@ def _mha_backward_kernel(
     dv_ref,
     *,
     softmax_scale: float,
-    bias_type: str,
     causal: bool,
     block_q: int,
     block_d: int,
@@ -474,6 +484,7 @@ def _mha_backward_kernel(
         k_ref: Input key ref.
         v_ref: Input value ref.
         b_ref: Input bias ref.
+        s_ref: Input segment_ids ref.
         out_ref: Input forward output ref.
         do_scaled_ref: Preprocessed dOut ref. See `_preprocess_backward_kernel`.
         l_ref: Input l ref.
@@ -499,7 +510,7 @@ def _mha_backward_kernel(
         k = pl.load(k_ref, (slice_k, slice(None)))
         v = pl.load(v_ref, (slice_k, slice(None)))
         span_k = start_k * block_k + jnp.arange(block_k)
-        kv_bias_ids = None if bias_type != "vector" else pl.load(b_ref, (slice_k))
+        kv_segment_ids = None if s_ref is None else pl.load(s_ref, (slice_k))
 
         def inner_loop(start_q, carry):
             dv, dk = carry
@@ -512,7 +523,7 @@ def _mha_backward_kernel(
 
             if softmax_scale != 1.0:
                 qk *= softmax_scale
-            if bias_type == "matrix":
+            if b_ref is not None:
                 # Load bias in transposed order, for hopefully better cache efficiency.
                 b = pl.load(
                     b_ref,
@@ -520,18 +531,14 @@ def _mha_backward_kernel(
                 )
                 b = b.astype(jnp.float32)
                 qk += b.T  # Transpose back.
-            elif bias_type == "vector":
-                q_bias_ids = pl.load(b_ref, (slice_q))
-            if causal or bias_type == "vector":
-                mask = None
-                if bias_type == "vector":
-                    mask = _bias_mask(q_bias_ids, kv_bias_ids)
-                if causal:
-                    span_q = start_q * block_q + jnp.arange(block_q)
-                    causal_mask = span_q[:, None] >= span_k[None, :]
-                    mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+            if s_ref is not None:
+                q_segment_ids = pl.load(s_ref, (slice_q))
+                mask = _segment_mask(q_segment_ids, kv_segment_ids)
                 qk = jnp.where(mask, qk, NEG_INF)
-
+            if causal:
+                span_q = start_q * block_q + jnp.arange(block_q)
+                mask = span_q[:, None] >= span_k[None, :]
+                qk = jnp.where(mask, qk, NEG_INF)
             m = pl.load(m_ref, (slice_q,))
             p = jnp.exp(qk - m[:, None])
             do = pl.load(do_scaled_ref, (slice_q, slice(None)))
@@ -579,7 +586,7 @@ def _mha_backward(
 ):
     """Calls `_mha_backward_kernel`."""
     del num_warps, num_stages, grid
-    q, k, v, b, out, l, m = res
+    q, k, v, b, s, out, l, m = res
 
     # NOTE: temporarily removed the "xla" branch, which seems unused.
     if backward_pass_impl == "triton":
@@ -597,25 +604,28 @@ def _mha_backward(
             jax.ShapeDtypeStruct(v.shape, v.dtype),
         ]
 
+        num_input = 8
+
         # Bias.
-        bias_type = "none"
         bias_block_spec = None
-        input_output_aliases = {8: 0}
         if b is not None:
-            if b.ndim == 2:
-                bias_type = "vector"
-                bias_block_spec = pl.BlockSpec(lambda j, k: (j, 0), (None, seq_len))
-            elif b.ndim == 4:
-                bias_type = "matrix"
-                # Transpose seq dims for cache efficiency.
-                b = jnp.moveaxis(b, -1, -2)
-                bias_block_spec = pl.BlockSpec(
-                    lambda j, k: (j, k, 0, 0), (None, None, seq_len, seq_len)
-                )
-            else:
-                raise ValueError(f"Invalid bias shape: {b.shape}")
-            # We have one more non-None input (i.e., in_specs has another tree_leaf).
-            input_output_aliases = {9: 0}
+            assert b.ndim == 4
+            b = jnp.moveaxis(b, -1, -2)
+
+            def bias_index_map(j, k):
+                return (j if b.shape[0] != 1 else 0, k if b.shape[1] != 1 else 0, 0, 0)
+
+            bias_block_spec = pl.BlockSpec(bias_index_map, (None, None, seq_len, seq_len))
+            num_input += 1
+
+        # Segment Ids.
+        segment_ids_block_spec = None
+        if s is not None:
+            assert s.ndim == 2
+            segment_ids_block_spec = pl.BlockSpec(lambda j, k: (j, 0), (None, seq_len))
+            num_input += 1
+
+        input_output_aliases = {num_input: 0}
 
         grid = (batch_size, num_heads)
         # TODO(markblee): num_warps=8 seems to work from basic testing, confirm the below comment.
@@ -625,7 +635,6 @@ def _mha_backward(
             functools.partial(
                 _mha_backward_kernel,
                 softmax_scale=softmax_scale,
-                bias_type=bias_type,
                 causal=causal,
                 block_q=block_q,
                 block_d=head_dim,
@@ -638,6 +647,7 @@ def _mha_backward(
                 pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # key
                 pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),  # value
                 bias_block_spec,  # bias
+                segment_ids_block_spec,  # segment_ids
                 pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
                 pl.BlockSpec(lambda j, k: (j, 0, k, 0), (None, seq_len, None, head_dim)),
                 pl.BlockSpec(lambda j, k: (j, k, 0), (None, None, seq_len)),
@@ -655,10 +665,10 @@ def _mha_backward(
             interpret=interpret,
             compiler_params=dict(triton=dict(num_warps=num_warps, num_stages=1)),
             input_output_aliases=input_output_aliases,
-        )(q, k, v, b, out, do_scaled, l, m, delta, dq)
+        )(q, k, v, b, s, out, do_scaled, l, m, delta, dq)
     else:
         raise ValueError(f"Invalid backward pass implementation: {backward_pass_impl}")
-    return dq.astype(q.dtype), dk, dv, None
+    return dq.astype(q.dtype), dk, dv, None, None
 
 
 flash_attention.defvjp(_mha_forward, _mha_backward)

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -8,10 +8,23 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from absl import logging
-from jax.experimental.pallas.ops.tpu.flash_attention import BlockSizes as LegacyBlockSizes
-from jax.experimental.pallas.ops.tpu.flash_attention import SegmentIds
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
 from jax.experimental.pallas.ops.tpu.flash_attention import (
-    flash_attention as pallas_tpu_flash_attention,
+    DEFAULT_MASK_VALUE,
+    MIN_BLOCK_SIZE,
+    NUM_LANES,
+    NUM_SUBLANES,
+)
+from jax.experimental.pallas.ops.tpu.flash_attention import BlockSizes as LegacyBlockSizes
+from jax.experimental.pallas.ops.tpu.flash_attention import (
+    SegmentIds,
+    _flash_attention_dkv_kernel,
+    _flash_attention_dq_kernel,
+    _flash_attention_kernel,
+    _verify_block,
+    below_or_on_diag,
 )
 from jax.experimental.pallas.ops.tpu.splash_attention import (
     splash_attention_kernel,
@@ -45,7 +58,8 @@ def tpu_flash_attention(
         query: The query tensor, of shape [batch_size, source_len, num_heads, head_dim].
         key: The key tensor, of shape [batch_size, target_len, num_heads, head_dim].
         value: The value tensor, of shape [batch_size, target_len, num_heads, head_dim].
-        bias: The attention biases, of shape [batch_size, num_heads, source_len, target_len].
+        bias: The attention biases, can broadcast to shape
+            [batch_size, num_heads, source_len, target_len].
         segment_ids: The id of which segment each token belongs to. Attention is not computed
              between tokens in different segments.
              Shape:  [batch_size, source_len].
@@ -367,3 +381,779 @@ class ComputableMask(splash_attention_mask.Mask):
 
     def __hash__(self) -> int:
         return hash(self._to_hashable())
+
+
+# The following code is adapted from jax-ml/jax:
+# Copyright 2023 The JAX Authors.
+# Licensed under the Apache License, Version 2.0 (the "License").
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "causal",
+        "sm_scale",
+        "block_sizes",
+        "debug",
+    ],
+)
+def pallas_tpu_flash_attention(
+    q,  # [batch_size, num_heads, q_seq_len, d_model]
+    k,  # [batch_size, num_heads, kv_seq_len, d_model]
+    v,  # [batch_size, num_heads, kv_seq_len, d_model]
+    ab=None,  # [batch_size, num_heads, q_seq_len, kv_seq_len] or [1, 1, q_seq_len, kv_seq_len]
+    segment_ids=None,  # q of [batch_size, q_seq_len] and kv of [batch_size, kv_seq_len]
+    *,
+    causal: bool = False,
+    sm_scale: float = 1.0,
+    block_sizes: Optional[LegacyBlockSizes] = None,
+    debug: bool = False,
+):
+    batch_size, num_heads, q_seq_len, d_model = q.shape
+    batch_size_k, num_heads_k, kv_seq_len, d_model_k = k.shape
+    batch_size_v, num_heads_v, kv_seq_len_v, d_model_v = v.shape
+    if batch_size != batch_size_k or batch_size != batch_size_v:
+        raise ValueError(
+            f"Batch size mismatch: got {batch_size}, {batch_size_k} and"
+            f" {batch_size_v} (for q, k, v respectively)"
+        )
+    if num_heads != num_heads_k or num_heads != num_heads_v:
+        raise ValueError(
+            f"Head count mismatch: got {num_heads}, {num_heads_k},"
+            f" {num_heads_v} (for q, k, v respectively)"
+        )
+    if d_model != d_model_k:
+        raise ValueError(
+            f"Model dimension mismatch: got {d_model} and {d_model_k} (for q and k" " respectively)"
+        )
+    if d_model != d_model_v:
+        raise NotImplementedError("V model dimension unequal to KV model dimension unsupported")
+    if kv_seq_len != kv_seq_len_v:
+        raise ValueError(f"KV sequence length mismatch: got {kv_seq_len} and {kv_seq_len_v}")
+    if ab is not None:
+        if ab.shape not in [
+            (batch_size, num_heads, q_seq_len, kv_seq_len),
+            (batch_size, 1, q_seq_len, kv_seq_len),
+            (1, num_heads, q_seq_len, kv_seq_len),
+            (1, 1, q_seq_len, kv_seq_len),
+        ]:
+            raise ValueError(
+                f"Attention bias shape mismatch: expected to broadcast ({batch_size=},"
+                f" {num_heads=}, {q_seq_len=}, {kv_seq_len=})"
+            )
+    if segment_ids is not None:
+        if segment_ids.q.shape != (batch_size, q_seq_len):
+            raise ValueError(
+                f"Q segment ids shape mismatch: expected ({batch_size=},"
+                f" {q_seq_len=},), got {segment_ids.q.shape}"
+            )
+        if segment_ids.kv.shape != (batch_size, kv_seq_len):
+            raise ValueError(
+                f"KV segment ids shape mismatch: expected ({batch_size=},"
+                f" {kv_seq_len=},), got {segment_ids.kv.shape}"
+            )
+    if block_sizes is None:
+        block_sizes = LegacyBlockSizes.get_default(
+            batch_size, num_heads, q_seq_len, kv_seq_len, d_model
+        )
+    return _flash_attention(q, k, v, ab, segment_ids, False, causal, sm_scale, block_sizes, debug)
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=range(5, 10))
+def _flash_attention(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_sizes,
+    debug,
+):
+    return _flash_attention_impl(
+        q,
+        k,
+        v,
+        ab,
+        segment_ids,
+        save_residuals,
+        causal,
+        sm_scale,
+        block_sizes.block_b,
+        block_sizes.block_q,
+        block_sizes.block_k_major,
+        block_sizes.block_k,
+        debug,
+    )
+
+
+def _flash_attention_fwd(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_sizes,
+    debug,
+):
+    if save_residuals:
+        raise NotImplementedError("Higher-order AD not supported")
+    o, l, m = _flash_attention(q, k, v, ab, segment_ids, True, causal, sm_scale, block_sizes, debug)
+    return o, (q, k, v, ab, segment_ids, o, l, m)
+
+
+def _flash_attention_bwd(
+    save_residuals: bool,
+    causal: bool,
+    sm_scale: float,
+    block_sizes: LegacyBlockSizes,
+    debug: bool,
+    residuals,
+    do,
+):
+    """VJP rule for FlashAttention."""
+    if save_residuals:
+        raise NotImplementedError("Higher-order AD not supported")
+    (q, k, v, ab, segment_ids, o, l, m) = residuals
+    if not block_sizes.has_backward_blocks:
+        raise ValueError(
+            "Program is being differentiated, but not all backward blocks are" " specified"
+        )
+
+    di = jnp.sum(
+        o.astype(jnp.float32) * do.astype(jnp.float32), axis=-1
+    )  # [batch_size, num_heads, q_seq_len]
+
+    dk, dv = _flash_attention_bwd_dkv(
+        q,
+        k,
+        v,
+        ab,
+        segment_ids,
+        l,
+        m,
+        do,
+        di,
+        block_q_major=block_sizes.block_q_major_dkv,
+        block_k_major=block_sizes.block_k_major_dkv,
+        block_k=block_sizes.block_k_dkv,
+        block_q=block_sizes.block_q_dkv,
+        sm_scale=sm_scale,
+        causal=causal,
+        mask_value=DEFAULT_MASK_VALUE,
+        debug=debug,
+    )
+
+    dq, ds = _flash_attention_bwd_dq(
+        q,
+        k,
+        v,
+        ab,
+        segment_ids,
+        l,
+        m,
+        do,
+        di,
+        block_q_major=block_sizes.block_q_dq,
+        block_k_major=block_sizes.block_k_major_dq,
+        block_k=block_sizes.block_k_dq,
+        sm_scale=sm_scale,
+        causal=causal,
+        mask_value=DEFAULT_MASK_VALUE,
+        debug=debug,
+    )
+    return dq, dk, dv, ds, None
+
+
+_flash_attention.defvjp(fwd=_flash_attention_fwd, bwd=_flash_attention_bwd)
+
+
+def _flash_attention_impl(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_b,
+    block_q,
+    block_k_major,
+    block_k,
+    debug,
+):
+    batch_size, num_heads, q_seq_len, head_dim = q.shape
+    _, _, kv_seq_len, _ = k.shape
+    _verify_block("block_q", "q_seq_len", block_q, q_seq_len, should_divide=False)
+    _verify_block("block_k_major", "kv_seq_len", block_k_major, kv_seq_len)
+    _verify_block("block_k", "kv_seq_len", block_k, kv_seq_len)
+    _verify_block("block_b", "batch", block_b, batch_size, should_divide=False)
+
+    # TODO(apaszke): Tile over heads as well.
+    grid = (
+        pl.cdiv(batch_size, block_b),
+        num_heads,
+        pl.cdiv(q_seq_len, block_q),
+        kv_seq_len // block_k_major,
+    )
+
+    def q_index_map(batch_index, head_index, q_seq_index, _):
+        return (batch_index, head_index, q_seq_index, 0)
+
+    def kv_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+        if causal:
+            # If the kv block is skipped, prefetch the next valid kv block, i.e. the
+            # 0th one to be used for the next block_q rows.
+            next_kv_index = lax.select(
+                below_or_on_diag(q_seq_index, block_q, kv_seq_index, block_k_major),
+                kv_seq_index,
+                0,
+            )
+        else:
+            next_kv_index = kv_seq_index
+        return (batch_index, head_index, next_kv_index, 0)
+
+    def ab_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+        if causal:
+            should_run = below_or_on_diag(q_seq_index, block_q, kv_seq_index, block_k_major)
+            # If the ab block is skipped, prefetch the next valid ab block, i.e. the
+            # 0th kv to be used for the next block_q rows.
+            next_q_index = lax.select(
+                should_run,
+                q_seq_index,
+                lax.select(q_seq_index == (q_seq_len // block_q) - 1, 0, q_seq_index + 1),
+            )
+            next_kv_index = lax.select(should_run, kv_seq_index, 0)
+        else:
+            next_q_index = q_seq_index
+            next_kv_index = kv_seq_index
+        return (
+            batch_index if ab.shape[0] != 1 else 0,
+            head_index if ab.shape[1] != 1 else 0,
+            next_q_index,
+            next_kv_index,
+        )
+
+    def o_index_map(batch_index, head_index, q_seq_index, _):
+        return (batch_index, head_index, q_seq_index, 0)
+
+    def lm_index_map(batch_index, head_index, q_seq_index, _):
+        return (batch_index, head_index, q_seq_index, 0)
+
+    kernel = functools.partial(
+        _flash_attention_kernel,
+        causal=causal,
+        mask_value=DEFAULT_MASK_VALUE,
+        sm_scale=sm_scale,
+        block_k=block_k,
+        kv_seq_len=kv_seq_len,
+    )
+    out_shape = jax.ShapeDtypeStruct(shape=q.shape, dtype=q.dtype)
+    out_shape = [out_shape]
+    out_specs = [pl.BlockSpec(o_index_map, (block_b, 1, block_q, head_dim))]
+
+    if block_k != kv_seq_len:
+        m_scratch = pltpu.VMEM((block_b, 1, block_q, MIN_BLOCK_SIZE), jnp.float32)
+        l_scratch = pltpu.VMEM((block_b, 1, block_q, MIN_BLOCK_SIZE), jnp.float32)
+        acc_scratch = pltpu.VMEM((block_b, 1, block_q, head_dim), jnp.float32)
+        scratch_shapes = [m_scratch, l_scratch, acc_scratch]
+    else:
+        scratch_shapes = []
+
+    if save_residuals:
+        out_specs = [
+            *out_specs,
+            pl.BlockSpec(lm_index_map, (block_b, 1, block_q, MIN_BLOCK_SIZE)),
+            pl.BlockSpec(lm_index_map, (block_b, 1, block_q, MIN_BLOCK_SIZE)),
+        ]
+        l = jax.ShapeDtypeStruct(
+            (batch_size, num_heads, q_seq_len, MIN_BLOCK_SIZE), dtype=jnp.float32
+        )
+        m = jax.ShapeDtypeStruct(
+            (batch_size, num_heads, q_seq_len, MIN_BLOCK_SIZE), dtype=jnp.float32
+        )
+        out_shape = (*out_shape, l, m)
+    else:
+        out_specs = [*out_specs, None, None]
+        out_shape = (*out_shape, None, None)
+
+    ab_block_spec = (
+        pl.BlockSpec(ab_index_map, (block_b, 1, block_q, block_k_major)) if ab is not None else None
+    )
+
+    q_segment_ids_spec = kv_segment_ids_spec = None
+    q_segment_ids = kv_segment_ids = None
+    if segment_ids is not None:
+
+        def q_segment_ids_index_map(batch_index, head_index, q_seq_index, _):
+            del head_index
+            return (batch_index, q_seq_index, 0)
+
+        def kv_segment_ids_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+            del head_index
+            if causal:
+                next_kv_index = lax.select(
+                    below_or_on_diag(q_seq_index, block_q, kv_seq_index, block_k_major),
+                    kv_seq_index,
+                    0,
+                )
+            else:
+                next_kv_index = kv_seq_index
+            return (batch_index, 0, next_kv_index)
+
+        q_segment_ids_spec = pl.BlockSpec(q_segment_ids_index_map, (block_b, block_q, NUM_LANES))
+        kv_segment_ids_spec = pl.BlockSpec(
+            kv_segment_ids_index_map, (block_b, NUM_SUBLANES, block_k_major)
+        )
+
+        q_segment_ids = jax.lax.broadcast_in_dim(
+            segment_ids.q,
+            (batch_size, q_seq_len, NUM_LANES),
+            (
+                0,
+                1,
+            ),
+        )
+        kv_segment_ids = jax.lax.broadcast_in_dim(
+            segment_ids.kv,
+            (batch_size, NUM_SUBLANES, kv_seq_len),
+            (
+                0,
+                2,
+            ),
+        )
+
+    in_specs = [
+        pl.BlockSpec(q_index_map, (block_b, 1, block_q, head_dim)),
+        pl.BlockSpec(kv_index_map, (block_b, 1, block_k_major, head_dim)),
+        pl.BlockSpec(kv_index_map, (block_b, 1, block_k_major, head_dim)),
+        ab_block_spec,
+        q_segment_ids_spec,
+        kv_segment_ids_spec,
+    ]
+
+    o, *aux = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=0,
+            grid=grid,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            scratch_shapes=scratch_shapes,
+        ),
+        out_shape=out_shape,
+        debug=debug,
+        compiler_params=dict(
+            mosaic=dict(
+                dimension_semantics=(
+                    "parallel",
+                    "parallel",
+                    "parallel",
+                    "arbitrary",
+                )
+            )
+        ),
+    )(q, k, v, ab, q_segment_ids, kv_segment_ids)
+    if save_residuals:
+        l, m = (v[..., 0] for v in aux[-2:])
+        return (o, l, m)
+    else:
+        return o
+
+
+def _flash_attention_bwd_dkv(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    l,
+    m,
+    do,
+    di,
+    *,
+    block_q_major: Optional[int],
+    block_q: Optional[int],
+    block_k_major: Optional[int],
+    block_k: Optional[int],
+    sm_scale: float,
+    causal: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    debug: bool = False,
+):
+    batch_size, num_heads, q_seq_len, head_dim = q.shape
+    _, _, kv_seq_len, _ = k.shape
+    _verify_block("block_q_major_dkv", "q_seq_len", block_q_major, q_seq_len)
+    _verify_block("block_q_dkv", "q_seq_len", block_q, q_seq_len)
+    _verify_block("block_k_major_dkv", "kv_seq_len", block_k_major, kv_seq_len)
+    _verify_block("block_k_dkv", "kv_seq_len", block_k, kv_seq_len)
+
+    # Broadcast out scalar values
+    m = jnp.broadcast_to(m[..., None], (*m.shape, MIN_BLOCK_SIZE))
+    l = jnp.broadcast_to(l[..., None], (*l.shape, MIN_BLOCK_SIZE))
+    # Preprocess contraction for bwd pass
+    di = jnp.broadcast_to(di[..., None], (*di.shape, MIN_BLOCK_SIZE))
+
+    # kv index needs to be before q index since q index is the contractng
+    # dimension.
+    grid = (
+        batch_size,
+        num_heads,
+        kv_seq_len // block_k_major,
+        q_seq_len // block_q_major,
+    )
+
+    def qo_index_map(batch_index, head_index, kv_seq_index, q_seq_index):
+        if causal:
+            # If the q block is skipped, stay at the 0th q block.
+            next_q_index = lax.select(
+                below_or_on_diag(q_seq_index, block_q_major, kv_seq_index, block_k_major),
+                q_seq_index,
+                0,
+            )
+        else:
+            next_q_index = q_seq_index
+
+        return (batch_index, head_index, next_q_index, 0)
+
+    qo_spec = pl.BlockSpec(qo_index_map, (1, 1, block_q_major, head_dim))
+    assert qo_spec.block_shape is not None
+    assert q.ndim == len(qo_spec.block_shape)
+    do_spec = qo_spec
+    assert do.ndim == len(qo_spec.block_shape)
+
+    def kv_index_map(batch_index, head_index, kv_seq_index, _):
+        return (batch_index, head_index, kv_seq_index, 0)
+
+    kv_spec = pl.BlockSpec(kv_index_map, (1, 1, block_k_major, head_dim))
+    assert kv_spec.block_shape is not None
+    assert k.ndim == len(kv_spec.block_shape)
+    assert v.ndim == len(kv_spec.block_shape)
+
+    def lm_index_map(batch_index, head_index, _, q_seq_index):
+        return (batch_index, head_index, q_seq_index, 0)
+
+    lm_spec = pl.BlockSpec(lm_index_map, (1, 1, block_q_major, MIN_BLOCK_SIZE))
+    assert lm_spec.block_shape is not None
+    assert l.ndim == len(lm_spec.block_shape)
+    assert m.ndim == len(lm_spec.block_shape)
+
+    di_spec = pl.BlockSpec(qo_index_map, (1, 1, block_q_major, MIN_BLOCK_SIZE))
+    assert di_spec.block_shape is not None
+    assert di.ndim == len(di_spec.block_shape)
+
+    def ab_index_map(batch_index, head_index, kv_seq_index, q_seq_index):
+        return (
+            batch_index if ab.shape[0] != 1 else 0,
+            head_index if ab.shape[1] != 1 else 0,
+            q_seq_index,
+            kv_seq_index,
+        )
+
+    dab_spec = (
+        pl.BlockSpec(ab_index_map, (1, 1, block_q_major, block_k_major)) if ab is not None else None
+    )
+
+    q_segment_ids_spec = kv_segment_ids_spec = None
+    q_segment_ids = kv_segment_ids = None
+    if segment_ids is not None:
+
+        def q_segment_ids_index_map(batch_index, head_index, kv_seq_index, q_seq_index):
+            del head_index
+            if causal:
+                next_q_index = lax.select(
+                    below_or_on_diag(q_seq_index, block_q_major, kv_seq_index, block_k_major),
+                    q_seq_index,
+                    0,
+                )
+            else:
+                next_q_index = q_seq_index
+            return (batch_index, next_q_index, 0)
+
+        def kv_segment_ids_index_map(batch_index, head_index, kv_seq_index, _):
+            del head_index
+            return (batch_index, 0, kv_seq_index)
+
+        q_segment_ids_spec = pl.BlockSpec(q_segment_ids_index_map, (1, block_q_major, NUM_LANES))
+        kv_segment_ids_spec = pl.BlockSpec(
+            kv_segment_ids_index_map, (1, NUM_SUBLANES, block_k_major)
+        )
+
+        q_segment_ids = jax.lax.broadcast_in_dim(
+            segment_ids.q,
+            (batch_size, q_seq_len, NUM_LANES),
+            (
+                0,
+                1,
+            ),
+        )
+        kv_segment_ids = jax.lax.broadcast_in_dim(
+            segment_ids.kv,
+            (batch_size, NUM_SUBLANES, kv_seq_len),
+            (
+                0,
+                2,
+            ),
+        )
+
+    in_specs = [
+        qo_spec,
+        kv_spec,
+        kv_spec,
+        dab_spec,
+        q_segment_ids_spec,
+        kv_segment_ids_spec,
+        lm_spec,
+        lm_spec,
+        do_spec,
+        di_spec,
+    ]
+
+    out_shapes = [
+        jax.ShapeDtypeStruct((batch_size, num_heads, kv_seq_len, head_dim), k.dtype),
+        jax.ShapeDtypeStruct((batch_size, num_heads, kv_seq_len, head_dim), v.dtype),
+    ]
+
+    def dkv_index_map(batch_index, head_index, kv_seq_index, _):
+        return (batch_index, head_index, kv_seq_index, 0)
+
+    dkv_spec = pl.BlockSpec(dkv_index_map, (1, 1, block_k_major, head_dim))
+    out_specs = [dkv_spec, dkv_spec]
+    scratch_shapes = [
+        pltpu.VMEM((block_k_major, head_dim), jnp.float32),  # type: ignore
+        pltpu.VMEM((block_k_major, head_dim), jnp.float32),  # type: ignore
+    ]
+
+    kernel = functools.partial(
+        _flash_attention_dkv_kernel,
+        block_q=block_q,
+        block_k=block_k,
+        sm_scale=sm_scale,
+        causal=causal,
+        mask_value=mask_value,
+        q_seq_len=q_seq_len,
+    )
+    name_scope = f"flash_mha_bwd_dkv_{block_q_major=}_{block_q=}_{block_k_major=}_{block_k=}"
+    with jax.named_scope(name_scope):
+        dk, dv = pl.pallas_call(
+            kernel,
+            grid_spec=pltpu.PrefetchScalarGridSpec(
+                num_scalar_prefetch=0,
+                grid=grid,
+                in_specs=in_specs,
+                out_specs=out_specs,
+                scratch_shapes=scratch_shapes,
+            ),
+            out_shape=out_shapes,
+            debug=debug,
+            compiler_params=dict(
+                mosaic=dict(
+                    dimension_semantics=(
+                        "parallel",
+                        "parallel",
+                        "parallel",
+                        "arbitrary",
+                    )
+                )
+            ),
+        )(q, k, v, ab, q_segment_ids, kv_segment_ids, l, m, do, di)
+        assert dk.shape == k.shape
+        assert dv.shape == v.shape
+    return dk, dv
+
+
+def _flash_attention_bwd_dq(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    l,
+    m,
+    do,
+    di,
+    *,
+    block_q_major: Optional[int],
+    block_k_major: Optional[int],
+    block_k: Optional[int],
+    sm_scale: float,
+    causal: bool,
+    mask_value: float,
+    debug: bool,
+):
+    batch_size, num_heads, q_seq_len, head_dim = q.shape
+    _, _, kv_seq_len, _ = k.shape
+    _verify_block("block_q_dq", "q_seq_len", block_q_major, q_seq_len)
+    _verify_block("block_k_major_dq", "kv_seq_len", block_k_major, kv_seq_len)
+    _verify_block("block_k_dq", "block_k", block_k, kv_seq_len)
+
+    # Broadcast out scalar values
+    m = jnp.broadcast_to(m[..., None], (*m.shape, MIN_BLOCK_SIZE))
+    l = jnp.broadcast_to(l[..., None], (*l.shape, MIN_BLOCK_SIZE))
+    # Preprocess contraction for bwd pass
+    di = jnp.broadcast_to(di[..., None], (*di.shape, block_k_major))
+
+    grid = (
+        batch_size,
+        num_heads,
+        q_seq_len // block_q_major,
+        kv_seq_len // block_k_major,
+    )
+
+    def qo_index_map(batch_index, head_index, q_seq_index, _):
+        return (batch_index, head_index, q_seq_index, 0)
+
+    qo_spec = pl.BlockSpec(qo_index_map, (1, 1, block_q_major, head_dim))
+    do_spec = qo_spec
+
+    def kv_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+        if causal:
+            # If the kv block is skipped, prefetch the next valid kv block, i.e. the
+            # 0th one to be used for the next block_q rows.
+            next_kv_index = lax.select(
+                below_or_on_diag(q_seq_index, block_q_major, kv_seq_index, block_k_major),
+                kv_seq_index,
+                0,
+            )
+        else:
+            next_kv_index = kv_seq_index
+        return (batch_index, head_index, next_kv_index, 0)
+
+    kv_spec = pl.BlockSpec(kv_index_map, (1, 1, block_k_major, head_dim))
+    assert kv_spec.block_shape is not None
+    assert k.ndim == len(kv_spec.block_shape)
+    assert v.ndim == len(kv_spec.block_shape)
+
+    def lm_index_map(batch_index, head_index, q_seq_index, _):
+        return (batch_index, head_index, q_seq_index, 0)
+
+    lm_spec = pl.BlockSpec(lm_index_map, (1, 1, block_q_major, MIN_BLOCK_SIZE))
+    assert lm_spec.block_shape is not None
+    assert l.ndim == len(lm_spec.block_shape)
+    assert m.ndim == len(lm_spec.block_shape)
+
+    di_spec = pl.BlockSpec(qo_index_map, (1, 1, block_q_major, MIN_BLOCK_SIZE))
+    assert di_spec.block_shape is not None
+    assert di.ndim == len(di_spec.block_shape)
+
+    def ab_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+        return (
+            batch_index if ab.shape[0] != 1 else 0,
+            head_index if ab.shape[1] != 1 else 0,
+            q_seq_index,
+            kv_seq_index,
+        )
+
+    dab_spec = (
+        pl.BlockSpec(ab_index_map, (1, 1, block_q_major, block_k_major)) if ab is not None else None
+    )
+
+    q_segment_ids_spec = kv_segment_ids_spec = None
+    q_segment_ids = kv_segment_ids = None
+    if segment_ids is not None:
+
+        def q_segment_ids_index_map(batch_index, head_index, q_seq_index, _):
+            del head_index
+            return (batch_index, q_seq_index, 0)
+
+        def kv_segment_ids_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+            del head_index
+            if causal:
+                # If the kv block is skipped, prefetch the next valid kv block, i.e. the
+                # 0th one to be used for the next block_q rows.
+                next_kv_index = lax.select(
+                    below_or_on_diag(q_seq_index, block_q_major, kv_seq_index, block_k_major),
+                    kv_seq_index,
+                    0,
+                )
+            else:
+                next_kv_index = kv_seq_index
+            return (batch_index, 0, next_kv_index)
+
+        q_segment_ids_spec = pl.BlockSpec(q_segment_ids_index_map, (1, block_q_major, NUM_LANES))
+        kv_segment_ids_spec = pl.BlockSpec(
+            kv_segment_ids_index_map, (1, NUM_SUBLANES, block_k_major)
+        )
+
+        q_segment_ids = jax.lax.broadcast_in_dim(
+            segment_ids.q,
+            (batch_size, q_seq_len, NUM_LANES),
+            (
+                0,
+                1,
+            ),
+        )
+        kv_segment_ids = jax.lax.broadcast_in_dim(
+            segment_ids.kv,
+            (batch_size, NUM_SUBLANES, kv_seq_len),
+            (
+                0,
+                2,
+            ),
+        )
+
+    in_specs = [
+        qo_spec,
+        kv_spec,
+        kv_spec,
+        dab_spec,
+        q_segment_ids_spec,
+        kv_segment_ids_spec,
+        lm_spec,
+        lm_spec,
+        do_spec,
+        di_spec,
+    ]
+
+    out_shapes = [
+        jax.ShapeDtypeStruct(q.shape, q.dtype),
+        jax.ShapeDtypeStruct(ab.shape, ab.dtype) if ab is not None else None,
+    ]
+    dq_spec = pl.BlockSpec(qo_index_map, (1, 1, block_q_major, head_dim))
+    out_specs = [
+        dq_spec,
+        dab_spec,
+    ]
+    scratch_shapes = [pltpu.VMEM((block_q_major, head_dim), jnp.float32)]  # type: ignore
+
+    kernel = functools.partial(
+        _flash_attention_dq_kernel,
+        sm_scale=sm_scale,
+        causal=causal,
+        mask_value=mask_value,
+        block_k=block_k,
+        kv_seq_len=kv_seq_len,
+    )
+    name_scope = f"flash_mha_bwd_dq_{block_q_major=}_{block_k_major=}_{block_k=}"
+    with jax.named_scope(name_scope):
+        dq, ds = pl.pallas_call(
+            kernel,
+            grid_spec=pltpu.PrefetchScalarGridSpec(
+                num_scalar_prefetch=0,
+                grid=grid,
+                in_specs=in_specs,
+                out_specs=out_specs,
+                scratch_shapes=scratch_shapes,
+            ),
+            out_shape=out_shapes,
+            debug=debug,
+            compiler_params=dict(
+                mosaic=dict(
+                    dimension_semantics=(
+                        "parallel",
+                        "parallel",
+                        "parallel",
+                        "arbitrary",
+                    )
+                )
+            ),
+        )(q, k, v, ab, q_segment_ids, kv_segment_ids, l, m, do, di)
+
+    # dab is just ds
+    return dq, ds


### PR DESCRIPTION
This PR implements **"logits bias in-kernel broadcasting"** for Flash Attention kernels, which allows passing `[None, None, seq_len, seq_len]` shaped attention logits bias to `flash_attention_implementation`. The 2d attention logits bias tensor (with two leading dummy axes) will be broadcasted to `[batch, num_heads, seq_len, seq_len]` in kernel without materialization. This reduces the HBM usage of the logits bias tensor by a factor of `(batch / data) * (num_heads / model)`.

Note that I had to fork JAX's TPU flash attention implemtation (i.e. changes in axlearn/common/flash_attention/tpu_attention.py are copied from https://github.com/jax-ml/jax/blob/main/jax/experimental/pallas/ops/tpu/flash_attention.py with changes to `ab_index_map`) in order to change the `index_map` for attention logits bias. We might want to upstream the changes to JAX so that we don't need to maintain the duplicate codes.

Unit tested on TPU and GPU hosts.