### PR TITLE
Revert "Speed up Axlearn CI"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   pre-commit:
     docker:
       - image: cimg/python:3.10
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   pre-commit:
     docker:
       - image: cimg/python:3.10
-    resource_class: xlarge
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker:
@@ -77,3 +77,4 @@ workflows:
       - build-and-test-job:
           requires:
             - hold
+            - pre-commit

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e -x
+set -e
 
 # Install the package (necessary for CLI tests).
 # Requirements should already be cached in the docker image.
@@ -18,7 +18,6 @@ exit_if_error() {
 }
 
 download_assets() {
-  set -e -x
   mkdir -p axlearn/data/tokenizers/sentencepiece
   mkdir -p axlearn/data/tokenizers/bpe
   curl https://huggingface.co/t5-base/resolve/main/spiece.model -o axlearn/data/tokenizers/sentencepiece/t5-base
@@ -26,42 +25,20 @@ download_assets() {
   curl https://huggingface.co/FacebookAI/roberta-base/raw/main/vocab.json -o axlearn/data/tokenizers/bpe/roberta-base-vocab.json
 }
 
-precommit_checks() {
-  set -e -x
-  pre-commit install
-  pre-commit run --all-files || exit_if_error $? "pre-commit failed."
-  # Run pytype separately to utilize all cpus and for better output.
-  pytype -j auto . || exit_if_error $? "pytype failed."
-}
-
-# Collect all background PIDs explicitly.
-TEST_PIDS=()
-
-download_assets
-
+set -o xtrace
 if [[ "${1:-x}" = "--skip-pre-commit" ]] ; then
   SKIP_PRECOMMIT=true
   shift
 fi
+UNQUOTED_PYTEST_FILES=$(echo $1 |  tr -d "'")
 
 # Skip pre-commit on parallel CI because it is run as a separate job.
 if [[ "${SKIP_PRECOMMIT:-false}" = "false" ]] ; then
-  precommit_checks &
-  TEST_PIDS[$!]=1
+  pre-commit install
+  pre-commit run --all-files || exit_if_error $? "pre-commit failed."
+  # Run pytype separately to utilize all cpus and for better output.
+  pytype -j auto . || exit_if_error $? "pytype failed."
 fi
-
-UNQUOTED_PYTEST_FILES=$(echo $1 |  tr -d "'")
-pytest --durations=100 -v -n auto \
-  -m "not (gs_login or tpu or high_cpu or fp64)" ${UNQUOTED_PYTEST_FILES} \
-  --dist worksteal &
-TEST_PIDS[$!]=1
-
-JAX_ENABLE_X64=1 pytest --durations=100 -v -n auto -v -m "fp64" --dist worksteal &
-TEST_PIDS[$!]=1
-
-# Use Bash 5.1's new wait -p feature to quit immediately if any subprocess fails to make error
-# finding a bit easier.
-while [ ${#TEST_PIDS[@]} -ne 0 ]; do
-  wait -n -p PID ${!TEST_PIDS[@]} || exit_if_error $? "Test failed."
-  unset TEST_PIDS[$PID]
-done
+download_assets
+pytest --durations=10 -n auto -v -m "not (gs_login or tpu or high_cpu or fp64)" ${UNQUOTED_PYTEST_FILES} || exit_if_error $? "pytest failed."
+JAX_ENABLE_X64=1 pytest -n auto -v -m "fp64" || exit_if_error $? "pytest failed."


### PR DESCRIPTION
It causes some flakiness in public CI, revert it first before fixing the flakiness. The flakiness is caused by concurrent runs, which caused OOM: 
https://app.circleci.com/pipelines/github/apple/axlearn/2936/workflows/716c95fc-e433-42f6-b28b-1fc16fcbfed6/jobs/6450

Sample error is like: 
#10 764.2 axlearn/common/decoder_test.py::TestDecoder::test_extend_step6 JIT session error: Cannot allocate memory
#10 768.5 Fatal Python error: Segmentation fault