### PR TITLE
Support more types of groupnorm

### DIFF
--- a/axlearn/common/layers.py
+++ b/axlearn/common/layers.py
@@ -371,7 +371,7 @@ def _compute_moments_with_paddings(
     x: Tensor,
     *,
     paddings: Tensor,
-    reduction_axis: list[int],
+    reduction_axis: Sequence[int],
     keepdims: bool = False,
 ) -> tuple[Tensor, Tensor]:
     """Computes mean and variance over sequence data.
@@ -396,6 +396,7 @@ def _compute_moments_with_paddings(
     sum_x2 = jnp.sum((x - mean) ** 2 * mask, axis=reduction_axis, keepdims=keepdims)
     variance = sum_x2 / denom_x
     return mean, variance
+
 
 def _compute_mean_square_with_paddings(
     x: Tensor,
@@ -566,7 +567,6 @@ class GroupNorm(BaseNormalizationLayer):
             x = x.astype(x_dtype)
             x = x * self.parameters["scale"]
         return x
-
 
 
 class BatchNorm(BaseNormalizationLayer):

--- a/axlearn/common/layers.py
+++ b/axlearn/common/layers.py
@@ -17,6 +17,7 @@
 # pylint: disable=too-many-lines
 """Basic layers."""
 
+import enum
 from collections.abc import Sequence
 from typing import Any, Callable, Optional, Union
 
@@ -396,9 +397,57 @@ def _compute_moments_with_paddings(
     variance = sum_x2 / denom_x
     return mean, variance
 
+def _compute_mean_square_with_paddings(
+    x: Tensor,
+    *,
+    paddings: Tensor,
+    reduction_axis: Sequence[int],
+) -> Tensor:
+    """Computes root mean square moments over sequence data.
+
+    Args:
+        x: inputs tensor of shape [batch_size, seq_len, ...].
+        paddings: 0/1 tensor of shape [batch_size, seq_len].
+        reduction_axis: a list of axes to compute moments over.
+
+    Returns:
+        mean_square: with the same shape as `x` except for axes specified in `reduction_axis`,
+            which will have dim of 1.
+    """
+    expanded_paddings = jnp.expand_dims(paddings, axis=tuple(range(2, x.ndim)))
+    mask = 1 - expanded_paddings
+    sum_x2 = jnp.sum((x * x) * mask, axis=reduction_axis, keepdims=True)
+    count_x2 = jnp.sum(jnp.ones_like(x) * mask, axis=reduction_axis, keepdims=True)
+    # If all elements of `padding` are 1 (i.e., jnp.all(padding == 1)), mean_square will be 0.
+    # However, the computation remains stable due to max(1, count).
+    mean_square = sum_x2 / jnp.maximum(count_x2, 1.0)
+    return mean_square
+
+
+class NormType(enum.Enum):
+    """NormType defines the normalization methods for the GroupNorm class.
+
+    Available normalization types:
+    - **LAYERNORM**: Applies layernorm across all axes except for the group and batch axes.
+    - **RMSNORM**: Applies rmsnorm across all axes except for the group and batch axes.
+    """
+
+    LAYERNORM = "layernorm"
+    RMSNORM = "rmsnorm"
+
 
 class GroupNorm(BaseNormalizationLayer):
-    """https://arxiv.org/abs/1803.08494."""
+    """GroupNorm provides group-wise normalization for inputs.
+
+    The choice of `norm_type` and `norm_axes` should be guided by the specific domain. In the vision
+    domain LayerNorm is typically applied across all axes except the group and batch dimensions,
+    e.g., normalization across spatial dims and feature channels (https://arxiv.org/abs/1803.08494).
+    In the text domain, normalization may be performed along the feature axis alone, e.g., RMSNorm
+    is applied along the last feature axis in [Mamba2](https://arxiv.org/abs/2405.21060).
+
+    In the future, we may consider supporting sliding window or causal group norm, e.g.,
+    https://github.com/tensorflow/lingvo/blob/b26149e423cd51498bd884ffd37a6b5ceb244d68/lingvo/core/bn_layers.py#L756-L764
+    """
 
     @config_class
     class Config(BaseNormalizationLayer.Config):
@@ -410,13 +459,35 @@ class GroupNorm(BaseNormalizationLayer):
         eps: float = 1e-8
         # Cast input to this dtype for the 'forward' call. If None, do not cast.
         forward_dtype: Optional[jnp.dtype] = jnp.float32
+        # LAYERNORM` or `RMSNORM`.
+        # If None, assumes `LAYERNORM` (for backwards compatibility).
+        norm_type: Optional[NormType] = None
+        # Axes to apply the normalization in addition to the group size axis.
+        # E.g., (1,) means normalizing normalizing along the time axis (as well as the group size
+        # axis) if the input tensor has shape (batch, time, dim); (1, -1) has the same effect as
+        # (1,) as the last dim (i.e., the group size axis) is automatically added.
+        # If None, reduces along all dims except for the num of group and batch axes (for
+        # backwards compatibility).
+        norm_axes: Optional[Union[tuple[int, ...], int]] = None
+
+    @classmethod
+    def default_config(cls):
+        cfg = super().default_config()
+        if cfg.norm_type is None:
+            cfg.norm_type = NormType.LAYERNORM
+        return cfg
 
     def _create_layer_parameter_specs(self) -> dict[str, ParameterSpec]:
         cfg = self.config
-        return {
-            "scale": ParameterSpec(shape=[cfg.input_dim], mesh_axes=(None,)),
-            "bias": ParameterSpec(shape=[cfg.input_dim], mesh_axes=(None,)),
-        }
+        if cfg.norm_type == NormType.LAYERNORM:
+            return {
+                "scale": ParameterSpec(shape=[cfg.input_dim], mesh_axes=(None,)),
+                "bias": ParameterSpec(shape=[cfg.input_dim], mesh_axes=(None,)),
+            }
+        else:
+            return {
+                "scale": ParameterSpec(shape=[cfg.input_dim], mesh_axes=(None,)),
+            }
 
     def forward(self, x: Tensor, *, paddings: Optional[Tensor] = None) -> Tensor:
         """Applies group normalization.
@@ -432,6 +503,7 @@ class GroupNorm(BaseNormalizationLayer):
 
         Raises:
             ValueError: if num_groups does not divide input_dim.
+            ValueError: if num_groups axis is included in norm_axes.
         """
         cfg = self.config
         if cfg.num_groups <= 0 or cfg.input_dim % cfg.num_groups != 0:
@@ -442,23 +514,59 @@ class GroupNorm(BaseNormalizationLayer):
             x = x.astype(cfg.forward_dtype)
         # Reshape to [..., num_groups, group_size].
         y = jnp.reshape(x, list(x.shape[:-1]) + [cfg.num_groups, group_size])
-        # Reduce along spatial dims and group_size, but not along batch or num_groups.
-        reduction_axis = list(range(1, y.ndim - 2)) + [-1]
-        if paddings is None:
-            mean = jnp.mean(y, axis=reduction_axis, keepdims=True)
-            variance = jnp.mean((y - mean) ** 2, axis=reduction_axis, keepdims=True)
+
+        # Default norm axes: all axes except for the group and batch axes.
+        if cfg.norm_axes is None:
+            reduction_axis = list(range(1, y.ndim - 2)) + [y.ndim - 1]
         else:
-            mean, variance = _compute_moments_with_paddings(
-                x=y,
-                paddings=paddings,
-                reduction_axis=reduction_axis,
-                keepdims=True,
-            )
-        y = (y - mean) * jax.lax.rsqrt(variance + cfg.eps)
-        x = jnp.reshape(y, x.shape)
-        x = x.astype(x_dtype)
-        x = x * self.parameters["scale"] + self.parameters["bias"]
+            reduction_axis = cfg.norm_axes
+
+        # Normalize to a list of non-negative axes.
+        if isinstance(reduction_axis, int):
+            reduction_axis = [reduction_axis]
+        reduction_axis = [axis if axis >= 0 else y.ndim + axis for axis in reduction_axis]
+
+        if y.ndim - 2 in reduction_axis:
+            raise ValueError("GroupNorm should not normalize along the num_groups axis.")
+
+        if 0 in reduction_axis:
+            raise ValueError("GroupNorm should not normalize along the batch axis.")
+
+        # Add the group size axis to the reduction axis.
+        if y.ndim - 1 not in reduction_axis:
+            reduction_axis.append(y.ndim - 1)
+
+        if cfg.norm_type == NormType.LAYERNORM:
+            if paddings is None:
+                mean = jnp.mean(y, axis=reduction_axis, keepdims=True)
+                variance = jnp.mean((y - mean) ** 2, axis=reduction_axis, keepdims=True)
+            else:
+                mean, variance = _compute_moments_with_paddings(
+                    x=y,
+                    paddings=paddings,
+                    reduction_axis=reduction_axis,
+                    keepdims=True,
+                )
+
+            y = (y - mean) * jax.lax.rsqrt(variance + cfg.eps)
+            x = jnp.reshape(y, x.shape)
+            x = x.astype(x_dtype)
+            x = x * self.parameters["scale"] + self.parameters["bias"]
+        else:
+            if paddings is None:
+                msquare = (y * y).mean(axis=reduction_axis, keepdims=True)
+            else:
+                msquare = _compute_mean_square_with_paddings(
+                    x=y,
+                    paddings=paddings,
+                    reduction_axis=reduction_axis,
+                )
+            y = y * jax.lax.rsqrt(msquare + cfg.eps)
+            x = jnp.reshape(y, x.shape)
+            x = x.astype(x_dtype)
+            x = x * self.parameters["scale"]
         return x
+
 
 
 class BatchNorm(BaseNormalizationLayer):

--- a/axlearn/common/layers_test.py
+++ b/axlearn/common/layers_test.py
@@ -45,7 +45,6 @@ from axlearn.common.layers import (
     DepthwiseConv1D,
     DropToken,
     Embedding,
-    NormType,
     GroupNorm,
     L2Norm,
     LayerNorm,
@@ -54,6 +53,7 @@ from axlearn.common.layers import (
     MaxPool2D,
     MovingAverage,
     MultiLinear,
+    NormType,
     RedirectToSharedModule,
     RMSNorm,
     SeparableSpaceTimePositionalEmbedding,
@@ -183,7 +183,6 @@ class LayerTest(TestCase, tf.test.TestCase):
         # forward() should not mutate 'inputs' in-place.
         assert_allclose(inputs, orig_inputs)
         assert_allclose(outputs, as_tensor(ref_ln(as_torch_tensor(orig_inputs))))
-
 
     @parameterized.parameters(
         [


### PR DESCRIPTION
Previously, `groupnorm` assumes that layernorm is applied on all the input axes apart from batch and group axes. With this PR, we can choose to apply either RMSNorm or LayerNorm along configurable axes of input tensors. 