### PR TITLE
Remove stale moveaxis optimization in attention.

### DIFF
--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -2670,7 +2670,7 @@ class MultiheadAttentionTest(TestCase):
         self.assertTrue(jnp.all(time_step == initial_states["i_proj"]["time_step"]))
         for proj in ["key", "value"]:
             self.assertEqual(
-                (batch_size, num_kv_heads or num_heads, model_dim // num_heads, tgt_len),
+                (batch_size, tgt_len, num_kv_heads or num_heads, model_dim // num_heads),
                 initial_states["i_proj"][proj].shape,
             )
             self.assertEqual(


### PR DESCRIPTION
With the hack,
```
----------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------
QkvLinearExtendStepBenchmark/2048/16/1024/1         1.70 ms        0.513 ms         1125
QkvLinearExtendStepBenchmark/2048/16/4096/1         3.40 ms        0.519 ms         1174
QkvLinearExtendStepBenchmark/2048/16/32768/1        20.1 ms        0.930 ms          404
QkvLinearExtendStepBenchmark/2048/16/4096/8         3.68 ms        0.524 ms         1139
QkvLinearExtendStepBenchmark/2048/16/4096/64        3.74 ms        0.532 ms         1125
QkvLinearExtendStepBenchmark/2048/16/4096/512       2530 ms         80.4 ms            1
```

If remove the weird moveaxis hack, there is speed up, especially when step size is big (512).

This PR w/o moveaxis
```
----------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------
QkvLinearExtendStepBenchmark/2048/16/1024/1         1.52 ms        0.542 ms         1082
QkvLinearExtendStepBenchmark/2048/16/4096/1         3.18 ms        0.547 ms         1096
QkvLinearExtendStepBenchmark/2048/16/32768/1        19.6 ms        0.824 ms          430
QkvLinearExtendStepBenchmark/2048/16/4096/8         3.34 ms        0.542 ms         1139
QkvLinearExtendStepBenchmark/2048/16/4096/64        3.48 ms        0.553 ms         1091
QkvLinearExtendStepBenchmark/2048/16/4096/512       36.5 ms         1.71 ms           71
```