### PR TITLE
Cleanup: Rename `make_..._mask` functions to `make_..._biases`

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -314,8 +314,7 @@ class BaseTransformerLayer(BaseLayer):
         raise NotImplementedError(type(self))
 
 
-# TODO(c_lan): Rename `..._mask` functions to "..._biases".
-def make_causal_mask(seq_len: int) -> Tensor:
+def make_causal_biases(seq_len: int) -> Tensor:
     """Generates attention logit biases for causal masking.
 
     Args:
@@ -329,7 +328,7 @@ def make_causal_mask(seq_len: int) -> Tensor:
     return _bool_to_bias(causal_mask(jnp.arange(seq_len)[:, None], jnp.arange(seq_len)[None, :]))
 
 
-def make_sliding_window_causal_mask(seq_len: int, sliding_window_size: int) -> Tensor:
+def make_sliding_window_causal_biases(seq_len: int, sliding_window_size: int) -> Tensor:
     """Generates attention logit biases for sliding window attention.
 
     Args:

--- a/axlearn/common/flash_attention/layer_test.py
+++ b/axlearn/common/flash_attention/layer_test.py
@@ -15,7 +15,7 @@ from axlearn.common.attention import (
     GroupedQueryAttention,
     _bool_to_bias,
     apply_attention_logit_biases,
-    make_causal_mask,
+    make_causal_biases,
     sliding_window_causal_mask,
 )
 from axlearn.common.base_layer import BaseLayer
@@ -558,7 +558,7 @@ class TestFlashAttention(TestCase):
                 dtype=dtype,
             )
             # Note: We need to use causal bias for flash attention input in case of decoding.
-            causal_bias = apply_attention_logit_biases(bias, make_causal_mask(seq_len)).astype(
+            causal_bias = apply_attention_logit_biases(bias, make_causal_biases(seq_len)).astype(
                 dtype
             )
             kv_state = None

--- a/axlearn/common/multiway_transformer_test.py
+++ b/axlearn/common/multiway_transformer_test.py
@@ -14,7 +14,7 @@ from axlearn.common.attention import (
     TransformerFeedForwardLayer,
     TransformerLayer,
     build_remat_spec,
-    make_causal_mask,
+    make_causal_biases,
 )
 from axlearn.common.module import functional as F
 from axlearn.common.multiway_transformer import (
@@ -126,7 +126,7 @@ class ModelTest(parameterized.TestCase):
         target = jax.random.normal(jax.random.PRNGKey(123), [batch_size, tgt_len, model_dim])
         source = jax.random.normal(jax.random.PRNGKey(456), [batch_size, src_len, model_dim * 2])
 
-        self_attention_logit_biases = make_causal_mask(tgt_len)
+        self_attention_logit_biases = make_causal_biases(tgt_len)
         cross_attention_logit_biases = (
             jnp.array(np.random.randint(0, 2, [tgt_len, src_len])) * NEG_INF
         )
@@ -228,7 +228,7 @@ class ModelTest(parameterized.TestCase):
         target = jax.random.normal(jax.random.PRNGKey(123), [batch_size, tgt_len, model_dim])
         source = jax.random.normal(jax.random.PRNGKey(456), [batch_size, src_len, model_dim * 2])
 
-        self_attention_logit_biases = make_causal_mask(tgt_len)
+        self_attention_logit_biases = make_causal_biases(tgt_len)
         cross_attention_logit_biases = (
             jnp.array(np.random.randint(0, 2, [tgt_len, src_len])) * NEG_INF
         )

--- a/axlearn/common/ssm_test.py
+++ b/axlearn/common/ssm_test.py
@@ -26,7 +26,7 @@ from absl.testing import parameterized
 from transformers.activations import ACT2FN
 from transformers.configuration_utils import PretrainedConfig
 
-from axlearn.common.attention import make_causal_mask
+from axlearn.common.attention import make_causal_biases
 from axlearn.common.config import InstantiableConfig
 from axlearn.common.module import functional as F
 from axlearn.common.ssm import (
@@ -521,7 +521,9 @@ def _test_extend_step(layer_cfg: InstantiableConfig, *, model_dim: int, dtype: j
         [batch_size, tgt_len, model_dim],
         dtype=dtype,
     )
-    self_attention_logit_biases = make_causal_mask(tgt_len)  # Only necessary for self-attn layers.
+    self_attention_logit_biases = make_causal_biases(
+        tgt_len
+    )  # Only necessary for self-attn layers.
     inputs = dict(data=query, self_attention_logit_biases=self_attention_logit_biases)
     forward_outputs, _ = F(
         layer,
@@ -564,7 +566,9 @@ def _test_prefill_states(layer_cfg: InstantiableConfig, *, model_dim: int, dtype
         [batch_size, tgt_len, model_dim],
         dtype=dtype,
     )
-    self_attention_logit_biases = make_causal_mask(tgt_len)  # Only necessary for self-attn layers.
+    self_attention_logit_biases = make_causal_biases(
+        tgt_len
+    )  # Only necessary for self-attn layers.
     inputs = dict(data=query, self_attention_logit_biases=self_attention_logit_biases)
     forward_outputs, _ = F(
         layer,
@@ -862,7 +866,7 @@ class StackedMixedSSMTransformerTest(TestCase):
 
         batch_size, tgt_len = 2, 6
         x = jax.random.uniform(jax.random.PRNGKey(1), [batch_size, tgt_len, model_dim])
-        self_attention_logit_biases = make_causal_mask(tgt_len)
+        self_attention_logit_biases = make_causal_biases(tgt_len)
         stacked_outputs, _ = F(
             test_layer,
             inputs=dict(data=x, self_attention_logit_biases=self_attention_logit_biases),


### PR DESCRIPTION
Clean up a TODO item as the term `biases` is more specific than `mask`.