### PR TITLE
Simplifies host_to_global_device_array.

### DIFF
--- a/axlearn/common/evaler.py
+++ b/axlearn/common/evaler.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 """Evaler and base metric calculators."""
+
 import functools
 import graphlib
 import os.path
@@ -657,7 +658,8 @@ class SpmdEvaler(Module):
 
         forward_outputs = None
         stop_trace_iter = None
-        for batch_ix, input_batch in enumerate(self.input):
+        eval_input_iter = iter(self.input.dataset())
+        for batch_ix, input_batch in enumerate(self.input.batches(eval_input_iter)):
             logging.log_first_n(logging.INFO, "Evaler input_batch=%s", 3, utils.shapes(input_batch))
 
             if batch_ix == stop_trace_iter:

--- a/axlearn/common/evaler_test.py
+++ b/axlearn/common/evaler_test.py
@@ -81,7 +81,10 @@ class DummyInput(Module):
         cfg.shape = _EXAMPLE_SHAPE
         return cfg
 
-    def __iter__(self):
+    def batches(self, it: tf.data.Iterator):
+        yield from it
+
+    def dataset(self):
         cfg: DummyInput.Config = self.config
         num_batches = 0
         shape = [cfg.batch_size, *cfg.shape]
@@ -89,6 +92,9 @@ class DummyInput(Module):
             num_batches += 1
             inputs = jnp.ones(shape=shape, dtype=jnp.float32)
             yield dict(inputs=inputs)
+
+    def __iter__(self):
+        return self.dataset()
 
 
 class DummyModel(BaseModel):

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -58,6 +58,7 @@ from axlearn.common.utils import (
     Nested,
     NestedTensor,
     Tensor,
+    as_numpy_array,
     as_tensor,
     dispatch_input_batch,
     flatten_items,
@@ -153,7 +154,8 @@ class DummyInput(Module):
         return ds
 
     def batches(self, it: tf.data.Iterator) -> Iterable[NestedTensor]:
-        yield from it
+        for input_batch in it:
+            yield as_numpy_array(input_batch)
 
     def dispatch_global_batch(
         self,

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -63,11 +63,13 @@ from axlearn.common.utils import (
     flatten_items,
     get_data_dir,
     get_recursively,
+    host_to_global_device_array,
     infer_mesh_shape,
     input_partition_spec,
     match_regex_rules,
     prune_tree,
     pytree_children,
+    replicate_to_local_data,
     runtime_checks,
     set_data_dir,
     set_recursively,
@@ -75,6 +77,7 @@ from axlearn.common.utils import (
     tree_paths,
     validate_float_dtype,
     vectorized_tree_map,
+    with_sharding_constraint,
 )
 
 
@@ -1678,6 +1681,87 @@ class HybridMeshShapeTest(TestCase):
             )
 
         self.assertEqual(2, len(HybridMeshShape(ici_mesh_shape=(1, 2), dcn_mesh_shape=(3, 4))))
+
+
+class HostToGlobalArrayTest(TestCase):
+    """Tests host_to_global_device_array."""
+
+    @pytest.mark.tpu
+    def test_partition_full(self):
+        """Test a case where each process produces a slice."""
+        device_count = jax.device_count()
+        process_count = jax.process_count()
+        print(f"{device_count=}, {process_count=}")
+        assert device_count > 1
+
+        global_shape = (device_count, 1)
+        assert global_shape[0] % process_count == 0
+        per_feed_size = global_shape[0] // process_count
+        feed_index = jax.process_index()
+
+        with jax.sharding.Mesh(np.array(jax.devices()).reshape(device_count // 2, 2), ("x", "y")):
+            start = feed_index * per_feed_size
+            local_x = jnp.arange(start, start + per_feed_size)[:, None]
+
+            # Construct global array.
+            global_x = host_to_global_device_array(local_x)
+
+            # Compare against expected.
+            expected = jnp.arange(global_shape[0])[:, None]
+            self.assertEqual(jnp.mean(expected), jnp.mean(global_x))
+            self.assertNestedEqual(expected, replicate_to_local_data(global_x))
+
+    @pytest.mark.tpu
+    def test_every_other_process(self):
+        """Test a case where every other process produces a slice."""
+
+        device_count = jax.device_count()
+        process_count = jax.process_count()
+        print(f"{device_count=}, {process_count=}")
+        assert process_count > 2  # E.g., run on v5e-16.
+
+        # Use a logical shape that has dim=0 smaller than number of hosts.
+        # This requires us to produce padding batches on some hosts.
+        global_logical_shape = (process_count // 2, 1)
+        global_physical_shape = (device_count, 1)
+        feed_index = jax.process_index()
+
+        with jax.sharding.Mesh(
+            np.array(jax.devices()).reshape(global_logical_shape[0], -1), ("x", "y")
+        ):
+            logical_sharding = PartitionSpec(("x",))
+
+            # Every other feed is padding.
+            if feed_index % 2 == 1:
+                local_x = np.zeros([1, 1])
+            else:
+                local_x = np.arange(feed_index, feed_index + 1)[:, None]
+
+            # Pad to at least number of local devices.
+            feed_physical_size = global_physical_shape[0] // process_count
+            pad_size = feed_physical_size - local_x.shape[0]
+            local_x = jnp.pad(local_x, ((0, pad_size), (0, 0)))
+
+            # Dispatch to remove padding examples.
+            dispatch = np.eye(global_physical_shape[0])[
+                np.arange(global_logical_shape[0]) * feed_physical_size * 2,
+            ]
+
+            # Convert to GDA.
+            global_x = host_to_global_device_array(local_x)
+            assert global_x.shape == global_physical_shape
+
+            batch = with_sharding_constraint(
+                jnp.einsum("p...,lp->l...", global_x, dispatch), logical_sharding
+            )
+            jax.debug.visualize_array_sharding(batch)
+
+        # Check that sharding is as expected.
+        self.assertEqual(logical_sharding, batch.sharding.spec)
+
+        # Check that contents are as expected.
+        expected = jnp.arange(0, process_count, 2, dtype=batch.dtype)[:, None]
+        self.assertNestedEqual(expected, replicate_to_local_data(batch))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Note: while previously `host_to_global_device_array` performed an implicit conversion to jnp arrays, the new jax API does not; we now explicitly iterate over `batches(...)` in evaler (which should be the same behavior as before, but fixes tests that did not do this conversion explicitly).