### PR TITLE
Remove `jax_enable_memories` config 

### DIFF
--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -412,11 +412,6 @@ class BoundedDataShardedAsyncCheckpointManager(serialization.GlobalAsyncCheckpoi
                 "max_data_shard_degree is not implemented for values other than 1 and -1"
             )
 
-        # Required for pinned host memory to work correctly.
-        # TODO(hanzhi-zhou): Pinned host memory for GPU doesn't work until jax 0.4.32.
-        # Fix this after jax upgrade.
-        jax.config.update("jax_enable_memories", jax.default_backend() == "tpu")
-
     def serialize(
         self,
         arrays: list[Tensor],


### PR DESCRIPTION
As documented in the comments, GPU pinned memory works correctly after jax 0.4.32, so we can move the conditional enablement.

Verified with a GPU job: no staging of unpinned memory transfer is observed in MemcpyD2H, so it worked correctly.
![image](https://github.com/user-attachments/assets/5eaf25b6-42b9-48f5-8fa5-fb5654d6302b)
