### PR TITLE
Optimize MQA computation.

### DIFF
--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -2303,31 +2303,6 @@ class MultiheadAttentionTest(TestCase):
         # The outputs are equivalent.
         self.assertNestedAllClose(outputs[0], outputs[1])
 
-    def test_gqa_kv_heads(self):
-        """Checks that only the heads dim is repeated."""
-        batch = source_length = num_heads = 8
-        per_head_dim = 2
-        num_kv_heads = 4
-        dtype = jnp.float32
-        key_or_value = jnp.zeros((batch, source_length, num_kv_heads, per_head_dim), dtype=dtype)
-        model_dim = per_head_dim * num_heads
-        cfg = attention.GroupedQueryAttention.default_config().set(
-            query_dim=model_dim,
-            key_dim=model_dim,
-            value_dim=model_dim,
-            num_heads=num_heads,
-            input_linear=attention.FusedGroupedQKVLinear.default_config().set(
-                num_kv_heads=num_kv_heads
-            ),
-            dtype=dtype,
-        )
-        test_layer = cfg.set(name="test").instantiate(parent=None)
-        # pylint: disable-next=protected-access
-        repeated_key_or_value = test_layer._repeat_kv_heads(key_or_value)
-        self.assertEqual(
-            repeated_key_or_value.shape, (batch, source_length, num_heads, per_head_dim)
-        )
-
     @parameterized.product(
         dtype=(jnp.float32, jnp.float16, jnp.bfloat16),
         per_dim_scale=(None, PerDimScale.default_config()),

--- a/axlearn/vision/attention.py
+++ b/axlearn/vision/attention.py
@@ -229,7 +229,7 @@ class WindowedAttention(MultiheadAttention):
             attention_logit_biases = attention_logit_biases[:, None, :, :]
         probs = softmax_with_biases(logits, attention_logit_biases=attention_logit_biases)
         probs = self.dropout(probs)
-        context = jnp.einsum("bnts,bsnh->btnh", probs, v_proj).astype(v_proj.dtype)
+        context = self._compute_context(probs, v_proj)
         context = self._remat_name(context, "context")
         self.vlog(3, "atten.prob=%s", probs[0, 0, 0, :])
         self.vlog(3, "atten.context=%s", context.sum())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 core = [
     "absl-py==2.1.0",
     "chex==0.1.86",  # chex 0.1.86 is required for jax 0.4.25.
+    "einops==0.8.0",
     "importlab==0.7",  # breaks pytype on 0.8
     "jax==0.4.34",
     "jaxlib==0.4.34",
@@ -53,10 +54,10 @@ apple-silicon = [
 ]
 # Requirements for testing and development.
 dev = [
+    "axlearn[core]",  # core
     "axlearn[audio]",  # audio tests
     "axlearn[orbax]",  # checkpointer tests
     "black==23.1a1",  # formatting
-    "einops==0.8.0",
     "evaluate",
     "isort",  # formatting
     "pika==1.3.2",  # used by event queue


### PR DESCRIPTION
The advantage of multi-query attention (MQA) lies in both reducing the size of the KV cache and making self-attention computation more efficient. The current implementation only saves on KV cache size.

This PR improves it further by not only reducing the computation cost, but also saving the per-layer KV cache memory.

This becomes especially critical when dealing with very long contexts. For
instance, if an LLM is processing a context length of 1 million tokens using
the Character.ai architecture [1], there might be around 4 unique KV cache layers.
Let’s assume there are 4 KV heads and 32 total attention heads, with a
dim_per_head of 128. In the current implementation, each layer consumes
significant memory for self-attention KV caching (using bfloat16):
* Current (ASIS): 8GB (128 * 32 * 2 * 1M)
* Optimized (TODO): 1GB (128 * 4 * 2 * 1M)

[1] https://research.character.ai/optimizing-inference/

* Benchmark results: it saves memory and computation.
tools/attention_benchmark.py on TPUv5p

ASIS
```
-----------------------------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations   HBM (over 95.74G)
-----------------------------------------------------------------------------------------
MQABenchmark/2048/16/2/1024       1.42 ms        0.247 ms         2347           291.16M
MQABenchmark/4096/16/2/1024       3.60 ms        0.277 ms         1257           322.95M
MQABenchmark/4096/16/2/4096       47.3 ms        0.818 ms          139             4.25G
MQABenchmark/4096/16/2/8192        869 ms        0.932 ms          140            48.00G
```

This PR
```
-----------------------------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations   HBM (over 95.74G)
-----------------------------------------------------------------------------------------
MQABenchmark/2048/16/2/1024       1.16 ms        0.256 ms         2535           262.35M
MQABenchmark/4096/16/2/1024       3.46 ms        0.294 ms         1114           266.88M
MQABenchmark/4096/16/2/4096       24.8 ms        0.769 ms          137             4.04G
MQABenchmark/4096/16/2/8192        860 ms         1.19 ms          136            48.00G
```
