### PR TITLE
CAUSAL padding=(dilate_window - stride, stride - 1), not (dilate_window - dilate_stride, dilate_stride - 1)

### DIFF
--- a/axlearn/common/layers_test.py
+++ b/axlearn/common/layers_test.py
@@ -968,9 +968,9 @@ class LayerTest(TestCase, tf.test.TestCase):
         (5, 1, "CAUSAL", 1, (4, 0)),
         (5, 2, "CAUSAL", 1, (3, 1)),
         (5, 3, "CAUSAL", 1, (2, 2)),
-        (5, 1, "CAUSAL", 2, (7, 1)),
-        (5, 2, "CAUSAL", 2, (5, 3)),
-        (5, 3, "CAUSAL", 2, (3, 5)),
+        (5, 1, "CAUSAL", 2, (8, 0)),
+        (5, 2, "CAUSAL", 2, (7, 1)),
+        (5, 3, "CAUSAL", 2, (6, 2)),
     )
     def test_conv_explicit_padding(
         self, window: int, stride: int, padding: ConvPaddingType, dilation: int, expected
@@ -1091,6 +1091,28 @@ class LayerTest(TestCase, tf.test.TestCase):
             paddings, window=window, stride=stride, conv_padding=ref_padding
         )
         self.assertAllEqual(out_paddings, ref_paddings)
+
+    @parameterized.parameters(
+        ("SAME", 1, [0, 0, 0, 0, 1, 1], [0, 0, 1]),
+        ("VALID", 1, [0, 0, 0, 0, 1, 1], [0]),
+        ("CAUSAL", 1, [0, 0, 0, 0, 1, 1], [0, 0, 1]),
+        ("SAME", 2, [0, 0, 0, 0, 0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 1]),
+        ("VALID", 2, [0, 0, 0, 0, 0, 0, 0, 0, 1, 1], [0]),
+        ("CAUSAL", 2, [0, 0, 0, 0, 0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 1]),
+    )
+    def test_compute_conv_paddings_with_dilation(
+        self, padding: ConvPaddingType, dilation: int, paddings, expected
+    ):
+        """Tests compute_conv_paddings() as described in conv_explicit_padding()."""
+        window, stride = 5, 2
+        out_paddings = compute_conv_paddings(
+            jnp.array([paddings]),
+            window=window,
+            stride=stride,
+            conv_padding=padding,
+            dilation=dilation,
+        )[0]
+        self.assertAllEqual(out_paddings, expected)
 
     @parameterized.parameters(
         (5, "SAME", None, [0, 0, 0, 1, 1, 1]),


### PR DESCRIPTION
With CAUSAL padding, the lookahead is limited to stride-1 because that portion becomes part of the past in the next stride.
```
e.g. window=5, stride=2 -> padding=(3,1)
 0 1 2|3 4 5 6 7 8 9 0 1 2 3 4 5|6
 |_____^_|       <-  ^ is anchor
     |_____^_|
         |_____^_|
```

Even when dilation > 1, the lookahead remains stride-1. This is because dilation increases the effective window size, but does not change the stride of the convolution.
```
e.g. window=5, stride=2, dilate=2 -> dilate_window=9, padding=(7,1)
 0 1 2 3 4 5 6|7 8 9 0 1 2 3 4 5|6
 |_____________^_|
     |_____________^_|
         |_____________^_|
```