### PR TITLE
Add neuron attention with tests

### DIFF
--- a/axlearn/common/flash_attention/neuron_attention.py
+++ b/axlearn/common/flash_attention/neuron_attention.py
@@ -1,0 +1,104 @@
+# Copyright © 2024 Amazon Inc.
+"""Tests for Flash attention on Neuron with NKI kernels."""
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import neuronxcc.nki.language as nl
+from jax import custom_vjp
+from jax_neuronx import nki_call
+from neuronxcc.nki._private_kernels.legacy.attention import flash_attn_bwd, flash_fwd
+
+
+@partial(custom_vjp, nondiff_argnums=(3, 4))
+def flash_attention(query, key, value, causal, softmax_scale):
+    out, _ = _mha_forward(query, key, value, causal, softmax_scale)
+    return out
+
+
+def _mha_forward(query, key, value, causal, softmax_scale):
+    # Get the batch size, sequence lengths, number of heads, and hidden dimension
+    batch_size, q_seq_len, num_heads, d_model = query.shape
+
+    # Transpose the query, key, and value tensors
+    q = query.transpose(0, 2, 3, 1)  # [batch_size, num_heads, d_model, q_seq_len]
+    k = key.transpose(0, 2, 3, 1)  # [batch_size, num_heads, d_model, kv_seq_len]
+    v = value.transpose(0, 2, 1, 3)  # [batch_size, num_heads, kv_seq_len, d_model]
+
+    # Create the output buffer
+    attn_output_shape = jax.ShapeDtypeStruct(
+        (batch_size, num_heads, q_seq_len, d_model), dtype=query.dtype
+    )
+    lse_shape = jax.ShapeDtypeStruct(
+        (batch_size, num_heads, nl.tile_size.pmax, q_seq_len // nl.tile_size.pmax),
+        dtype=jnp.float32,
+    )
+    seed = jnp.array([1])
+    # Call the NKI kernel
+    attn_output, lse = nki_call(
+        partial(
+            flash_fwd,
+            use_causal_mask=causal,
+            softmax_scale=softmax_scale,
+            mixed_precision=True,
+            dropout_p=0.0,
+        ),
+        q,
+        k,
+        v,
+        seed,
+        out_shape=(attn_output_shape, lse_shape),
+        grid=(batch_size, num_heads),
+    )
+    # Transpose the output back to the original shape
+    attn_output = attn_output.transpose(0, 2, 1, 3)  # [batch_size, q_seq_len, num_heads, d_model]
+
+    return attn_output, (lse, attn_output, q, k, v)
+
+
+def _mha_backward(causal, softmax_scale, res, d_attn_output):
+    lse, o, q, k, v = res
+    batch_size, num_heads, _, _ = q.shape
+
+    # Transpose the input tensors
+    o = o.transpose(0, 2, 3, 1)
+    dy = d_attn_output.transpose(0, 2, 3, 1)
+
+    # Transpose v tensor
+    v = jnp.transpose(v, axes=(0, 1, 3, 2))
+    # Create the output buffer shapes
+    d_query_shape = jax.ShapeDtypeStruct(q.shape, q.dtype)
+    d_key_shape = jax.ShapeDtypeStruct(k.shape, k.dtype)
+    d_value_shape = jax.ShapeDtypeStruct(v.shape, v.dtype)
+    seed = jnp.array([1])
+
+    # Call the NKI kernel using nki_call
+    d_query, d_key, d_value = nki_call(
+        partial(
+            flash_attn_bwd,
+            use_causal_mask=causal,
+            mixed_precision=True,
+            dropout_p=0.0,
+            softmax_scale=softmax_scale,
+        ),
+        q,
+        k,
+        v,
+        o,
+        dy,
+        lse,
+        seed,
+        out_shape=(d_query_shape, d_key_shape, d_value_shape),
+        grid=(batch_size, num_heads),
+    )
+
+    # Batch seq_len heads, head_dim
+    # Transpose the gradients back to the original shape
+    d_query = d_query.transpose(0, 3, 1, 2)
+    d_key = d_key.transpose(0, 3, 1, 2)
+    d_value = d_value.transpose(0, 3, 1, 2)
+
+    return d_query, d_key, d_value
+
+
+flash_attention.defvjp(_mha_forward, _mha_backward)

--- a/axlearn/common/flash_attention/neuron_attention_test.py
+++ b/axlearn/common/flash_attention/neuron_attention_test.py
@@ -1,0 +1,129 @@
+# Copyright © 2024 Amazon Inc.
+"""Tests for Flash attention on Neuron. Tested on trn1."""
+import functools
+
+import chex
+import jax
+import jax.numpy as jnp
+import pytest
+
+from axlearn.common.flash_attention.neuron_attention import flash_attention
+from axlearn.common.flash_attention.utils import mha_reference
+
+
+@pytest.mark.parametrize(
+    "batch_size,seq_len,num_heads,per_head_dim",
+    [
+        (1, 2048, 1, 64),
+        (2, 2048, 2, 64),
+        (1, 2048, 1, 128),
+        (2, 2048, 2, 128),
+        (1, 2048, 8, 128),
+        (2, 2048, 8, 128),
+    ],
+)
+@pytest.mark.parametrize("use_fwd", [True, False])
+@pytest.mark.parametrize("causal", [True, False])
+@pytest.mark.parametrize("input_dtype", [jnp.float16, jnp.bfloat16, jnp.float32])
+@pytest.mark.skipif(jax.devices()[0].platform != "neuron", reason="Test only runs on Neuron.")
+def test_fwd_against_ref(
+    batch_size: int,
+    seq_len: int,
+    num_heads: int,
+    per_head_dim: int,
+    use_fwd: bool,
+    causal: bool,
+    input_dtype: jnp.dtype,
+):
+    sm_scale = 1.0 / (per_head_dim**0.5)
+    k1, k2, k3 = jax.random.split(jax.random.PRNGKey(0), 3)
+    q = jax.random.normal(k1, (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype)
+    k = jax.random.normal(k2, (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype)
+    v = jax.random.normal(k3, (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype)
+
+    bias = None
+    segment_ids = None
+
+    if use_fwd:
+
+        @jax.jit
+        def impl(q, k, v):
+            fn = functools.partial(
+                flash_attention,
+                causal=causal,
+                softmax_scale=sm_scale,
+            )
+            out, _ = jax.vjp(fn, q, k, v)
+            return out
+
+    else:
+        impl = functools.partial(
+            flash_attention,
+            causal=causal,
+            softmax_scale=sm_scale,
+        )
+
+    o = impl(q, k, v)
+    o_ref = mha_reference(q, k, v, bias, segment_ids, causal=causal, softmax_scale=sm_scale)
+    chex.assert_trees_all_close(o, o_ref, atol=0.05)
+
+
+@pytest.mark.parametrize(
+    "batch_size,num_heads,seq_len,per_head_dim",
+    [
+        (1, 1, 2048, 64),
+        (2, 2, 2048, 64),
+        (1, 1, 2048, 128),
+        (2, 2, 2048, 128),
+        (1, 8, 2048, 128),
+        (2, 8, 2048, 128),
+    ],
+)
+@pytest.mark.parametrize("causal", [True, False])
+@pytest.mark.parametrize("input_dtype", [jnp.bfloat16, jnp.float16, jnp.float32])
+@pytest.mark.skipif(jax.devices()[0].platform != "neuron", reason="Test only runs on Neuron.")
+def test_bwd_against_ref(
+    batch_size: int,
+    num_heads: int,
+    seq_len: int,
+    per_head_dim: int,
+    causal: bool,
+    input_dtype: jnp.dtype,
+):
+    sm_scale = 1.0 / (per_head_dim**0.5)
+    q = jax.random.normal(
+        jax.random.PRNGKey(0), (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype
+    )
+    k = jax.random.normal(
+        jax.random.PRNGKey(1), (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype
+    )
+    v = jax.random.normal(
+        jax.random.PRNGKey(2), (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype
+    )
+
+    bias = None
+    segment_ids = None
+
+    def fn(q, k, v):
+        return flash_attention(
+            q,
+            k,
+            v,
+            causal=causal,
+            softmax_scale=sm_scale,
+        ).sum()
+
+    def ref_fn(q, k, v, bias, segment_ids):
+        return mha_reference(
+            q,
+            k,
+            v,
+            bias,
+            segment_ids,
+            causal=causal,
+            softmax_scale=sm_scale,
+        ).sum()
+
+    jax_grads = jax.grad(fn, argnums=(0, 1, 2))(q, k, v)
+    jax_ref_grads = jax.grad(ref_fn, argnums=(0, 1, 2))(q, k, v, bias, segment_ids)
+    chex.assert_trees_all_close(jax_grads, jax_ref_grads, atol=0.07)


### PR DESCRIPTION
Adding NKI kernel along with integration with attention layer and tests.
Tests are passing on trn1:
```
$ pytest -vvv -s -rap -x neuron_attention_test.py
... (output of -vvv and -s)
================================================ short test summary info =================================================
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-True-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-True-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-True-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-True-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-True-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-True-2-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-False-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-False-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-False-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-False-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-False-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-True-False-2-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-True-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-True-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-True-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-True-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-True-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-True-2-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-False-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-False-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-False-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-False-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-False-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float16-False-False-2-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-True-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-True-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-True-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-True-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-True-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-True-2-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-False-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-False-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-False-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-False-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-False-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-True-False-2-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-True-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-True-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-True-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-True-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-True-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-True-2-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-False-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-False-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-False-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-False-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-False-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[bfloat16-False-False-2-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-True-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-True-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-True-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-True-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-True-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-True-2-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-False-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-False-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-False-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-False-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-False-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-True-False-2-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-True-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-True-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-True-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-True-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-True-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-True-2-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-False-1-2048-1-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-False-2-2048-2-64]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-False-1-2048-1-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-False-2-2048-2-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-False-1-2048-8-128]
PASSED neuron_attention_test.py::test_fwd_against_ref[float32-False-False-2-2048-8-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-True-1-1-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-True-2-2-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-True-1-1-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-True-2-2-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-True-1-8-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-True-2-8-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-False-1-1-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-False-2-2-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-False-1-1-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-False-2-2-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-False-1-8-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[bfloat16-False-2-8-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-True-1-1-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-True-2-2-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-True-1-1-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-True-2-2-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-True-1-8-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-True-2-8-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-False-1-1-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-False-2-2-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-False-1-1-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-False-2-2-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-False-1-8-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float16-False-2-8-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-True-1-1-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-True-2-2-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-True-1-1-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-True-2-2-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-True-1-8-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-True-2-8-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-False-1-1-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-False-2-2-2048-64]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-False-1-1-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-False-2-2-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-False-1-8-2048-128]
PASSED neuron_attention_test.py::test_bwd_against_ref[float32-False-2-8-2048-128]
============================================ 108 passed in 2516.32s (0:41:56) ============================================
```

Pre-commit (pylint fails but not in changed files):
```
$ pre-commit run -a
Check Yaml...............................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
black....................................................................Passed
isort....................................................................Passed
pylint...................................................................Failed

...
************* Module axlearn.common.adapter_torch
/home/ubuntu/WorkingDir/axlearn-merge/axlearn/axlearn/common/adapter_torch.py:182: [W0246(useless-parent-delegation), LayerNorm.__init__] Useless parent or super() delegation in method '__init__'
************* Module axlearn.vision.coco_utils
/home/ubuntu/WorkingDir/axlearn-merge/axlearn/axlearn/vision/coco_utils.py:68: [C0103(invalid-name), COCOWrapper.loadRes] Method name "loadRes" doesn't conform to '(?x)^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase|tearDownTestCase|setupSelf|tearDownClass|setUpClass|(test|assert)_*[A-Z0-9][a-zA-Z0-9_]*|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9_]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$' pattern
```