### PR TITLE
Introduce @nowrap annotaion.

### DIFF
--- a/axlearn/common/layers.py
+++ b/axlearn/common/layers.py
@@ -40,7 +40,7 @@ from axlearn.common.config import (
 from axlearn.common.loss import binary_cross_entropy, categorical_hinge_loss, cross_entropy
 from axlearn.common.metrics import WeightedScalar
 from axlearn.common.metrics_classification import precision_recall_f_score
-from axlearn.common.module import Module, child_context
+from axlearn.common.module import Module, child_context, nowrap
 from axlearn.common.normalize import l2_normalize
 from axlearn.common.param_init import (
     PARAM_REGEXP_WEIGHT,
@@ -760,6 +760,7 @@ class MaxPool2D(BaseLayer):
         )
         return output
 
+    @nowrap
     def output_shape(self, *, input_shape: Sequence[Optional[int]]) -> Sequence[Optional[int]]:
         cfg = self.config
         if len(input_shape) != 4:
@@ -995,6 +996,7 @@ class Conv2D(BaseConv):
             output += self.parameters["bias"]
         return output
 
+    @nowrap
     def output_shape(self, *, input_shape: Sequence[Optional[int]]) -> Sequence[Optional[int]]:
         cfg = self.config
         if len(input_shape) != 4:
@@ -1130,6 +1132,7 @@ class Conv2DTranspose(BaseConv):
             output += self.parameters["bias"]
         return output
 
+    @nowrap
     def output_shape(self, *, input_shape: Sequence[Optional[int]]) -> Sequence[Optional[int]]:
         cfg = self.config
         if len(input_shape) != 4:
@@ -1358,6 +1361,7 @@ class Conv3D(BaseConv):
             output += self.parameters["bias"]
         return output
 
+    @nowrap
     def output_shape(self, *, input_shape: Sequence[Optional[int]]) -> Sequence[Optional[int]]:
         cfg = self.config
         if len(input_shape) != 5:
@@ -2051,6 +2055,7 @@ class StackOverTime(BaseLayer):
         stacked_inputs = stacked_inputs * (1 - stacked_paddings)[:, :, None]
         return stacked_inputs, stacked_paddings
 
+    @nowrap
     def output_shape(self, *, input_shape: Sequence[Optional[int]]) -> Sequence[Optional[int]]:
         """Computes stacked output shape.
 

--- a/axlearn/common/module_test.py
+++ b/axlearn/common/module_test.py
@@ -32,6 +32,7 @@ from axlearn.common.module import functional as F
 from axlearn.common.module import (
     install_context_stack,
     new_output_collection,
+    nowrap,
     scan_in_context,
     set_current_context,
 )
@@ -793,6 +794,21 @@ class ModuleTest(TestWithTemporaryCWD):
         # Outer should also wrap the inner methods. We also ensure that `self.config` points to
         # `InnerModule.Config` rather than `OuterModule.Config`.
         self.assertEqual(inner_cfg.inner_a, outer.inner_method())
+
+    def test_nowrap(self):
+        class MyModule(Module):
+            def my_method1(self):
+                return 1
+
+            @nowrap
+            def my_method2(self):
+                return 2
+
+        cfg = MyModule.default_config()
+        layer = cfg.set(name="test").instantiate(parent=None)
+        wrapped_methods = layer._methods_to_wrap_for_auto_child_context()
+        self.assertIn("my_method1", wrapped_methods)
+        self.assertNotIn("my_method2", wrapped_methods)
 
 
 class ScanInContextTest(TestWithTemporaryCWD):


### PR DESCRIPTION
It's similar to Flax `@nowarp` annotaion.
https://flax-linen.readthedocs.io/en/latest/api_reference/flax.linen/decorators.html#flax.linen.nowrap

Marks the specified module method as one that doesn't need to be wrapped.

Methods decorated with `@nowrap` are helper methods that don't require wrapping, and
`_methods_to_wrap_for_auto_child_context()` will not return them.

This is especially useful in cases where a public method (i.e., one that is not explicitly
prefixed with `_`) does not need an invocation context, such as methods that do not attempt
to access state or PRNG keys.

For instance::
```
        >>> from axlearn.common import module
        >>> class Foo(module.Module):
        ...   @module.nowrap
        ...   def init_states(self, batch_size: int):
        ...     return dict(time_step=jnp.zeros(batch_size, dtype=jnp.int32))
```