### PR TITLE
improve GCS perf: Change resource limit to request

### DIFF
--- a/axlearn/cloud/gcp/job.py
+++ b/axlearn/cloud/gcp/job.py
@@ -629,9 +629,9 @@ class TPUGKEJob(GKEJob):
             annotations.update(
                 {
                     "gke-gcsfuse/volumes": "true",
-                    "gke-gcsfuse/cpu-limit": cfg.gcsfuse_mount.cpu,
-                    "gke-gcsfuse/memory-limit": cfg.gcsfuse_mount.memory,
-                    "gke-gcsfuse/ephemeral-storage-limit": cfg.gcsfuse_mount.ephemeral_gb,
+                    "gke-gcsfuse/cpu-request": cfg.gcsfuse_mount.cpu,
+                    "gke-gcsfuse/memory-request": cfg.gcsfuse_mount.memory,
+                    "gke-gcsfuse/ephemeral-storage-request": cfg.gcsfuse_mount.ephemeral_gb,
                 }
             )
             # Parse GCSFuseMount path into bucket, prefix.


### PR DESCRIPTION
By using a limit we're restricting the resources that GCS needs to achieve decent performance. This PR changes the resource limit to a request, which allows GCS Fuse to use all available resources. This is now also the recommended default for GKE Standard clusters.