### PR TITLE
Erase KV before updating during extend_step

### DIFF
--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -221,12 +221,6 @@ class FlashAttention(GroupedQueryAttention):
             # TODO(senyut): Implement FlashDecoding kernel and support TPU decoding.
             if q_proj.shape[1] == 1:
                 mask_fn = None
-        elif backend == "gpu" and q_proj.shape[1] != k_proj.shape[1]:
-            # TODO(xuan-zou): Generalize GPU Flash Attention for q_len != kv_len.
-            raise NotImplementedError(
-                f"Query length {q_proj.shape[1]} must be equal to KV length "
-                f"{k_proj.shape[1]} for correctly supported GPU flash attention usage."
-            )
 
         if backend == "tpu":
             assert q_proj.shape[1] % cfg.tpu_block_size == 0, (

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -221,6 +221,12 @@ class FlashAttention(GroupedQueryAttention):
             # TODO(senyut): Implement FlashDecoding kernel and support TPU decoding.
             if q_proj.shape[1] == 1:
                 mask_fn = None
+        elif backend == "gpu" and q_proj.shape[1] != k_proj.shape[1]:
+            # TODO(xuan-zou): Generalize GPU Flash Attention for q_len != kv_len.
+            raise NotImplementedError(
+                f"Query length {q_proj.shape[1]} must be equal to KV length "
+                f"{k_proj.shape[1]} for correctly supported GPU flash attention usage."
+            )
 
         if backend == "tpu":
             assert q_proj.shape[1] % cfg.tpu_block_size == 0, (


### PR DESCRIPTION
Allows for the external caller to control whether they want to call extend_step with the same time_step multiple times. Otherwise, the KV at the same time_step is summed across multiple calls.