### PR TITLE
Fix garbage collector not garbage collecting for gcs dirs

### DIFF
--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -915,7 +915,9 @@ class Checkpointer(BaseCheckpointer):
         remaining_dirs, gc_dirs = [], []
 
         try:
-            step_dirs = [step for step in fs.listdir(cfg.dir) if step.startswith(STEP_PREFIX)]
+            step_dirs = [
+                step.rstrip("/") for step in fs.listdir(cfg.dir) if step.startswith(STEP_PREFIX)
+            ]
         except fs.NotFoundError:
             step_dirs = []
 

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -14,6 +14,7 @@ import time
 import unittest
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
 from typing import Optional, Type, cast
 from unittest import mock
 
@@ -363,40 +364,54 @@ class CheckpointerTest(test_utils.TestCase):
             # Ensure that the last ckpt is considered invalid.
             self.assertEqual(Checkpointer.latest_checkpoint_path(temp_dir), ckpt_paths[0])
 
-    @parameterized.parameters(
+    @parameterized.product(
         # By default, we restore from the latest ckpt, keep the last 3 steps, and every 2 after.
-        dict(
-            ckpt_paths=None,
-            expect_restore_step=9,
-            expect_saved_steps=[0, 2, 4, 6, 7, 8, 9],
+        (
+            dict(
+                ckpt_paths=None,
+                expect_restore_step=9,
+                expect_saved_steps=[0, 2, 4, 6, 7, 8, 9],
+            ),
+            # If we pretend that the first 2 ckpt paths failed, they should be retained.
+            # We then keep the next 3 steps and every 2 afterwards.
+            dict(
+                ckpt_paths=range(8),
+                expect_restore_step=7,
+                expect_saved_steps=[0, 2, 4, 5, 6, 7, 8, 9],
+            ),
+            # Test a case where committed dirs are not consecutive.
+            # In this case, we keep 9 due to possible in-progress write;
+            # we keep 8, 6, 3, which are the last 3 checkpoints;
+            # And we keep 0 (but not 1, since it doesn't respect keep_every_n=2).
+            dict(
+                ckpt_paths=[0, 1, 3, 6, 8],
+                expect_restore_step=8,
+                expect_saved_steps=[0, 3, 6, 8, 9],
+            ),
         ),
-        # If we pretend that the first 2 ckpt paths failed, they should be retained.
-        # We then keep the next 3 steps and every 2 afterwards.
-        dict(
-            ckpt_paths=range(8),
-            expect_restore_step=7,
-            expect_saved_steps=[0, 2, 4, 5, 6, 7, 8, 9],
-        ),
-        # Test a case where committed dirs are not consecutive.
-        # In this case, we keep 9 due to possible in-progress write;
-        # we keep 8, 6, 3, which are the last 3 checkpoints;
-        # And we keep 0 (but not 1, since it doesn't respect keep_every_n=2).
-        dict(
-            ckpt_paths=[0, 1, 3, 6, 8],
-            expect_restore_step=8,
-            expect_saved_steps=[0, 3, 6, 8, 9],
-        ),
+        listdir_add_trailing_slash=[True, False],
     )
     def test_garbage_collection(
         self,
         ckpt_paths: Optional[Sequence[str]],
         expect_restore_step: int,
         expect_saved_steps: Sequence[int],
+        listdir_add_trailing_slash: bool,
     ):
         mesh_shape = (1, 1)
         if not test_utils.is_supported_mesh_shape(mesh_shape):
             return
-        with _mesh(mesh_shape), tempfile.TemporaryDirectory() as temp_dir:
+
+        orig_tf_listdir = tf.io.gfile.listdir
+
+        def patch_tf_io_behavior(*args):
+            out = orig_tf_listdir(*args)
+            return [x + "/" for x in out if not x.endswith("/")]
+
+        # pylint: disable=line-too-long
+        with _mesh(mesh_shape), mock.patch(
+            "tensorflow.io.gfile.listdir", patch_tf_io_behavior
+        ) if listdir_add_trailing_slash else nullcontext(), tempfile.TemporaryDirectory() as temp_dir:
             cfg = Checkpointer.default_config().set(
                 name="test",
                 dir=temp_dir,


### PR DESCRIPTION
Fixed garbage collection bugs introduced by #703.

The cause is that `tf.io.gfile.listdir` will append trailing slash to gcs dirs. However, `checkpoint_paths` will return path without the trailing slash due to the use of `os.path.dirname`. This causes the `in` operator to fail.

This is not caught by unit tests since `tf.io.gfile.listdir` has inconsistent behavior. When listing local dirs, it has no trailing slash.

Before #703, we use `tf.io.gfile.glob` consistently and therefore there're no mismatching slashes.

We fixed this bug by stripping the trailing slash if present. We also added a unit tests to catch this.