### PR TITLE
Reshard the train state after restoring from builder

### DIFF
--- a/axlearn/common/eval_classification_test.py
+++ b/axlearn/common/eval_classification_test.py
@@ -87,6 +87,15 @@ def _compute_metrics(
 
 
 class ClassificationMetricCalculatorTest(parameterized.TestCase):
+    def setUp(self):
+        """
+        Explicitly set `jax_enable_memories` to avoid the following JAX error:
+        ```Memory kinds passed to jax.jit does not match memory kind on the respective arg.
+        Got pjit memory kind: None, arg memory kind: unpinned_host for arg shape: ...```
+        """
+
+        jax.config.update("jax_enable_memories", True)
+
     @parameterized.parameters(
         # Test case for multiple precision, recall level
         {

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -556,7 +556,11 @@ class SpmdTrainer(Module):
             self._init_with_prebuilt_state(prng_key, prebuilt_state=None)
             built_state = self._restore_from_builder()
             self._step = built_state.step
-            self._trainer_state = built_state.trainer_state
+            self._trainer_state = jax.tree.map(
+                lambda state, spec: jax.device_put(state, spec.sharding),
+                built_state.trainer_state,
+                self._trainer_state_specs,
+            )
 
     def _init_with_prebuilt_state(
         self,


### PR DESCRIPTION
The trainer can load checkpoint from two sources:

1. `self.restore_checkpoint`: Train state loaded from here will be sharded in accordance with the trainer config (`self._trainer_state_specs`).
2. `self.init_state_builder`: When it builds StateType.TENSORS state, the train state does not necessarily conform to the trainer's sharding. To fix this issue, we need to reshard the train state after building it.

This enables us to change/optimize default shardings without breaking the pretrained checkpoint loading.