### PR TITLE
Sparse Sliding Window Attention

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -325,7 +325,7 @@ def make_causal_biases(seq_len: int) -> Tensor:
         0 otherwise.
     """
     # TODO(sneha): support batching
-    return _bool_to_bias(causal_mask(jnp.arange(seq_len)[:, None], jnp.arange(seq_len)[None, :]))
+    return bool_to_bias(causal_mask(jnp.arange(seq_len)[:, None], jnp.arange(seq_len)[None, :]))
 
 
 def make_sliding_window_causal_biases(seq_len: int, sliding_window_size: int) -> Tensor:
@@ -339,10 +339,10 @@ def make_sliding_window_causal_biases(seq_len: int, sliding_window_size: int) ->
         if i - j > sliding_window_size or i < j, 0 otherwise.
     """
     mask_fn = sliding_window_causal_mask(sliding_window_size)
-    return _bool_to_bias(mask_fn(jnp.arange(seq_len)[:, None], jnp.arange(seq_len)[None, :]))
+    return bool_to_bias(mask_fn(jnp.arange(seq_len)[:, None], jnp.arange(seq_len)[None, :]))
 
 
-def _bool_to_bias(mask: Tensor) -> Tensor:
+def bool_to_bias(mask: Tensor) -> Tensor:
     """Converts a bool mask tensor to a bias mask tensor.
 
     Maps:
@@ -1965,7 +1965,7 @@ class MultiheadAttention(BaseLayer):
             mask = mask[:, None, None, :]
         else:
             raise ValueError(f"Unrecognized mode {mode}.")
-        mask = _bool_to_bias(mask)
+        mask = bool_to_bias(mask)
         return mask
 
     def _compute_attention(

--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -96,13 +96,9 @@ from axlearn.common.config import (
 )
 from axlearn.common.decoder import Decoder, TransformerTextEmbeddings
 from axlearn.common.layers import RMSNorm, set_bias_recursively
-from axlearn.common.module import (
-    InvocationContext,
-    Module,
-    new_output_collection,
-    set_current_context,
-)
+from axlearn.common.module import InvocationContext, Module
 from axlearn.common.module import functional as F
+from axlearn.common.module import new_output_collection, set_current_context
 from axlearn.common.optimizer_base import OptParam
 from axlearn.common.optimizers import adafactor_optimizer
 from axlearn.common.param_converter import as_torch_tensor

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -120,8 +120,7 @@ class FlashAttention(GroupedQueryAttention):
         return (
             backend == "tpu"
             and self.per_head_dim() % splash_attention_kernel.NUM_LANES == 0
-            # TODO(c_lan): sliding_window_mask fails layer_test with seq_len = 2048. Need to fix.
-            and self._mask_fn is causal_mask
+            and self._mask_fn is not None
         )
 
     def _logit_biases_for_mask(

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -16,6 +16,9 @@ from jax.experimental.pallas.ops.tpu.flash_attention import (
     MIN_BLOCK_SIZE,
     NUM_LANES,
     NUM_SUBLANES,
+)
+from jax.experimental.pallas.ops.tpu.flash_attention import BlockSizes as LegacyBlockSizes
+from jax.experimental.pallas.ops.tpu.flash_attention import (
     SegmentIds,
     _flash_attention_dkv_kernel,
     _flash_attention_dq_kernel,
@@ -23,7 +26,6 @@ from jax.experimental.pallas.ops.tpu.flash_attention import (
     _verify_block,
     below_or_on_diag,
 )
-from jax.experimental.pallas.ops.tpu.flash_attention import BlockSizes as LegacyBlockSizes
 from jax.experimental.pallas.ops.tpu.splash_attention import (
     splash_attention_kernel,
     splash_attention_mask,

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -278,7 +278,9 @@ def _tpu_splash_attention(
         cols = np.arange(target_len)
         with jax.ensure_compile_time_eval():
             mask_array = np.asarray(mask(rows[:, None], cols[None, :]))
-        # NumpyMask may consume a large amount of host memory for long sequences at compile time.
+
+        # NumpyMask is backed by a dense [source_len, target_len] numpy array.
+        # May consume a large amount of host memory for long sequences at compile time.
         mask = splash_attention_mask.NumpyMask(array=mask_array)
 
     kernel = splash_attention_kernel.make_splash_mha(

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -278,6 +278,7 @@ def _tpu_splash_attention(
         cols = np.arange(target_len)
         with jax.ensure_compile_time_eval():
             mask_array = np.asarray(mask(rows[:, None], cols[None, :]))
+        # NumpyMask may consume a large amount of host memory for long sequences at compile time.
         mask = splash_attention_mask.NumpyMask(array=mask_array)
 
     kernel = splash_attention_kernel.make_splash_mha(

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -16,9 +16,6 @@ from jax.experimental.pallas.ops.tpu.flash_attention import (
     MIN_BLOCK_SIZE,
     NUM_LANES,
     NUM_SUBLANES,
-)
-from jax.experimental.pallas.ops.tpu.flash_attention import BlockSizes as LegacyBlockSizes
-from jax.experimental.pallas.ops.tpu.flash_attention import (
     SegmentIds,
     _flash_attention_dkv_kernel,
     _flash_attention_dq_kernel,
@@ -26,6 +23,7 @@ from jax.experimental.pallas.ops.tpu.flash_attention import (
     _verify_block,
     below_or_on_diag,
 )
+from jax.experimental.pallas.ops.tpu.flash_attention import BlockSizes as LegacyBlockSizes
 from jax.experimental.pallas.ops.tpu.splash_attention import (
     splash_attention_kernel,
     splash_attention_mask,
@@ -268,6 +266,10 @@ def _tpu_splash_attention(
         raise SplashAttentionUnsupportedError(
             "The public API for SplashAttention that we "
             "currently use does not support segment ids."
+        )
+    if source_len != target_len and mask is not None:
+        raise SplashAttentionUnsupportedError(
+            "Query and key/value must have same length when mask is used."
         )
 
     mask_shape = (source_len, target_len)

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -2,7 +2,7 @@
 
 """Wrappers for FlashAttention on TPU in JAX with logit bias support."""
 import functools
-from typing import Any, Callable, Hashable, Optional, Union
+from typing import Optional
 
 import jax
 import jax.numpy as jnp
@@ -31,7 +31,7 @@ from jax.experimental.pallas.ops.tpu.splash_attention import (
     splash_attention_mask,
 )
 
-from axlearn.common.attention import MaskFn, causal_mask
+from axlearn.common.attention import MaskFn, apply_attention_logit_biases, bool_to_bias, causal_mask
 from axlearn.common.utils import Tensor
 
 
@@ -184,9 +184,14 @@ def _legacy_tpu_flash_attention(
     Raises:
         NotImplementedError: If a custom (non-causal, non-full) mask is specified.
     """
-    if mask is not None and mask is not causal_mask:
-        raise NotImplementedError("Custom masks are not supported by legacy attention.")
     causal = mask is causal_mask
+    if mask is not None and not causal:
+        rows = jnp.arange(0, query.shape[2])
+        cols = jnp.arange(0, key.shape[2])
+        bias = apply_attention_logit_biases(
+            bool_to_bias(mask(rows[:, None], cols[None, :]))[None, None, :, :], bias
+        )
+
     context = pallas_tpu_flash_attention(
         q=query,
         k=key,
@@ -269,24 +274,11 @@ def _tpu_splash_attention(
     if mask is None:
         mask = splash_attention_mask.FullMask(mask_shape)
     else:
-
-        def wrap_mask(mask: MaskFn) -> MaskFn:
-            """Wrap `mask` so that the return type is a numpy array
-            if the original input was, even if we are inside of jit.
-            """
-
-            def wrapped_mask(*args, **kwargs) -> Union[np.ndarray, Tensor]:
-                if all(
-                    isinstance(x, np.ndarray) for x in jax.tree_util.tree_leaves([args, kwargs])
-                ):
-                    with jax.ensure_compile_time_eval():
-                        result = mask(*args, **kwargs)
-                        return jax.tree.map(np.asarray, result)
-                return mask(*args, **kwargs)
-
-            return wrapped_mask
-
-        mask = ComputableMask(mask_shape, mask_function=wrap_mask(mask))
+        rows = np.arange(source_len)
+        cols = np.arange(target_len)
+        with jax.ensure_compile_time_eval():
+            mask_array = np.asarray(mask(rows[:, None], cols[None, :]))
+        mask = splash_attention_mask.NumpyMask(array=mask_array)
 
     kernel = splash_attention_kernel.make_splash_mha(
         mask=splash_attention_mask.MultiHeadMask(masks=[mask] * num_heads),
@@ -297,90 +289,6 @@ def _tpu_splash_attention(
     kernel = jax.vmap(kernel)
     context = kernel(q=query, k=key, v=value)
     return context
-
-
-class ComputableMask(splash_attention_mask.Mask):
-    """A Mask that can be lazily computed using a callable.
-
-    This implementation is mostly copied from
-
-    `jax.experimental.pallas.ops.flash_attention.splash_attention_mask._ComputableMask`
-
-    in order to avoid relying on that private API.
-    """
-
-    # The shape of the mask.
-    _shape: tuple[int, int]
-    # The sequence of query indices that the mask covers.
-    q_sequence: np.ndarray
-    # A function compute the mask value given indices.
-    mask_function: MaskFn
-
-    def __init__(
-        self,
-        shape: tuple[int, int],
-        mask_function: Callable[..., Any],
-        shard_count: int = 1,
-    ):
-        self._shape = shape
-        self.mask_function = mask_function
-        source_len = self.shape[0]
-
-        if source_len % (shard_count * shard_count) != 0:
-            raise ValueError(
-                f"Shard count squared ({shard_count * shard_count}) must"
-                f" divide Q seq_len ({self.shape[0]}) evenly."
-            )
-
-        self.q_sequence = np.arange(source_len, dtype=np.int32)
-
-    @property
-    def shape(self) -> tuple[int, ...]:
-        return self._shape
-
-    def __getitem__(self, idx) -> np.ndarray:
-        """Return the entries of the mask specified by the row and column slice in idx."""
-        if len(idx) != 2:
-            raise NotImplementedError(f"Unsupported slice: {idx}")
-
-        q_slice, kv_slice = idx
-        if not isinstance(q_slice, slice) or not isinstance(kv_slice, slice):
-            raise NotImplementedError(f"Unsupported slice: {idx}")
-
-        def _fill_slice(inp_slice: slice, size: int) -> slice:
-            assert inp_slice.step is None or inp_slice.step == 1
-            start = 0 if inp_slice.start is None else inp_slice.start
-            stop = size if inp_slice.stop is None else inp_slice.stop
-            assert start >= 0
-            assert stop <= size
-            return slice(start, stop, None)
-
-        q_slice = _fill_slice(q_slice, self.shape[0])
-        kv_slice = _fill_slice(kv_slice, self.shape[1])
-
-        rows = self.q_sequence[q_slice]
-        cols = np.arange(kv_slice.start, kv_slice.stop)
-
-        return self.mask_function(rows[:, None], cols[None, :])
-
-    def _to_hashable(self) -> Hashable:
-        """Returns a hashable representation of this object that can be used for equality
-        comparisons.
-        """
-        return (
-            type(self),
-            self.shape,
-            self.q_sequence.tobytes() if self.q_sequence is not None else None,
-            self.mask_function,
-        )
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ComputableMask):
-            raise NotImplementedError
-        return self._to_hashable() == other._to_hashable()
-
-    def __hash__(self) -> int:
-        return hash(self._to_hashable())
 
 
 # The following code is adapted from jax-ml/jax:

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -141,7 +141,6 @@ class TestFlashAttention(TestCase):
 
         # Trigger compilation.
         fn(q, k, v)
-        # Compare grads.
         jax.grad(lambda q, k, v: fn(q, k, v).mean(), argnums=(0, 1, 2))(q, k, v)
 
     @parameterized.product(

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -70,7 +70,7 @@ class TestFlashAttention(TestCase):
             self.assertNestedAllClose(ref_mask[i:, i:], test_mask[i:, i:])
 
     @parameterized.product(
-        batch_size=[8],
+        batch_size=[4],
         seq_len=[32768],
         sliding_window_size=[1024],
         num_heads=[4],

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -10,12 +10,16 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 from absl.testing import parameterized
+from jax.experimental import mesh_utils
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask
+from jax.experimental.shard_map import shard_map
+from jax.interpreters.pxla import thread_resources
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 from axlearn.common.attention import causal_mask, sliding_window_causal_mask
 from axlearn.common.flash_attention import tpu_attention
 from axlearn.common.flash_attention.utils import mha_reference
-from axlearn.common.test_utils import TestCase
+from axlearn.common.test_utils import TestCase, is_supported_mesh_shape
 from axlearn.common.utils import Tensor
 
 if jax.default_backend() != "tpu":
@@ -51,7 +55,7 @@ class TestFlashAttention(TestCase):
     ]
 
     @parameterized.product(seq_len=[8, 16, 32, 128], sliding_window_size=[4, 8, 16])
-    def test_sliding_window_mask(self, seq_len, sliding_window_size):
+    def test_sliding_window_mask_equivalence(self, seq_len, sliding_window_size):
         shape = (seq_len, seq_len)
         ref_mask = splash_attention_mask.LocalMask(
             shape=shape, window_size=(sliding_window_size, 0), offset=0
@@ -64,6 +68,81 @@ class TestFlashAttention(TestCase):
 
         for i in range(seq_len):
             self.assertNestedAllClose(ref_mask[i:, i:], test_mask[i:, i:])
+
+    @parameterized.product(
+        batch_size=[8],
+        seq_len=[32768],
+        sliding_window_size=[1024],
+        num_heads=[4],
+        per_head_dim=[256],
+        mesh=[(4, 1)],
+        mesh_axis_names=[("data", "model")],
+    )
+    def test_sliding_window_mask(
+        self,
+        batch_size,
+        seq_len,
+        num_heads,
+        per_head_dim,
+        sliding_window_size,
+        mesh,
+        mesh_axis_names,
+    ):
+        if not is_supported_mesh_shape(mesh):
+            pytest.skip(reason=f"Unsupported mesh {mesh}.")
+
+        k1, k2, k3 = jax.random.split(jax.random.PRNGKey(0), 3)
+        q = jax.random.normal(
+            k1, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16
+        )
+        k = jax.random.normal(
+            k2, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16
+        )
+        v = jax.random.normal(
+            k3, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16
+        )
+
+        with Mesh(mesh_utils.create_device_mesh(mesh), mesh_axis_names):
+            mesh = thread_resources.env.physical_mesh
+
+            def fn(q, k, v):
+                q = jax.lax.with_sharding_constraint(
+                    q, NamedSharding(mesh, PartitionSpec("data", None, "model", None))
+                )
+                k = jax.lax.with_sharding_constraint(
+                    k, NamedSharding(mesh, PartitionSpec("data", None, "model", None))
+                )
+                v = jax.lax.with_sharding_constraint(
+                    v, NamedSharding(mesh, PartitionSpec("data", None, "model", None))
+                )
+
+                softmax_scale = q.shape[-1] ** -0.5
+                mask = sliding_window_causal_mask(sliding_window_size)
+
+                attn = lambda q, k, v: tpu_attention.tpu_flash_attention(
+                    q, k, v, mask=mask, softmax_scale=softmax_scale
+                )
+
+                partitioned_mha = shard_map(
+                    attn,
+                    mesh=mesh,
+                    in_specs=(
+                        PartitionSpec("data", None, "model", None),
+                        PartitionSpec("data", None, "model", None),
+                        PartitionSpec("data", None, "model", None),
+                    ),
+                    out_specs=PartitionSpec("data", None, "model", None),
+                    check_rep=False,
+                )
+
+                return partitioned_mha(q, k, v)
+
+            fn = jax.jit(fn)
+
+        # Trigger compilation.
+        fn(q, k, v)
+        # Compare grads.
+        jax.grad(lambda q, k, v: fn(q, k, v).mean(), argnums=(0, 1, 2))(q, k, v)
 
     @parameterized.product(
         _TEST_CONFIGS,

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -166,7 +166,10 @@ class TestFlashAttention(TestCase):
         causal = mask in [causal_mask, jax_fn_mask]
 
         fallback_to_legacy = (
-            per_head_dim % 128 != 0 or (attention_bias_type is not None) or with_segment_ids
+            per_head_dim % 128 != 0
+            or (attention_bias_type is not None)
+            or with_segment_ids
+            or (query_length_multiplier != 1 and mask is not None)
         )
 
         if fallback_to_legacy and mask is jax_fn_mask:


### PR DESCRIPTION
Sliding Window Attention (SWA) using Splash Attention. Refactored the Splash Attention integration to support non-trivial mask functions other than causal mask.

Tested on v4-8 VM.

Benchmark:
```
# No SWA (Causal)

ref_fwd:0.0040s, flash_fwd:0.0026s
ref_bwd:0.0140s, flash_bwd:0.0060s

# Bias-based SWA (No sparsity optimization, current implementation)

ref_fwd:0.0038s, flash_fwd:0.0033s
ref_bwd:0.0141s, flash_bwd:0.0141s

# NumpyMask-based SWA (Splash)

ref_fwd:0.0039s, flash_fwd:0.0022s
ref_bwd:0.0138s, flash_bwd:0.0051s

# Now with the sparse kernel, SWA is indeed faster!
``` 