### PR TITLE
Rename jax.tree_util.tree_map to jax.tree.map

### DIFF
--- a/axlearn/audio/asr_decoder_test.py
+++ b/axlearn/audio/asr_decoder_test.py
@@ -370,7 +370,7 @@ class CTCPrefixMergerTest(TestCase):
                 axis=-1,
             )
         )
-        jax.tree_util.tree_map(
+        jax.tree.map(
             np.testing.assert_array_equal,
             state,
             prefill_state,

--- a/axlearn/common/adapter_flax.py
+++ b/axlearn/common/adapter_flax.py
@@ -60,7 +60,7 @@ class FlaxLayer(BaseLayer):
                 mesh_axes=mesh_axes,
             )
 
-        return jax.tree_util.tree_map(
+        return jax.tree.map(
             get_param_spec,
             param_specs,
             is_leaf=lambda x: isinstance(x, Partitioned),
@@ -78,7 +78,7 @@ class FlaxLayer(BaseLayer):
         self, prng_key: utils.Tensor, *, prebuilt: Optional[Nested[Optional[ParameterSpec]]] = None
     ) -> Nested[Tensor]:
         if self._use_prebuilt_params(prebuilt):
-            return jax.tree_util.tree_map(lambda _: None, prebuilt)
+            return jax.tree.map(lambda _: None, prebuilt)
         args, kwargs = self._dummy_inputs
         return self._module.init(prng_key, *args, **kwargs)
 

--- a/axlearn/common/adapter_flax_test.py
+++ b/axlearn/common/adapter_flax_test.py
@@ -148,7 +148,7 @@ class FlaxLayerTest(TestCase):
             self.assertSequenceEqual(spec.shape, param.shape)
             self.assertEqual(spec.mesh_axes, None)
 
-        jax.tree_util.tree_map(check_spec_and_param, param_specs, layer_params)
+        jax.tree.map(check_spec_and_param, param_specs, layer_params)
 
         self.assertEqual(
             {
@@ -215,7 +215,7 @@ class FlaxLayerTest(TestCase):
             self.assertSequenceEqual(spec.shape, param.shape)
             self.assertEqual(spec.mesh_axes, None)
 
-        jax.tree_util.tree_map(check_spec_and_param, param_specs, layer_params)
+        jax.tree.map(check_spec_and_param, param_specs, layer_params)
 
         self.assertEqual(
             {
@@ -251,7 +251,7 @@ class FlaxLayerTest(TestCase):
             )
             layer = cfg.set(name="test").instantiate(parent=None)
             param_specs = layer.create_parameter_specs_recursively()
-            partition_specs = jax.tree_util.tree_map(lambda spec: spec.mesh_axes, param_specs)
+            partition_specs = jax.tree.map(lambda spec: spec.mesh_axes, param_specs)
 
             jit_init_state = pjit(
                 layer.initialize_parameters_recursively,

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -272,7 +272,7 @@ async def _run_serializer(
         else None
     )
     # pylint: enable=protected-access
-    future_writer = jax.tree_util.tree_map(
+    future_writer = jax.tree.map(
         functools.partial(
             _async_serialize, limiter=limiter, max_data_shard_degree=max_data_shard_degree
         ),
@@ -350,7 +350,7 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
 
         # pylint: disable-next=redefined-outer-name
         async def _run_serializer():
-            future_writer = jax.tree_util.tree_map(
+            future_writer = jax.tree.map(
                 serialization.async_serialize, arrays, tensorstore_specs, commit_futures
             )
             return await asyncio.gather(*future_writer)

--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -1064,7 +1064,7 @@ class FusedQKVLinear(BaseQKVLinear):
                 return None
             return FactorizationSpec(axes=[None] + list(spec.axes))
 
-        return jax.tree_util.tree_map(
+        return jax.tree.map(
             lambda spec: ParameterSpec(
                 dtype=spec.dtype,
                 shape=(3, *spec.shape),
@@ -1081,7 +1081,7 @@ class FusedQKVLinear(BaseQKVLinear):
         self, prng_key: Tensor, *, prebuilt: Optional[Nested[Optional[ParameterSpec]]] = None
     ) -> NestedTensor:
         if self._use_prebuilt_params(prebuilt):
-            return jax.tree_util.tree_map(lambda _: None, prebuilt)
+            return jax.tree.map(lambda _: None, prebuilt)
 
         def init(prng_key_i):
             return VDict(qkv_proj=self.qkv_proj.initialize_parameters_recursively(prng_key_i))
@@ -3539,7 +3539,7 @@ class StackedTransformerLayer(BaseStackedTransformerLayer):
         state = {}
         for i in range(cfg.num_layers):
             layer = self._layers[i]
-            key = jax.tree_util.tree_map(lambda x, index=i: x[index], prng_key.keys)
+            key = jax.tree.map(lambda x, index=i: x[index], prng_key.keys)
             state[layer.name] = layer.initialize_parameters_recursively(
                 key, prebuilt=get_or_none(prebuilt, layer.name)
             )
@@ -3628,7 +3628,7 @@ class StackedTransformerLayer(BaseStackedTransformerLayer):
             output._replace(data=None, self_attention_kv_state=None) for output in layer_outputs
         ]
         # Stack auxiliary outputs along axis 0.
-        outputs = jax.tree_util.tree_map(lambda *xs: jnp.stack(xs, axis=0), *aux_outputs)
+        outputs = jax.tree.map(lambda *xs: jnp.stack(xs, axis=0), *aux_outputs)
         return outputs._replace(data=data, self_attention_kv_state=self_attention_kv_state)
 
     def forward(

--- a/axlearn/common/base_layer.py
+++ b/axlearn/common/base_layer.py
@@ -46,7 +46,7 @@ class FactorizationSpec:
 NestedFactorizationSpec = dict[str, Union[FactorizationSpec, Any]]
 
 
-# ParameterSpec is a dataclass so that jax.tree_util.tree_map does not expand it.
+# ParameterSpec is a dataclass so that jax.tree.map does not expand it.
 @dataclasses.dataclass
 class ParameterSpec(TensorSpec):
     """Specification of a layer parameter."""

--- a/axlearn/common/base_layer_test.py
+++ b/axlearn/common/base_layer_test.py
@@ -110,7 +110,7 @@ class ParameterScaler(ParameterNoise):
 
     def apply(self, prng_key: utils.Tensor, params: NestedTensor) -> NestedTensor:
         cfg = self.config
-        return jax.tree_util.tree_map(lambda x: x * cfg.scale, params)
+        return jax.tree.map(lambda x: x * cfg.scale, params)
 
 
 def _callback_primitive(forward, backward):

--- a/axlearn/common/checkpointer_orbax.py
+++ b/axlearn/common/checkpointer_orbax.py
@@ -244,7 +244,7 @@ class OrbaxCheckpointer(BaseCheckpointer):
             else:
                 return None
 
-        restore_args = jax.tree_util.tree_map(_restore_args, state)
+        restore_args = jax.tree.map(_restore_args, state)
 
         try:
             composite_state = self._manager.restore(

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -161,7 +161,7 @@ class CheckpointerTest(test_utils.TestCase):
         step = 1
 
         def state_specs(state, partition_spec):
-            return jax.tree_util.tree_map(
+            return jax.tree.map(
                 lambda x: utils.TensorSpec(shape=x.shape, dtype=x.dtype, mesh_axes=partition_spec),
                 state,
             )
@@ -171,7 +171,7 @@ class CheckpointerTest(test_utils.TestCase):
             sharding = jax.sharding.NamedSharding(
                 mesh, spec=jax.sharding.PartitionSpec("data", "model")
             )
-            state = jax.tree_util.tree_map(lambda x: jax.device_put(x, device=sharding), state)
+            state = jax.tree.map(lambda x: jax.device_put(x, device=sharding), state)
             ckpt.save(step=step, state=state)
             ckpt.wait_until_finished()
 
@@ -772,9 +772,7 @@ class CheckpointerTest(test_utils.TestCase):
             state_spec = read_state_spec(checkpointer_cls.latest_checkpoint_path(cfg.dir))
             self.assertNestedEqual(
                 state_spec,
-                jax.tree_util.tree_map(
-                    lambda t: utils.TensorSpec(shape=t.shape, dtype=t.dtype), state0
-                ),
+                jax.tree.map(lambda t: utils.TensorSpec(shape=t.shape, dtype=t.dtype), state0),
             )
             step, state1 = ckpt.restore(state=state_spec)
             self.assertNestedEqual(0, step)
@@ -816,7 +814,7 @@ class CheckpointerTest(test_utils.TestCase):
                 ckpt: Checkpointer = cfg.instantiate(parent=None)
                 # VDict with out of order keys.
                 state0 = dict(a=3, b=SwitchableVDict(d=6, b=5))
-                state0 = jax.tree_util.tree_map(jnp.asarray, state0)
+                state0 = jax.tree.map(jnp.asarray, state0)
                 self.assertEqual(list(state0["b"].keys()), ["d", "b"])
                 ckpt.save(step=0, state=state0)
                 ckpt.wait_until_finished()
@@ -829,7 +827,7 @@ class CheckpointerTest(test_utils.TestCase):
                 self.assertNestedEqual(state0, result)
                 self.assertEqual(list(result["b"].keys()), ["b", "d"])
 
-                after_tree_map = jax.tree_util.tree_map(lambda x: x, result)
+                after_tree_map = jax.tree.map(lambda x: x, result)
                 self.assertEqual(list(after_tree_map["b"].keys()), ["b", "d"])
 
                 _, result = ckpt.restore(step=0, state=after_tree_map)

--- a/axlearn/common/conformer_test.py
+++ b/axlearn/common/conformer_test.py
@@ -213,9 +213,7 @@ class ConformerLayerTest(TestCase):
         outputs = inputs
         for ll in range(num_layers):
             # Run a stack of layers by loop
-            state_i = jax.tree_util.tree_map(lambda param, i=ll: param[i], repeat_state)["repeat"][
-                "layer"
-            ]
+            state_i = jax.tree.map(lambda param, i=ll: param[i], repeat_state)["repeat"]["layer"]
             outputs, _ = F(
                 layer,
                 inputs=dict(inputs=outputs, paddings=paddings),

--- a/axlearn/common/decoding_test.py
+++ b/axlearn/common/decoding_test.py
@@ -337,7 +337,7 @@ class DecodeTest(parameterized.TestCase):
             }
         }
         np.testing.assert_array_equal(expected_seqs, gathered_seqs)
-        jax.tree_util.tree_map(np.testing.assert_array_equal, expected_cache, gathered_cache)
+        jax.tree.map(np.testing.assert_array_equal, expected_cache, gathered_cache)
 
     def test_beam_search_decode(self):
         # Toy problem, we have 4 states, A, B, START, END, (plus PAD).

--- a/axlearn/common/eval_classification_test.py
+++ b/axlearn/common/eval_classification_test.py
@@ -59,7 +59,7 @@ def _compute_metrics(
         jax.experimental.mesh_utils.create_device_mesh((1, 1)), ("data", "model")
     ):
         model = DummyClassificationModel.default_config().set(name="model").instantiate(parent=None)
-        model_param_partition_specs = jax.tree_util.tree_map(
+        model_param_partition_specs = jax.tree.map(
             lambda spec: spec.mesh_axes, model.create_parameter_specs_recursively()
         )
         calculator = calculator_cfg.set(name="calculator").instantiate(

--- a/axlearn/common/eval_retrieval.py
+++ b/axlearn/common/eval_retrieval.py
@@ -362,7 +362,7 @@ class EmbeddingRetrievalMetricCalculator(GlobalMetricCalculator):
             categories = jnp.concatenate(categories_chunked)
         else:
             categories = None
-        per_query_metrics = jax.tree_util.tree_map(  # pylint: disable=no-value-for-parameter
+        per_query_metrics = jax.tree.map(  # pylint: disable=no-value-for-parameter
             lambda *xs: jnp.concatenate(xs), *metrics_chunked
         )
 

--- a/axlearn/common/eval_retrieval_test.py
+++ b/axlearn/common/eval_retrieval_test.py
@@ -80,7 +80,7 @@ def _compute_metrics(
         jax.experimental.mesh_utils.create_device_mesh((1, 1)), ("data", "model")
     ):
         model = DummyRetrievalModel.default_config().set(name="model").instantiate(parent=None)
-        model_param_partition_specs = jax.tree_util.tree_map(
+        model_param_partition_specs = jax.tree.map(
             lambda spec: spec.mesh_axes, model.create_parameter_specs_recursively()
         )
         calculator = calculator_cfg.set(name="calculator").instantiate(

--- a/axlearn/common/evaler_test.py
+++ b/axlearn/common/evaler_test.py
@@ -200,7 +200,7 @@ class EvalerTest(TestCase):
             # Create model state.
             model_cfg = DummyModel.default_config()
             model = model_cfg.instantiate(parent=None)
-            model_param_partition_specs = jax.tree_util.tree_map(
+            model_param_partition_specs = jax.tree.map(
                 lambda spec: spec.mesh_axes, model.create_parameter_specs_recursively()
             )
             model_state = pjit(
@@ -286,7 +286,7 @@ class EvalerTest(TestCase):
             # Create model state.
             model_cfg = DummyModel.default_config()
             model = model_cfg.instantiate(parent=None)
-            model_param_partition_specs = jax.tree_util.tree_map(
+            model_param_partition_specs = jax.tree.map(
                 lambda spec: spec.mesh_axes, model.create_parameter_specs_recursively()
             )
             model_state = pjit(
@@ -333,7 +333,7 @@ class EvalerTest(TestCase):
                     # Create model state.
                     model_cfg = DummyModel.default_config()
                     model = model_cfg.instantiate(parent=None)
-                    model_param_partition_specs = jax.tree_util.tree_map(
+                    model_param_partition_specs = jax.tree.map(
                         lambda spec: spec.mesh_axes, model.create_parameter_specs_recursively()
                     )
                     model_state = pjit(
@@ -542,7 +542,7 @@ class CompositeMetricCalculatorTest(TestCase):
                 DummyModel.default_config().set(name="model").instantiate(parent=None)
             )
             model_params = model.initialize_parameters_recursively(jax.random.PRNGKey(0))
-            partition_specs = jax.tree_util.tree_map(
+            partition_specs = jax.tree.map(
                 lambda spec: spec.mesh_axes, model.create_parameter_specs_recursively()
             )
 
@@ -800,7 +800,7 @@ class GlobalEvalerTest(TestCase):
             jax.experimental.mesh_utils.create_device_mesh((1, 1)), ("data", "model")
         ):
             model = DummyModel.default_config().set(name="model").instantiate(parent=None)
-            model_param_partition_specs = jax.tree_util.tree_map(
+            model_param_partition_specs = jax.tree.map(
                 lambda spec: spec.mesh_axes, model.create_parameter_specs_recursively()
             )
             calculator_cfg = GlobalMetricCalculator.default_config().set(

--- a/axlearn/common/factorized_rms_test.py
+++ b/axlearn/common/factorized_rms_test.py
@@ -113,7 +113,7 @@ class FactorizedRMSTest(TestCase):
                     count=count_spec,
                     v_row=dict(w=dummy_spec, b=dummy_spec),
                     v_col=dict(w=dummy_spec, b=dummy_spec),
-                    v=jax.tree_util.tree_map(
+                    v=jax.tree.map(
                         lambda param_spec: OptStateSpec(
                             dtype=dtype, shape=param_spec.shape, mesh_axes=param_spec.mesh_axes
                         ),
@@ -166,7 +166,7 @@ class FactorizedRMSTest(TestCase):
 
         # update() behaves the same between ref and exp.
         for step in range(10):
-            updates = jax.tree_util.tree_map(
+            updates = jax.tree.map(
                 lambda x, seed=100 + step: jax.random.normal(jax.random.PRNGKey(seed), x.shape),
                 opt_params,
             )

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -281,7 +281,7 @@ def _tpu_splash_attention(
                 ):
                     with jax.ensure_compile_time_eval():
                         result = mask(*args, **kwargs)
-                        return jax.tree_util.tree_map(np.asarray, result)
+                        return jax.tree.map(np.asarray, result)
                 return mask(*args, **kwargs)
 
             return wrapped_mask

--- a/axlearn/common/inference.py
+++ b/axlearn/common/inference.py
@@ -221,7 +221,7 @@ class InferenceRunner(Module):
                 prng_key=TensorSpec(dtype=jnp.uint32, shape=[4], mesh_axes=PartitionSpec(None)),
                 model=self._model_param_specs,
             )
-            self._inference_runner_state_partition_specs = jax.tree_util.tree_map(
+            self._inference_runner_state_partition_specs = jax.tree.map(
                 lambda spec: spec.mesh_axes, self._inference_runner_state_specs
             )
             logging.info("Building ckpt state from %s", cfg.init_state_builder.klass.__name__)

--- a/axlearn/common/inference_output.py
+++ b/axlearn/common/inference_output.py
@@ -202,7 +202,7 @@ class OutputRecordWriter(BaseOutputWriter):
         local_batch_size = jax.tree_util.tree_leaves(local_data)[0].shape[0]
 
         for i in range(local_batch_size):
-            example = jax.tree_util.tree_map(lambda x, index=i: x[index], local_data)
+            example = jax.tree.map(lambda x, index=i: x[index], local_data)
             self.sink.write(
                 self._build_record(input_example=example["input"], output_example=example["output"])
             )

--- a/axlearn/common/inference_test.py
+++ b/axlearn/common/inference_test.py
@@ -269,7 +269,7 @@ class InferenceTest(test_utils.TestCase):
                         ema=ParamEmaState(
                             count=0,
                             # pylint: disable-next=unnecessary-lambda
-                            ema=jax.tree_util.tree_map(lambda p: jnp.ones_like(p), params),
+                            ema=jax.tree.map(lambda p: jnp.ones_like(p), params),
                         ),
                     )
                 else:

--- a/axlearn/common/input_dispatch.py
+++ b/axlearn/common/input_dispatch.py
@@ -180,7 +180,7 @@ class InputDispatcher(Module):
             padding = jnp.zeros([pad_size] + list(x.shape[1:]), dtype=x.dtype)
             return jnp.concatenate([x, padding], axis=0)
 
-        physical_feed_batch = jax.tree_util.tree_map(pad_to_physical_batch_size, logical_feed_batch)
+        physical_feed_batch = jax.tree.map(pad_to_physical_batch_size, logical_feed_batch)
 
         if cfg.physical_feed_index not in cfg.logical_feed_indices:
             logical_example_indices = -1 + jnp.zeros([feed_physical_batch_size], dtype=jnp.int32)
@@ -233,9 +233,7 @@ class InputDispatcher(Module):
                         f"{dispatch.shape} vs. "
                         f"{(cfg.global_physical_batch_size, cfg.global_logical_batch_size)}"
                     )
-                    return jax.tree_util.tree_map(
-                        lambda x: jnp.einsum("p...,pl->l...", x, dispatch), data
-                    )
+                    return jax.tree.map(lambda x: jnp.einsum("p...,pl->l...", x, dispatch), data)
                 for key, value in data.items():
                     data[key] = traverse_and_dispatch(value)
             return data

--- a/axlearn/common/input_dispatch_test.py
+++ b/axlearn/common/input_dispatch_test.py
@@ -77,7 +77,7 @@ class DispatcherTest(TestCase):
         random.shuffle(all_physical_batches)
         # Form the global batch by concatenating the tensors.
         # pylint: disable-next=no-value-for-parameter
-        global_physical_batch = jax.tree_util.tree_map(
+        global_physical_batch = jax.tree.map(
             lambda *xs: jnp.concatenate(xs, axis=0),
             *all_physical_batches,
         )

--- a/axlearn/common/input_tf_data.py
+++ b/axlearn/common/input_tf_data.py
@@ -1213,7 +1213,7 @@ class Input(Module):
         batch_axis_names: Union[str, Sequence[str]] = "data",
     ) -> NestedTensor:
         if "input_dispatcher" in self.children:
-            global_physical_batch = jax.tree_util.tree_map(
+            global_physical_batch = jax.tree.map(
                 lambda x: with_sharding_constraint(x, PartitionSpec(batch_axis_names)),
                 global_physical_batch,
             )

--- a/axlearn/common/input_tf_data_test.py
+++ b/axlearn/common/input_tf_data_test.py
@@ -669,13 +669,13 @@ class PadTest(test_utils.TestCase):
             # For each step, assemble global logical batches from `manual_feeds` and
             # `input_feeds` and check that they are equal.
             manual_global_batch = utils.dispatch_input_batch(
-                jax.tree_util.tree_map(
+                jax.tree.map(
                     lambda *xs: jnp.concatenate(as_numpy_array(xs), axis=0),
                     *[batches[step] for batches in manual_feeds.values()],
                 )
             )
             input_global_batch = input_generator.input_dispatcher.physical_to_logical_batch(
-                jax.tree_util.tree_map(
+                jax.tree.map(
                     lambda *xs: jnp.concatenate(as_numpy_array(xs), axis=0),
                     *[batches[step] for batches in input_feeds.values()],
                 )

--- a/axlearn/common/layers.py
+++ b/axlearn/common/layers.py
@@ -1827,7 +1827,7 @@ class VariationalNoise(ParameterNoise):
         cfg = self.config
         if cfg.vn_std <= 0:
             return params
-        return jax.tree_util.tree_map(
+        return jax.tree.map(
             lambda x: x + jax.random.normal(prng_key, x.shape, dtype=x.dtype) * cfg.vn_std, params
         )
 

--- a/axlearn/common/metrics.py
+++ b/axlearn/common/metrics.py
@@ -83,7 +83,7 @@ class MetricAccumulator(Configurable):
     @staticmethod
     def _tree_map(*args, **kwargs):
         is_leaf = lambda x: isinstance(x, Summary)
-        return jax.tree_util.tree_map(*args, **kwargs, is_leaf=is_leaf)
+        return jax.tree.map(*args, **kwargs, is_leaf=is_leaf)
 
 
 def _metric_accumulator_flatten(v: MetricAccumulator) -> tuple[tuple, tuple]:

--- a/axlearn/common/metrics_test.py
+++ b/axlearn/common/metrics_test.py
@@ -40,7 +40,7 @@ class TestMetricAccumulator(test_utils.TestCase):
             ),
         ]
 
-        summaries_copy = jax.tree_util.tree_map(lambda x: x, summaries)
+        summaries_copy = jax.tree.map(lambda x: x, summaries)
         for s in summaries_copy:
             acc.update(s)
         result = acc.summaries()
@@ -71,7 +71,7 @@ class TestMetricAccumulator(test_utils.TestCase):
                 loss=metrics.WeightedScalar(100, 0),
             ),
         ]
-        summaries_copy = jax.tree_util.tree_map(lambda x: x, summaries)
+        summaries_copy = jax.tree.map(lambda x: x, summaries)
         for s in summaries_copy:
             acc.update(s)
 

--- a/axlearn/common/metrics_text_dual_encoder_test.py
+++ b/axlearn/common/metrics_text_dual_encoder_test.py
@@ -91,7 +91,7 @@ def _compute_metrics(
         jax.experimental.mesh_utils.create_device_mesh((1, 1)), ("data", "model")
     ):
         model = DummyRetrievalModel.default_config().set(name="model").instantiate(parent=None)
-        model_param_partition_specs = jax.tree_util.tree_map(
+        model_param_partition_specs = jax.tree.map(
             lambda spec: spec.mesh_axes, model.create_parameter_specs_recursively()
         )
         calculator: TextDualEncoderMetricCalculator = (

--- a/axlearn/common/mixture_of_experts.py
+++ b/axlearn/common/mixture_of_experts.py
@@ -911,7 +911,7 @@ def _convert_feedforward_to_moe_parameters(
         NotImplementedError: if the source TransformerFeedForwardLayer includes bias in its linear
             parameters or upon unexpected source parameter names.
     """
-    moe_parameters = jax.tree_util.tree_map(lambda x: None, moe_parameter_specs)
+    moe_parameters = jax.tree.map(lambda x: None, moe_parameter_specs)
     for path, value in flatten_items(source_parameters):
         m = re.fullmatch("linear([0-9_]+)/(weight|bias)", path)
         if not m:
@@ -1018,9 +1018,7 @@ def convert_dense_to_moe_parameters(
                 moe_layer_parameter_specs=ff_layer_parameter_specs,
             ) -> Nested[Tensor]:
                 """Converts source_layer_parameters[layer_index] to params of a target layer."""
-                layer_parameters = jax.tree_util.tree_map(
-                    lambda w: w[layer_index], source_layer_parameters
-                )
+                layer_parameters = jax.tree.map(lambda w: w[layer_index], source_layer_parameters)
                 if not num_experts:
                     return layer_parameters
 
@@ -1043,11 +1041,11 @@ def convert_dense_to_moe_parameters(
             return None
         return parameter_spec.mesh_axes
 
-    out_shardings = jax.tree_util.tree_map(
+    out_shardings = jax.tree.map(
         compute_out_sharding, tree_paths(target_parameter_specs), target_parameter_specs
     )
     target_parameters = pjit(convert_fn, out_shardings=out_shardings)(source_parameters)
-    target_parameters = jax.tree_util.tree_map(
+    target_parameters = jax.tree.map(
         lambda spec, param: spec if param is None else param,
         target_parameter_specs,
         target_parameters,

--- a/axlearn/common/mixture_of_experts_test.py
+++ b/axlearn/common/mixture_of_experts_test.py
@@ -603,7 +603,7 @@ class ParamConversionTest(parameterized.TestCase):
         state_moe_converted = _convert_feedforward_to_moe_parameters(
             state_dense, num_experts=num_experts, moe_parameter_specs=param_specs_moe
         )
-        state_moe_converted = jax.tree_util.tree_map(
+        state_moe_converted = jax.tree.map(
             lambda spec, param: spec if param is None else param,
             param_specs_moe,
             state_moe_converted,

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -175,7 +175,7 @@ def propagate_repeated_output_collections(
         for i in range(num_children):
             child_i_output = target_output_collection.add_child(f"{child_name_prefix}{i}")
             child_i_output.summaries.update(
-                jax.tree_util.tree_map(lambda x, i=i: x[i], repeated_output_collection.summaries)
+                jax.tree.map(lambda x, i=i: x[i], repeated_output_collection.summaries)
             )
 
 
@@ -301,7 +301,7 @@ class InvocationContext:  # pylint: disable=too-many-instance-attributes
             if isinstance(leaf, Summary):
                 leaf.validate()
 
-        jax.tree_util.tree_map(validate, value, is_leaf=lambda x: isinstance(x, Summary))
+        jax.tree.map(validate, value, is_leaf=lambda x: isinstance(x, Summary))
 
         self.output_collection.summaries[name] = value
 
@@ -922,7 +922,7 @@ class _Functional:
         # This results in a cryptic error that doesn't make the root cause obvious.
         # So we raise a clearer error explicitly.
         raise_for_cycles(dict(context=self.context, args=args, kwargs=kwargs))
-        context, args, kwargs = jax.tree_util.tree_map(lambda x: x, (self.context, args, kwargs))
+        context, args, kwargs = jax.tree.map(lambda x: x, (self.context, args, kwargs))
 
         with set_current_context(context, require_parent=self.require_parent):
             # pylint: disable-next=not-an-iterable,not-a-mapping,not-callable

--- a/axlearn/common/ops/_optimization_barrier.py
+++ b/axlearn/common/ops/_optimization_barrier.py
@@ -57,7 +57,7 @@ def forward_optimization_barrier(pytree: Any) -> Any:
 
 
         def print_result(msg: str, scalars: Tensor):
-            scalars = jax.tree_util.tree_map(lambda x: x.item(), scalars)
+            scalars = jax.tree.map(lambda x: x.item(), scalars)
             print(msg, scalars)
 
 

--- a/axlearn/common/param_converter_test.py
+++ b/axlearn/common/param_converter_test.py
@@ -120,7 +120,7 @@ class BaseParamConverterTest(TestCase):
             ref_layer(**ref_inputs) if isinstance(ref_inputs, dict) else ref_layer(ref_inputs)
         )
         ref_outputs = torch_output_to_dict(ref_outputs)
-        return test_outputs, jax.tree_util.tree_map(as_tensor, ref_outputs)
+        return test_outputs, jax.tree.map(as_tensor, ref_outputs)
 
 
 class ParameterTest(BaseParamConverterTest):
@@ -545,7 +545,7 @@ class ParameterTest(BaseParamConverterTest):
             token_type_ids=hf_inputs["token_type_ids"],
             return_dict=False,
         )
-        expected, actual = jax.tree_util.tree_map(
+        expected, actual = jax.tree.map(
             as_tensor, (hf_layer(**hf_inputs), hf_layer_copy(**hf_inputs))
         )
         self.assertNestedAllClose(expected, actual)
@@ -630,7 +630,7 @@ class T5ModelConverterTest(TestCase):
             target_ids=t5_inputs["target"]["input_ids"],
             target_labels=t5_inputs["target_labels"],
         )
-        expected, actual = jax.tree_util.tree_map(
+        expected, actual = jax.tree.map(
             as_tensor,
             (
                 hf_layer(**hf_inputs).logits,
@@ -698,7 +698,7 @@ class HFGPT2ModelConverterTest(TestCase):
             input_ids=as_torch_tensor(input_ids),
             labels=as_torch_tensor(labels).type(torch.LongTensor),
         )
-        expected, actual = jax.tree_util.tree_map(
+        expected, actual = jax.tree.map(
             as_tensor,
             (
                 hf_layer(**hf_inputs).logits,
@@ -742,7 +742,7 @@ class DeBERTaModelConverterTest(TestCase):
         layer_params = parameters_from_torch_layer(hf_layer, dst_layer=layer)
         axlearn_to_torch(layer=layer, src=layer_params, dst=hf_layer_copy)
 
-        expected, actual = jax.tree_util.tree_map(
+        expected, actual = jax.tree.map(
             as_tensor, (hf_layer.state_dict(), hf_layer_copy.state_dict())
         )
         self.assertNestedAllClose(expected, actual)
@@ -778,7 +778,7 @@ class DeBERTaModelConverterTest(TestCase):
         axlearn_to_torch(layer=layer, src=params, dst=hf_layer_copy)
 
         # Test parameters are identical.
-        expected, actual = jax.tree_util.tree_map(
+        expected, actual = jax.tree.map(
             as_tensor, (hf_layer.state_dict(), hf_layer_copy.state_dict())
         )
         self.assertNestedAllClose(expected, actual)
@@ -796,7 +796,7 @@ class DeBERTaModelConverterTest(TestCase):
         )
 
         # Test we get same outputs.
-        expected, actual = jax.tree_util.tree_map(
+        expected, actual = jax.tree.map(
             as_tensor, (hf_layer(**hf_inputs), hf_layer_copy(**hf_inputs))
         )
         self.assertNestedAllClose(expected, actual)

--- a/axlearn/common/pipeline_test.py
+++ b/axlearn/common/pipeline_test.py
@@ -109,7 +109,7 @@ class TestPipeline(Pipeline):
         microbatch_size = batch_size // cfg.num_microbatches
         layer_state = self.layer.init_forward_state(microbatch_size)
         return dict(
-            layer=jax.tree_util.tree_map(
+            layer=jax.tree.map(
                 lambda x: jnp.tile(x[None, None, :], [cfg.num_layers, cfg.num_microbatches, 1]),
                 layer_state,
             )
@@ -199,7 +199,7 @@ class PipelineTest(TestCase):
         logging.info("module_outputs=%s", shapes(output_collection.module_outputs))
 
         # Ensure carry dtype matches input.
-        jax.tree_util.tree_map(lambda x: self.assertEqual(x.dtype, dtype), carry)
+        jax.tree.map(lambda x: self.assertEqual(x.dtype, dtype), carry)
 
         assert_allclose(carry, jnp.arange(num_layers, num_layers + batch_size))
         self.assertEqual(shapes(input_forward_state), shapes(output_forward_state))
@@ -375,7 +375,7 @@ class PipelineTest(TestCase):
                 def inject_nans(x):
                     return jnp.where(self._is_valid_stage(x, t=t), x, jnp.nan)
 
-                return jax.tree_util.tree_map(inject_nans, x)
+                return jax.tree.map(inject_nans, x)
 
         layer: TestPipeline = (
             TestPipeline.default_config()
@@ -424,9 +424,7 @@ class PipelineTest(TestCase):
 
         self.assertNestedAllClose(test_out, ref_out)
         self.assertNestedAllClose(test_grads, ref_grads)
-        jax.tree_util.tree_map(
-            lambda x: self.assertFalse(jnp.isnan(x).any().item()), output_collection
-        )
+        jax.tree.map(lambda x: self.assertFalse(jnp.isnan(x).any().item()), output_collection)
 
     @parameterized.product(
         schedule=[

--- a/axlearn/common/quantizer_test.py
+++ b/axlearn/common/quantizer_test.py
@@ -416,7 +416,7 @@ class RandomVectorQuantizerTest(TestCase):
         _, (grad_params, grad_inputs) = jax.value_and_grad(_loss, argnums=(0, 1), has_aux=False)(
             layer_params, jnp.asarray(inputs), jnp.asarray(paddings)
         )
-        self.assertNestedAllClose(grad_params, jax.tree_util.tree_map(jnp.zeros_like, layer_params))
+        self.assertNestedAllClose(grad_params, jax.tree.map(jnp.zeros_like, layer_params))
         assert_allclose(grad_inputs, jnp.zeros_like(inputs), atol=1e-6, rtol=1e-6)
 
 

--- a/axlearn/common/repeat.py
+++ b/axlearn/common/repeat.py
@@ -125,7 +125,7 @@ class Repeat(BaseLayer):
                 return None
             return FactorizationSpec(axes=[None] + list(spec.axes))
 
-        return jax.tree_util.tree_map(
+        return jax.tree.map(
             lambda spec: dataclasses.replace(
                 spec,
                 shape=(cfg.num_layers, *spec.shape),

--- a/axlearn/common/repeat_test.py
+++ b/axlearn/common/repeat_test.py
@@ -87,7 +87,7 @@ class TestRepeat(Repeat):
         cfg = self.config
         layer_state = self.layer.init_forward_state(batch_size)
         return dict(
-            layer=jax.tree_util.tree_map(
+            layer=jax.tree.map(
                 lambda x: jnp.tile(x[None, :], [cfg.num_layers, 1]),
                 layer_state,
             )
@@ -380,7 +380,7 @@ class RepeatTest(TestCase):
 
         input_forward_state = layer.shared_layer.init_forward_state(batch_size)
         input_forward_state = dict(
-            layer=jax.tree_util.tree_map(
+            layer=jax.tree.map(
                 lambda x: jnp.tile(x[None, :], [num_layers, 1]),
                 input_forward_state,
             )
@@ -433,7 +433,7 @@ class RepeatTest(TestCase):
 
 
 def _get_first_n(n, tree):
-    return jax.tree_util.tree_map(lambda x: x[:n], tree)
+    return jax.tree.map(lambda x: x[:n], tree)
 
 
 if __name__ == "__main__":

--- a/axlearn/common/rnn.py
+++ b/axlearn/common/rnn.py
@@ -279,7 +279,7 @@ class StackedRNNLayer(BaseRNNCell):
         prng_key = split_prng_key(prng_key, len(cfg.layers))
         state = {}
         for i, layer in enumerate(self._layers):
-            key = jax.tree_util.tree_map(lambda x, index=i: x[index], prng_key.keys)
+            key = jax.tree.map(lambda x, index=i: x[index], prng_key.keys)
             state[layer.name] = layer.initialize_parameters_recursively(
                 key, prebuilt=get_or_none(prebuilt, layer.name)
             )

--- a/axlearn/common/rnn_test.py
+++ b/axlearn/common/rnn_test.py
@@ -169,9 +169,9 @@ class StackedRNNTest(TestCase):
         final_states_list = []
         outputs = inputs
         for ll in range(num_layers):
-            layer_params_ll = jax.tree_util.tree_map(lambda param, i=ll: param[i], layer_params)[
-                "repeat"
-            ]["layer"]
+            layer_params_ll = jax.tree.map(lambda param, i=ll: param[i], layer_params)["repeat"][
+                "layer"
+            ]
             outputs, output_collections = F(
                 layer.repeat.layer,  # LSTMCell.
                 is_training=True,
@@ -385,7 +385,7 @@ class StackedRNNTest(TestCase):
         repeat_params = {
             "repeat": VDict(
                 {
-                    "layer": jax.tree_util.tree_map(
+                    "layer": jax.tree.map(
                         lambda *xs: jnp.stack(xs),
                         *stack_params.values(),
                     )

--- a/axlearn/common/serialization_test.py
+++ b/axlearn/common/serialization_test.py
@@ -107,9 +107,9 @@ class SerializationTest(parameterized.TestCase):
             "1": {},
         }
         self.assertEqual(state, expected_state)
-        state = jax.tree_util.tree_map(lambda x: x + 1, expected_state)
+        state = jax.tree.map(lambda x: x + 1, expected_state)
         restored_tx_state = serialization.from_state_dict(tx_state, state)
-        tx_state_plus1 = jax.tree_util.tree_map(lambda x: x + 1, tx_state)
+        tx_state_plus1 = jax.tree.map(lambda x: x + 1, tx_state)
         self.assertEqual(restored_tx_state, tx_state_plus1)
 
     def test_collection_serialization(self):

--- a/axlearn/common/ssm_test.py
+++ b/axlearn/common/ssm_test.py
@@ -764,7 +764,7 @@ class StackedMambaTest(TestCase):
         # Make params in the format a stacked model expects.
         stacked_params = {}
         for i in range(num_layers):
-            stacked_params[f"layer{i}"] = jax.tree_util.tree_map(
+            stacked_params[f"layer{i}"] = jax.tree.map(
                 # pylint: disable-next=cell-var-from-loop
                 lambda x: x[i],
                 layer_params["repeat"]["layer"],

--- a/axlearn/common/state_builder.py
+++ b/axlearn/common/state_builder.py
@@ -366,9 +366,7 @@ def clone_tree(in_tree: NestedTensor) -> NestedTensor:
     # Tensors are not pickleable, so deepcopy isn't possible.
     # They should be immutable and exist beyond the lifetime of this fn, however,
     # so we copy by reference.
-    return jax.tree_util.tree_map(
-        lambda x: x if isinstance(x, Tensor) else copy.deepcopy(x), in_tree
-    )
+    return jax.tree.map(lambda x: x if isinstance(x, Tensor) else copy.deepcopy(x), in_tree)
 
 
 class TensorStoreStateStorageBuilder(Builder):
@@ -469,7 +467,7 @@ class BertSequenceClassificationHeadConverter(BaseConverterFromPretrainedModel):
 
     def source_to_target(self, source: Builder.State, aux: Any) -> Builder.State:
         """Produces state compatible with the new classification head."""
-        restored_model = jax.tree_util.tree_map(
+        restored_model = jax.tree.map(
             lambda s, t: self._swap_heads(s, t) if self._is_bert_lm_head(s) else s,
             source.trainer_state.model,
             aux.trainer_state.model,
@@ -536,7 +534,7 @@ def traverse_and_set_target_state_parameters(
                 data_callback=lambda index: src[index],
             )
 
-        target_state = jax.tree_util.tree_map(_to_target_sharding, source_params, target_state)
+        target_state = jax.tree.map(_to_target_sharding, source_params, target_state)
     else:
         scope = target_scope.pop(0)  # The item should be popped from the bottom of the list.
         target_state[scope] = traverse_and_set_target_state_parameters(
@@ -872,7 +870,7 @@ class PosEmbeddingConverter(BaseConverterFromPretrainedModel):
                 return self._derive_compat_source_pos_emb(src, tgt)
             return src if isinstance(src, Tensor) else tgt
 
-        restored_state = jax.tree_util.tree_map(
+        restored_state = jax.tree.map(
             restored_state,
             source.trainer_state,
             aux.trainer_state,
@@ -1065,7 +1063,7 @@ class SimpleWeightModifierBuilder(Builder):
             else:
                 return x
 
-        modified_trainer_state = jax.tree_util.tree_map(
+        modified_trainer_state = jax.tree.map(
             maybe_modify,
             state.trainer_state,
             is_leaf=self._should_modify,

--- a/axlearn/common/state_builder_test.py
+++ b/axlearn/common/state_builder_test.py
@@ -803,7 +803,7 @@ class DiffusersPretrainedBuilderTest(TestCase):
                 model=model.create_parameter_specs_recursively(),
                 learner=None,
             )
-            trainer_state_partition_specs = jax.tree_util.tree_map(
+            trainer_state_partition_specs = jax.tree.map(
                 lambda spec: spec.mesh_axes, trainer_state_specs
             )
 
@@ -883,7 +883,7 @@ class HuggingFacePreTrainedBuilderTest(TestCase):
                 model=model.create_parameter_specs_recursively(),
                 learner=None,
             )
-            trainer_state_partition_specs = jax.tree_util.tree_map(
+            trainer_state_partition_specs = jax.tree.map(
                 lambda spec: spec.mesh_axes, trainer_state_specs
             )
 
@@ -944,7 +944,7 @@ class HuggingFacePreTrainedBuilderTest(TestCase):
                 model=model.create_parameter_specs_recursively(),
                 learner=None,
             )
-            trainer_state_partition_specs = jax.tree_util.tree_map(
+            trainer_state_partition_specs = jax.tree.map(
                 lambda spec: spec.mesh_axes, trainer_state_specs
             )
 
@@ -1040,9 +1040,7 @@ def _create_dummy_state(prng_key, model_config=DummyModel.default_config(), use_
     trainer_state = trainer.trainer_state
     if use_ema:
         trainer_state.learner["ema"] = trainer_state.learner["ema"]._replace(
-            ema=jax.tree_util.tree_map(
-                lambda p: -jnp.ones_like(p), trainer.trainer_state.learner["ema"].ema
-            )
+            ema=jax.tree.map(lambda p: -jnp.ones_like(p), trainer.trainer_state.learner["ema"].ema)
         )
     return config_for_function(trainer_cfg_fn), Builder.State(
         step=0, trainer_state=trainer_state, built_keys=set()

--- a/axlearn/common/struct_test.py
+++ b/axlearn/common/struct_test.py
@@ -60,7 +60,7 @@ class StructTest(absltest.TestCase):
         p = _Point(x=1, y=2, meta={"abc": True})
         leaves = jax.tree_util.tree_leaves(p)
         self.assertEqual(leaves, [1, 2])
-        new_p = jax.tree_util.tree_map(lambda x: x + x, p)
+        new_p = jax.tree.map(lambda x: x + x, p)
         self.assertEqual(new_p, _Point(x=2, y=4, meta={"abc": True}))
 
     def test_keypath_error(self):

--- a/axlearn/common/summary.py
+++ b/axlearn/common/summary.py
@@ -179,9 +179,7 @@ class CallbackSummary(Summary):
 
     def value(self) -> Tensor:
         args = tuple(np.asarray(x) for x in self.args)
-        kwargs = jax.tree_util.tree_map(
-            lambda x: np.asarray(x) if isinstance(x, Tensor) else x, self.kwargs
-        )
+        kwargs = jax.tree.map(lambda x: np.asarray(x) if isinstance(x, Tensor) else x, self.kwargs)
         return self.fn(*args, **kwargs)
 
     def accumulate(self, other: Summary) -> Summary:

--- a/axlearn/common/summary_writer.py
+++ b/axlearn/common/summary_writer.py
@@ -252,7 +252,7 @@ class SummaryWriter(BaseWriter):
                 return isinstance(x, Summary)
 
             paths = tree_paths(values, separator="/", is_leaf=is_leaf)
-            jax.tree_util.tree_map(write, paths, values, is_leaf=is_leaf)
+            jax.tree.map(write, paths, values, is_leaf=is_leaf)
             self.summary_writer.flush()
 
 
@@ -401,7 +401,7 @@ class WandBWriter(BaseWriter):
             return isinstance(x, Summary)
 
         paths = tree_paths(values, separator="/", is_leaf=is_leaf)
-        values = jax.tree_util.tree_map(convert, paths, values, is_leaf=is_leaf)
+        values = jax.tree.map(convert, paths, values, is_leaf=is_leaf)
 
         if cfg.prefix:
             values = {f"{cfg.prefix}/{k}": v for k, v in values.items()}

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -348,7 +348,7 @@ def prng_impl(new_prng_impl: str):
     switch(old_prng_impl)
 
 
-# Use dataclass so that jax.tree_util.tree_map does not expand it.
+# Use dataclass so that jax.tree.map does not expand it.
 @dataclasses.dataclass
 class ParamInitSpec:
     shape: Optional[Sequence[int]]
@@ -560,7 +560,7 @@ def read_per_param_settings(
         model_specs = complete_partition_spec_tree(
             jax.tree_util.tree_structure(model_params), model_specs
         )
-        opt_params = jax.tree_util.tree_map(
+        opt_params = jax.tree.map(
             lambda param, spec: OptParam(
                 value=param,
                 # Disable factored second moment since we use a dummy weight value.
@@ -571,10 +571,10 @@ def read_per_param_settings(
             model_specs,
         )
         # Sets gradients to dummy values.
-        zero_grads = jax.tree_util.tree_map(lambda p: jnp.zeros(1), opt_param_values(opt_params))
+        zero_grads = jax.tree.map(lambda p: jnp.zeros(1), opt_param_values(opt_params))
         learner = trainer_cfg.learner.set(name="learner").instantiate(parent=None)
         learner_state = learner.init(opt_params)
-        zero_grads = jax.tree_util.tree_map(
+        zero_grads = jax.tree.map(
             lambda use_opt, g: g if use_opt else None,
             learner.should_update_with_optimizers(opt_params),
             zero_grads,
@@ -873,7 +873,7 @@ def initialize_parameters_with_prebuilt(
         return layer.initialize_parameters_recursively(prng_key)
     # A tree where a leaf is a ParameterSpec for a prebuilt param, None otherwise.
     # This is used for `initialize_parameters_recursively`.
-    prebuilt_param_specs = jax.tree_util.tree_map(
+    prebuilt_param_specs = jax.tree.map(
         lambda value: (
             ParameterSpec(
                 shape=value.shape,
@@ -890,7 +890,7 @@ def initialize_parameters_with_prebuilt(
     # Merge `prebuilt` and `initialized`.
     logging.info("prebuilt params: %s", shapes(prebuilt))
     logging.info("initialized params: %s", shapes(initialized))
-    return jax.tree_util.tree_map(
+    return jax.tree.map(
         lambda prebuilt, initialized: (prebuilt if isinstance(prebuilt, Tensor) else initialized),
         prebuilt,
         initialized,

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -1016,7 +1016,7 @@ class CompatibilityTest(test_utils.TestCase):
                 shape_dtype = jax.eval_shape(
                     lambda: self.initialize_parameters_recursively(jax.random.PRNGKey(0))
                 )
-                return jax.tree_util.tree_map(
+                return jax.tree.map(
                     lambda x: ParameterSpec(shape=x.shape, dtype=x.dtype), shape_dtype
                 )
 

--- a/axlearn/common/transducer.py
+++ b/axlearn/common/transducer.py
@@ -249,7 +249,7 @@ class Transducer(BaseLayer):
             # of transducer training.
             def map_fn(am_t: Seq) -> tuple[Tensor, Tensor]:
                 # [1, ...].
-                am_t = jax.tree_util.tree_map(lambda x: jnp.expand_dims(x, 0), am_t)
+                am_t = jax.tree.map(lambda x: jnp.expand_dims(x, 0), am_t)
                 # [1, lm_max_len, ...].
                 prediction_t = self.predict(am_t.data, lm_i.data)
                 # [1, lm_max_len].

--- a/axlearn/common/transducer_test.py
+++ b/axlearn/common/transducer_test.py
@@ -596,7 +596,7 @@ class AlignmentTest(TestWithTemporaryCWD, tf.test.TestCase):
             loss += loss_i
 
             # Batch forward with padded length is the same as forward with exact length.
-            jax.tree_util.tree_map(
+            jax.tree.map(
                 lambda x, y, n=i: compare_fn(x, y[n : n + 1]), log_probs_i, log_probs_batch
             )
             # Batch backward with padded length is the same as backward with exact length.

--- a/axlearn/common/update_transformation.py
+++ b/axlearn/common/update_transformation.py
@@ -121,7 +121,7 @@ class Updates(struct.PyTreeNode):
 
     def param_values(self) -> Nested[Tensor]:
         """Returns a tree with the same structure as `opt_params` with the value of each param."""
-        return jax.tree_util.tree_map(
+        return jax.tree.map(
             lambda x: x.value, self.opt_params, is_leaf=lambda x: isinstance(x, OptParam)
         )
 
@@ -129,7 +129,7 @@ class Updates(struct.PyTreeNode):
         """Returns a tree with the same structure as `opt_params` with the metadata of each
         param.
         """
-        return jax.tree_util.tree_map(
+        return jax.tree.map(
             lambda x: ParameterSpec(
                 shape=x.value.shape,
                 dtype=x.value.dtype,
@@ -257,7 +257,7 @@ def mask_tree(tree: dict, *, keep: dict, mask_value: Any) -> dict:
     """
     # For sub-learner optimizer state, only the subset of parameters
     # that belongs to the optimizer is kept and the rest is masked as optax.MaskNode().
-    return jax.tree_util.tree_map(
+    return jax.tree.map(
         lambda should_keep, leaf: leaf if should_keep else mask_value,
         keep,
         tree,

--- a/axlearn/common/update_transformation_test.py
+++ b/axlearn/common/update_transformation_test.py
@@ -169,7 +169,7 @@ def mock_params() -> Nested[Tensor]:
 def mock_updates() -> axlearn.common.update_transformation.Updates:
     """Create an updates object with various semi-reasonable values."""
     model_params = mock_params()
-    opt_params = jax.tree_util.tree_map(
+    opt_params = jax.tree.map(
         lambda p: OptParam(
             value=p,
             factorization_spec=FactorizationSpec([None] * p.ndim),
@@ -177,7 +177,7 @@ def mock_updates() -> axlearn.common.update_transformation.Updates:
         ),
         model_params,
     )
-    delta_updates = jax.tree_util.tree_map(lambda p: p * -0.1, model_params)
+    delta_updates = jax.tree.map(lambda p: p * -0.1, model_params)
     delta_updates["state"] = None
     inplace_updates = dict(
         state=jnp.arange(2, dtype=jnp.int32),

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -247,7 +247,7 @@ class TreeUtilsTest(TestCase):
             as_tensor(torch.ones([4, 1], dtype=torch.float16)),
         )
         # From a nested structure.
-        jax.tree_util.tree_map(
+        jax.tree.map(
             self.assertTensorEqual,
             {
                 "a": jnp.ones([1], dtype=jnp.float32),
@@ -348,7 +348,7 @@ class TreeUtilsTest(TestCase):
             as_numpy_array(torch.ones([4, 1], dtype=torch.float)),
         )
         # From a nested structure.
-        jax.tree_util.tree_map(
+        jax.tree.map(
             self.assertNumpyArrayEqual,
             {
                 "a": np.ones([1], dtype=np.float32),
@@ -377,16 +377,12 @@ class TreeUtilsTest(TestCase):
         self.assertNestedAllClose([("a", tree["a"]), ("b", tree["b"])], flatten_items(tree))
 
         # Stack 3 trees together.
-        stacked_tree = jax.tree_util.tree_map(lambda *xs: jnp.stack(xs), tree, tree, tree)
+        stacked_tree = jax.tree.map(lambda *xs: jnp.stack(xs), tree, tree, tree)
         self.assertEqual(type(stacked_tree), VDict)
-        self.assertEqual(
-            VDict(a=(3, 10), b=(3, 7)), jax.tree_util.tree_map(lambda t: t.shape, stacked_tree)
-        )
+        self.assertEqual(VDict(a=(3, 10), b=(3, 7)), jax.tree.map(lambda t: t.shape, stacked_tree))
 
-        # jax.tree_util.tree_map() treats VDict similarly to dict.
-        self.assertEqual(
-            VDict(a=45 * 3, b=0), jax.tree_util.tree_map(lambda t: t.sum(), stacked_tree)
-        )
+        # jax.tree.map() treats VDict similarly to dict.
+        self.assertEqual(VDict(a=45 * 3, b=0), jax.tree.map(lambda t: t.sum(), stacked_tree))
         # vectorized_tree_map() vectorizes 'fn' on VDict and processes the 3 trees separately.
         self.assertNestedAllClose(
             VDict(a=jnp.asarray([45, 45, 45]), b=jnp.asarray([0, 0, 0])),
@@ -395,10 +391,10 @@ class TreeUtilsTest(TestCase):
 
         # Nested VDict.
         tree2 = VDict(c=stacked_tree)
-        stacked_tree2 = jax.tree_util.tree_map(lambda *xs: jnp.stack(xs), tree2, tree2)
+        stacked_tree2 = jax.tree.map(lambda *xs: jnp.stack(xs), tree2, tree2)
         self.assertEqual(
             VDict(c=VDict(a=(2, 3, 10), b=(2, 3, 7))),
-            jax.tree_util.tree_map(lambda t: t.shape, stacked_tree2),
+            jax.tree.map(lambda t: t.shape, stacked_tree2),
         )
         self.assertNestedAllClose(
             VDict(c=VDict(a=jnp.full([2, 3], 45), b=jnp.full([2, 3], 0))),
@@ -453,13 +449,13 @@ class TreeUtilsTest(TestCase):
         v2 = VDict(d2)
 
         # Make sure keys are in sorted order after using tree utils like they are for dicts.
-        d_result = jax.tree_util.tree_map(lambda *args: args, d1, d2)
-        v_result = jax.tree_util.tree_map(lambda *args: args, v1, v2)
+        d_result = jax.tree.map(lambda *args: args, d1, d2)
+        v_result = jax.tree.map(lambda *args: args, v1, v2)
         self.assertSequenceEqual(v_result, d_result)
         self.assertSequenceEqual(list(v_result.values()), list(d_result.values()))
 
         # Explicitly test that mismatching key orders work.
-        result = jax.tree_util.tree_map(lambda *args: args, VDict(b=2, a=1), VDict(a=1, b=2))
+        result = jax.tree.map(lambda *args: args, VDict(b=2, a=1), VDict(a=1, b=2))
         self.assertSequenceEqual(list(result), ["a", "b"])
         self.assertSequenceEqual(list(result.values()), [(1, 1), (2, 2)])
 
@@ -703,7 +699,7 @@ class TreeUtilsTest(TestCase):
             if x.dtype in [jnp.float32, jnp.bfloat16]:
                 self.assertEqual(x.dtype, to_dtype)
 
-        jax.tree_util.tree_map(check_type, out_tree)
+        jax.tree.map(check_type, out_tree)
 
         self.assertEqual(out_tree["w2"].dtype, in_tree["w2"].dtype)
 

--- a/axlearn/huggingface/hf_module.py
+++ b/axlearn/huggingface/hf_module.py
@@ -159,7 +159,7 @@ class HfModuleWrapper(BaseModel):
         self, prng_key: Tensor, *, prebuilt: Optional[Nested[Optional[ParameterSpec]]] = None
     ) -> NestedTensor:
         if self._use_prebuilt_params(prebuilt):
-            return jax.tree_util.tree_map(lambda _: None, prebuilt)
+            return jax.tree.map(lambda _: None, prebuilt)
         params = super().initialize_parameters_recursively(prng_key, prebuilt=prebuilt)
         cfg = self.config
         if self._local_pretrained_model_path is not None:

--- a/axlearn/vision/clip_test.py
+++ b/axlearn/vision/clip_test.py
@@ -223,7 +223,7 @@ class TestCLIPModel(parameterized.TestCase):
         tokenized_text_generator_params,
     ):
         layer_params = layer.initialize_parameters_recursively(prng_key=jax.random.PRNGKey(0))
-        layer_param_shapes = jax.tree_util.tree_map(lambda x: x.shape, layer_params)
+        layer_param_shapes = jax.tree.map(lambda x: x.shape, layer_params)
         print(f"layer state={layer_param_shapes}")
         layer_params = parameters_from_torch_layer(ref)
         images = (

--- a/axlearn/vision/coco_evaluator.py
+++ b/axlearn/vision/coco_evaluator.py
@@ -244,7 +244,7 @@ class COCOEvaluator:
     def _convert_to_numpy(self, groundtruths, predictions):
         """Converts tensors to numpy arrays."""
         if groundtruths:
-            labels = jax.tree_util.tree_map(np.array, groundtruths)
+            labels = jax.tree.map(np.array, groundtruths)
             numpy_groundtruths = {}
             for key, val in labels.items():
                 if isinstance(val, tuple):
@@ -254,7 +254,7 @@ class COCOEvaluator:
             numpy_groundtruths = groundtruths
 
         if predictions:
-            outputs = jax.tree_util.tree_map(np.array, predictions)
+            outputs = jax.tree.map(np.array, predictions)
             numpy_predictions = {}
             for key, val in outputs.items():
                 if isinstance(val, tuple):

--- a/axlearn/vision/eval_detection_test.py
+++ b/axlearn/vision/eval_detection_test.py
@@ -91,7 +91,7 @@ class COCOMetricCalculatorTest(TestCase, parameterized.TestCase):
                 .set(name="model", need_rescale_bboxes=need_rescale_bboxes, input_cfg=input_cfg)
                 .instantiate(parent=None)
             )
-            model_param_partition_specs = jax.tree_util.tree_map(
+            model_param_partition_specs = jax.tree.map(
                 lambda spec: spec.mesh_axes, model.create_parameter_specs_recursively()
             )
             calculator: COCOMetricCalculator = (

--- a/axlearn/vision/image_classification_test.py
+++ b/axlearn/vision/image_classification_test.py
@@ -50,7 +50,7 @@ class ClassificationModelTest(parameterized.TestCase):
         for name, param in ref.named_parameters():
             logging.info("ref param: %s=%s", name, list(param.shape))
 
-        model_params = jax.tree_util.tree_map(utils.as_tensor, params_from_model(ref=ref))
+        model_params = jax.tree.map(utils.as_tensor, params_from_model(ref=ref))
         model_param_strs = [
             f"{name}={list(param.shape)}" for name, param in utils.flatten_items(model_params)
         ]
@@ -69,7 +69,7 @@ class ClassificationModelTest(parameterized.TestCase):
             is_training=is_training,
             prng_key=jax.random.PRNGKey(123),
             state=model_params,
-            inputs=dict(input_batch=jax.tree_util.tree_map(jnp.asarray, inputs)),
+            inputs=dict(input_batch=jax.tree.map(jnp.asarray, inputs)),
         )
         if not is_training:
             ref.eval()

--- a/axlearn/vision/mobilenets_test.py
+++ b/axlearn/vision/mobilenets_test.py
@@ -121,7 +121,7 @@ class MobileNetsTest(parameterized.TestCase):
             is_training=is_training,
             prng_key=jax.random.PRNGKey(123),
             state=init_params,
-            inputs=dict(input_batch=jax.tree_util.tree_map(jnp.asarray, inputs)),
+            inputs=dict(input_batch=jax.tree.map(jnp.asarray, inputs)),
         )
         self.assertListEqual(
             sorted(outputs.keys()),
@@ -155,7 +155,7 @@ class MobileNetsTest(parameterized.TestCase):
             is_training=False,
             prng_key=jax.random.PRNGKey(123),
             state=init_params,
-            inputs=dict(input_batch=jax.tree_util.tree_map(jnp.asarray, inputs)),
+            inputs=dict(input_batch=jax.tree.map(jnp.asarray, inputs)),
         )
         expected_feature_dims = {
             (ModelNames.MOBILENETV3, "small-minimal-100", None): {

--- a/axlearn/vision/param_converter.py
+++ b/axlearn/vision/param_converter.py
@@ -110,9 +110,7 @@ def parameters_to_hf_clip_encoder(*, src: Encoder, params: NestedTensor, dst: hf
             assert isinstance(src.transformer, RepeatedTransformerLayer)
             axlearn_to_torch(
                 src.transformer.repeat.layer,
-                jax.tree_util.tree_map(
-                    lambda x, idx=i: x[idx], params["transformer"]["repeat"]["layer"]
-                ),
+                jax.tree.map(lambda x, idx=i: x[idx], params["transformer"]["repeat"]["layer"]),
                 dst_layer,
             )
 

--- a/axlearn/vision/param_converter_test.py
+++ b/axlearn/vision/param_converter_test.py
@@ -286,7 +286,7 @@ class HFClipTest(BaseParamConverterTest):
             "input_ids": as_torch_tensor(inputs),
             "pixel_values": as_torch_tensor(image_inputs),
         }
-        expected, actual = jax.tree_util.tree_map(
+        expected, actual = jax.tree.map(
             as_tensor,
             (
                 torch_output_to_dict(hf_layer(**hf_inputs)),

--- a/axlearn/vision/resnet_test.py
+++ b/axlearn/vision/resnet_test.py
@@ -52,7 +52,7 @@ class ResNetTest(parameterized.TestCase):
             is_training=is_training,
             prng_key=jax.random.PRNGKey(123),
             state=init_params,
-            inputs=dict(image=jax.tree_util.tree_map(jnp.asarray, inputs)),
+            inputs=dict(image=jax.tree.map(jnp.asarray, inputs)),
         )
         for level in range(2, 6):
             self.assertEqual(outputs[str(level)].shape[-1], model.endpoints_dims[str(level)])
@@ -77,7 +77,7 @@ class ResNetTest(parameterized.TestCase):
             is_training=is_training,
             prng_key=jax.random.PRNGKey(123),
             state=init_params,
-            inputs=dict(image=jax.tree_util.tree_map(jnp.asarray, inputs)),
+            inputs=dict(image=jax.tree.map(jnp.asarray, inputs)),
         )
         num_params = utils.count_model_params(init_params)
         logging.info("Model contains %s Million parameters.", num_params / 10.0**6)


### PR DESCRIPTION
Because jax.tree_util.tree_map was deprecated.
https://jax.readthedocs.io/en/latest/changelog.html#jaxlib-0-4-27-may-7-2024