### PR TITLE
Optimizing the sliding window in the frontend.

### DIFF
--- a/axlearn/audio/encoder_asr_test.py
+++ b/axlearn/audio/encoder_asr_test.py
@@ -7,6 +7,7 @@ import pytest
 from absl.testing import parameterized
 from jax import numpy as jnp
 
+from axlearn.audio import frontend_utils
 from axlearn.audio.encoder_asr import ASREncoder, SpeechContextNetwork, SpeechFeatureLayer
 from axlearn.audio.test_utils import fake_audio
 from axlearn.common.module import functional as F
@@ -248,9 +249,11 @@ class ASREncoderTest(TestCase):
 
         spectrogram = output_collections.module_outputs["feature"]["spectrogram"]
         spec, spec_paddings = spectrogram["outputs"], spectrogram["paddings"]
-        expected_spec_len = (seq_len - frame_size_ms * sample_rate // 1000) // (
-            hop_size_ms * sample_rate // 1000
-        ) + 1
+        expected_spec_len = frontend_utils.num_frames(
+            seq_len,
+            frame_size=frontend_utils.ms_to_samples(frame_size_ms, sample_rate=sample_rate),
+            hop_size=frontend_utils.ms_to_samples(hop_size_ms, sample_rate=sample_rate),
+        )
         self.assertEqual(spec.shape, (batch_size, expected_spec_len, num_filters, 1))
         self.assertEqual(spec_paddings.shape, (batch_size, expected_spec_len))
 

--- a/axlearn/audio/frontend.py
+++ b/axlearn/audio/frontend.py
@@ -9,18 +9,22 @@
 import functools
 from collections.abc import Sequence
 from functools import partial
-from typing import Callable, Optional, Protocol, Union
+from typing import Callable, Optional, Protocol
 
+import einops
 import jax.numpy as jnp
 
 from axlearn.audio.frontend_utils import (
     WindowType,
+    frame,
+    frame_paddings,
     linear_to_log_mel_spectrogram,
     linear_to_mel_weight_matrix,
     magnitude_spectrogram,
+    ms_to_samples,
     next_power_of_2,
+    num_frames,
     pre_emphasis,
-    sliding_window,
     windowing,
 )
 from axlearn.common.base_layer import BaseLayer
@@ -33,7 +37,7 @@ from axlearn.common.config import (
     maybe_instantiate,
     maybe_set_config,
 )
-from axlearn.common.module import Module
+from axlearn.common.module import Module, nowrap
 from axlearn.common.utils import Tensor
 
 
@@ -53,11 +57,6 @@ def normalize_by_mean_std(
     if std is not None:
         x = x / jnp.maximum(jnp.array(std, dtype=x.dtype), jnp.finfo(x.dtype).eps)
     return x
-
-
-def _ms_to_samples(ms: Union[int, float], *, sample_rate: int) -> float:
-    """Converts time in milliseconds to number of samples under the given sample rate."""
-    return sample_rate / 1000 * ms
 
 
 class BaseFrontend(BaseLayer):
@@ -82,15 +81,10 @@ class BaseFrontend(BaseLayer):
         super().__init__(cfg, parent=parent)
         cfg = self.config
 
-        frame_size = _ms_to_samples(cfg.frame_size_ms, sample_rate=cfg.sample_rate)
-        hop_size = _ms_to_samples(cfg.hop_size_ms, sample_rate=cfg.sample_rate)
-        if not frame_size.is_integer():
-            raise ValueError(f"frame_size must be an integer, got {frame_size}.")
-        if not hop_size.is_integer():
-            raise ValueError(f"hop_size must be an integer, got {hop_size}.")
-
-        self._frame_size = int(frame_size)
-        self._hop_size = int(hop_size)
+        frame_size = ms_to_samples(cfg.frame_size_ms, sample_rate=cfg.sample_rate)
+        hop_size = ms_to_samples(cfg.hop_size_ms, sample_rate=cfg.sample_rate)
+        self._frame_size = frame_size
+        self._hop_size = hop_size
 
 
 def _log_mel_spectrogram(
@@ -204,8 +198,27 @@ class LogMelFrontend(BaseFrontend):
             - paddings: A 0/1 Tensor of shape [batch, num_frames].
         """
         # TODO(markblee): Make these configurable as needed.
-        # Framer.
-        frames = sliding_window(inputs, window_size=self._frame_size, stride=self._hop_size)
+        frames = frame(inputs, frame_size=self._frame_size, hop_size=self._hop_size)
+        # TODO(dhwang2): Currently, a partial frame is padded. Explore it later.
+        out_paddings = frame_paddings(
+            paddings,
+            frame_size=self._frame_size,
+            hop_size=self._hop_size,
+        )
+        return self._to_logmel(frames, frames_paddings=out_paddings)
+
+    def _to_logmel(self, frames: Tensor, *, frames_paddings: Tensor) -> dict[str, Tensor]:
+        """Computes log-mel spectrogram features.
+
+        Args:
+            frames: Tensor of dtype float32 and shape [batch, num_frames, frame_size].
+            frames_paddings: A 0/1 Tensor of shape [batch, num_frames].
+
+        Returns:
+            A dict containing:
+            - outputs: A Tensor of shape [batch, num_frames, num_filters, 1].
+            - paddings: A 0/1 Tensor of shape [batch, num_frames].
+        """
         if self._pre_emphasis is not None:
             frames = self._pre_emphasis(frames)
         # Windowing. Defaults to a Hann window.
@@ -216,14 +229,10 @@ class LogMelFrontend(BaseFrontend):
         outputs = self._spectrogram(self._fft(frames), dtype=frames.dtype)
         if self._output_transformation is not None:
             outputs = self._output_transformation(outputs)
-        # To identify padding frames, apply the framer to the input padding.
-        # Consider a frame padded if it contains at least one padding sample.
-        paddings = sliding_window(paddings, window_size=self._frame_size, stride=self._hop_size)
-        # TODO(dhwang2): Logically, a partial frame is a valid frame. Explore it later.
-        paddings = jnp.max(paddings, axis=-1, keepdims=True)
-        outputs = outputs * (1 - paddings)
-        return dict(outputs=outputs[..., None], paddings=jnp.squeeze(paddings, axis=-1))
+        outputs = outputs * (1 - einops.rearrange(frames_paddings, "b t -> b t 1"))
+        return dict(outputs=einops.rearrange(outputs, "b t f -> b t f 1"), paddings=frames_paddings)
 
+    @nowrap
     def output_shape(self, *, input_shape: Sequence[Optional[int]]):
         """Computes the output shape given input shape.
 
@@ -242,7 +251,7 @@ class LogMelFrontend(BaseFrontend):
             raise ValueError(f"We expect len(input_shape) = 2, but got {len(input_shape)}.")
         batch_size, seq_len = input_shape
         if seq_len is not None:
-            num_frames = max(seq_len - self._frame_size, 0) // self._hop_size + 1
+            frame_len = num_frames(seq_len, frame_size=self._frame_size, hop_size=self._hop_size)
         else:
-            num_frames = None
-        return [batch_size, num_frames, cfg.num_filters, cfg.output_dim]
+            frame_len = None
+        return [batch_size, frame_len, cfg.num_filters, cfg.output_dim]

--- a/axlearn/audio/frontend_benchmark.py
+++ b/axlearn/audio/frontend_benchmark.py
@@ -1,0 +1,68 @@
+"""Benchmark Frontend.
+
+1) frontend_utils.frame benchmark
+* TPU v4
+  * frame_time: 0.0686s.
+  * Note: before pull/836, frame_time: 1.7839s
+* CPU
+  * frame_time:0.2298s
+  * Note: before pull/836, frame_time: 0.1403s
+"""
+
+import functools
+import time
+from typing import Callable
+
+import jax
+
+from axlearn.audio import frontend_utils, test_utils
+
+_BENCHMARK_CONFIGS = {
+    "b32s600": dict(
+        batch_size=32,
+        seq_secs=600,
+    ),
+}
+
+
+def _time_call(fn: Callable, *, num_iters: int = 5) -> float:
+    """Times average execution time for fn call over num_iters after warmup."""
+    fn().block_until_ready()
+    tic = time.perf_counter()
+    for _ in range(num_iters):
+        fn().block_until_ready()
+    toc = time.perf_counter()
+    return (toc - tic) / num_iters
+
+
+def _benchmark(
+    *,
+    batch_size: int,
+    seq_secs: int,
+):
+    """Benchmarks TPU FlashAttention vs reference impl."""
+    sample_rate = 16_000
+    frame_size_ms = 25
+    frame_step_ms = 10
+    frame_size = frontend_utils.ms_to_samples(frame_size_ms, sample_rate=sample_rate)
+    frame_step = frontend_utils.ms_to_samples(frame_step_ms, sample_rate=sample_rate)
+    seq_len = seq_secs * sample_rate
+    inputs, _ = test_utils.fake_audio(
+        prng_key=jax.random.PRNGKey(123), batch_size=batch_size, seq_len=seq_len
+    )
+
+    fn = functools.partial(
+        frontend_utils.frame, x=inputs, frame_size=frame_size, hop_size=frame_step
+    )
+    fn = jax.jit(fn)
+    frame_time = _time_call(fn)
+
+    print(f"frame_time: {frame_time:.4f}s.")
+
+
+if __name__ == "__main__":
+    print(f"Benchmarking on {jax.default_backend()} backend.")
+    device_kind = jax.devices()[0].device_kind
+    for name, cfg in _BENCHMARK_CONFIGS.items():
+        print(f"Benchmarking frame() representative of {name} config on {device_kind}.")
+        _benchmark(**cfg)

--- a/axlearn/audio/model_asr_test.py
+++ b/axlearn/audio/model_asr_test.py
@@ -130,14 +130,14 @@ class ASRModelTest(TestCase):
     """Tests ASRModel."""
 
     @parameterized.parameters(
-        (True, "forward", "ctc", 15.256454),
+        (True, "forward", "ctc", 13.895943),
         (False, "forward", "ctc", 15.304867),
         (False, "beam_search_decode", "ctc", None),
         (False, "predict", "ctc", None),
-        (True, "forward", "rnnt", 26.235899),
+        (True, "forward", "rnnt", 25.613092),
         (False, "forward", "rnnt", 26.705172),
         (False, "beam_search_decode", "rnnt", None),
-        (True, "forward", "las", 2.4774954),
+        (True, "forward", "las", 2.6430604),
         (False, "forward", "las", 2.5735652),
         (False, "beam_search_decode", "las", None),
     )


### PR DESCRIPTION
Creating an index at the sample level and using advanced indexing is quite costly—processing 100 seconds of audio at 24kHz results in 2.4 million samples.

To optimize this, we can index chunk-wise instead. For 100 seconds of audio at 24kHz, with a 10ms hop and a 25ms window, each chunk is 5ms, or 1200 samples. This approach reduces the indexing computation by a factor of 1200.

The newly added `frontend_benchmark.py` shows that a batch of 32 with 10-minute audio has improved from 1.8 seconds to 0.07 seconds on TPUv4.

**In addition**, rename `sliding_window` to `frame` according to tf.signal.frame.

**In addition**, there is a logic change. Currently, the frontend cuts off the last partial frame. After this PR, it keeps the last partial frame, which may increase the output length by 1. While the output tensor shape changes, the output values do not, because the paddings still treat the partial frame as padding. As a result, there will be no change in the neural network's output. ASRModelTest.test_asr_model demonstrates this behavior clearly. When is_training=False, there is no change in the loss value. However, when is_training=True, the loss changes due to dropout. Even with the same seed, different input shapes result in different returned values.