### PR TITLE
Support orbax state builder

### DIFF
--- a/axlearn/common/checkpointer_orbax.py
+++ b/axlearn/common/checkpointer_orbax.py
@@ -201,6 +201,11 @@ class OrbaxCheckpointer(BaseCheckpointer):
         """See `BaseCheckpointer.checkpointer_paths`."""
         return [str(path) for path in ocp.utils.checkpoint_steps_paths(base_dir)]
 
+    @classmethod
+    def checkpoint_steps(cls, base_dir) -> list[int]:
+        """See `BaseCheckpointer.checkpointer_steps`."""
+        return ocp.utils.checkpoint_steps(base_dir)
+
     def __init__(self, cfg: Config, *, parent: Optional[Module]):
         super().__init__(cfg, parent=parent)
 
@@ -226,12 +231,6 @@ class OrbaxCheckpointer(BaseCheckpointer):
             step_prefix=STEP_PREFIX,
             step_format_fixed_length=STEP_NUM_DIGITS,
         )
-        # TODO(matthew_e_hopkins): bring back save_concurrent_gb and restore_concurrent_gb
-        # after bumping up the Jax version.
-        if cfg.max_concurrent_restore_gb is not None:
-            raise NotImplementedError(
-                "Orbax version (0.5.23) doesn't support separate save/restore concurrent_gb."
-            )
         self._manager = ocp.CheckpointManager(
             directory=cfg.dir,
             options=ocp.CheckpointManagerOptions(
@@ -251,7 +250,8 @@ class OrbaxCheckpointer(BaseCheckpointer):
                 # Note that this defaults to use_ocdb=True. Note also that custom `TypeHandler`s are
                 # ignored by `StandardCheckpointHandler`, so we use `PyTreeCheckpointHandler`.
                 "state": ocp.PyTreeCheckpointHandler(
-                    concurrent_gb=cfg.max_concurrent_save_gb,
+                    save_concurrent_gb=cfg.max_concurrent_save_gb,
+                    restore_concurrent_gb=cfg.max_concurrent_restore_gb,
                 ),
             },
         )

--- a/axlearn/common/state_builder.py
+++ b/axlearn/common/state_builder.py
@@ -381,8 +381,9 @@ class BaseStateStorageBuilder(Builder):
         """Configures BaseStateStorageBuilder.
 
         Attributes:
-            base_dir: Base directory that contains the checkpoint.
-            step: Step number to load.
+            base_dir: Base directory that contains checkpoints of a trainer, usually containing
+                subdirs, one for each checkpointed step.
+            step: Step number to load. Required if `base_dir` is specified.
             validation: Checkpoint validation type.
             concurrent_gb: Memory limit of the in-flight reads.
         """
@@ -406,7 +407,8 @@ class TensorStoreStateStorageBuilder(BaseStateStorageBuilder):
         """Configures TensorStoreStateStorageBuilder.
 
         Attributes:
-            dir: Full checkpoint path. This is supported for backward compatibility purposes.
+            dir: Full checkpoint path that contains a checkpoint of a single step.
+                This is supported for backward compatibility purposes.
                 It's recommended to use `base_dir` and `step` if possible.
             storage: Config for the underlying storage used during checkpoint loading. Defaults
                 to `TensorStoreStateStorage`.

--- a/axlearn/common/state_builder_test.py
+++ b/axlearn/common/state_builder_test.py
@@ -4,8 +4,9 @@
 
 # pylint: disable=no-self-use,too-many-lines
 import os
+import tempfile
 from copy import deepcopy
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 import jax
 import jax.numpy as jnp
@@ -50,13 +51,18 @@ from axlearn.common.state_builder import (
     MergeStateConverter,
     MergeStateSelection,
     ModelStateScopeConverter,
+    OrbaxCheckpointer,
+    OrbaxStateBuilder,
     PosEmbeddingConverter,
     RestoreAndConvertBuilder,
+    TensorStoreStateStorage,
+    TensorStoreStateStorageBuilder,
+    build_step_dir,
     clone_tree,
     get_builder,
     traverse_and_set_target_state_parameters,
 )
-from axlearn.common.test_utils import TestCase, mock_trainer_config
+from axlearn.common.test_utils import TestCase, is_supported_mesh_shape, mock_trainer_config
 from axlearn.common.trainer import SpmdTrainer, TrainerState
 from axlearn.common.utils import (
     NestedTensor,
@@ -1363,6 +1369,85 @@ class EmaParamsConverterTest(TestCase):
                 output_state.trainer_state.learner["ema"],
                 source_state.trainer_state.learner["ema"],
             )
+
+
+def _mesh(mesh_shape: Sequence[int]):
+    devices = mesh_utils.create_device_mesh(mesh_shape)
+    return jax.sharding.Mesh(devices, ("data", "model"))
+
+
+def _make_state(float_dtype):
+    return dict(x=jnp.zeros([], dtype=jnp.int32), y=jnp.ones([2], dtype=float_dtype))
+
+
+class TensorStoreStateStorageBuilderTest(TestCase):
+    """Tests TensorStoreStateStorageBuilder."""
+
+    def test_build(self):
+        mesh_shape = (1, 1)
+        if not is_supported_mesh_shape(mesh_shape):
+            return
+
+        with tempfile.TemporaryDirectory() as root_dir, _mesh(mesh_shape):
+            state = _make_state(float_dtype=jnp.float32)
+            storage = TensorStoreStateStorage.default_config().instantiate()
+
+            step = 1000
+            # Save ckpt.
+            final_dir = build_step_dir(root_dir, step=step)
+            storage.save_to_dir(step=step, state=state, ckpt_dir=final_dir)
+            storage.wait_until_finished()
+
+            # Build with dir.
+            builder_state = Builder.State(step=step, trainer_state=state, built_keys=set())
+            builder_state = (
+                TensorStoreStateStorageBuilder.default_config()
+                .set(name="tsssb", dir=final_dir)
+                .instantiate(parent=None)(builder_state)
+            )
+            self.assertNestedEqual(state, builder_state.trainer_state)
+
+            # Build with base_dir and step.
+            builder_state = Builder.State(step=step, trainer_state=state, built_keys=set())
+            builder_state = (
+                TensorStoreStateStorageBuilder.default_config()
+                .set(name="tsssb", base_dir=root_dir, step=step)
+                .instantiate(parent=None)(builder_state)
+            )
+            self.assertNestedEqual(state, builder_state.trainer_state)
+
+            with self.assertRaises(ValueError):
+                TensorStoreStateStorageBuilder.default_config().set(
+                    name="tsssb", dir=final_dir, base_dir=root_dir, step=step
+                ).instantiate(parent=None)
+
+
+class OrbaxStateBuilderTest(TestCase):
+    """Tests OrbaxStateBuilder."""
+
+    def test_build(self):
+        mesh_shape = (1, 1)
+        if not is_supported_mesh_shape(mesh_shape):
+            return
+
+        with tempfile.TemporaryDirectory() as root_dir, _mesh(mesh_shape):
+            state = _make_state(float_dtype=jnp.float32)
+            step = 1000
+            checkpointer = (
+                OrbaxCheckpointer.default_config()
+                .set(dir=root_dir, name="orbax")
+                .instantiate(parent=None)
+            )
+            checkpointer.save(step=step, state=state)
+            checkpointer.wait_until_finished()
+
+            builder_state = Builder.State(step=step, trainer_state=state, built_keys=set())
+            builder_state = (
+                OrbaxStateBuilder.default_config()
+                .set(name="osb", base_dir=root_dir, step=step)
+                .instantiate(parent=None)(builder_state)
+            )
+            self.assertNestedEqual(state, builder_state.trainer_state)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ mmau = [
 # Orbax checkpointing.
 orbax = [
     "humanize==4.10.0",
-    "orbax-checkpoint==0.5.23",
+    "orbax-checkpoint==0.6.4",
 ]
 # Grain input processing. Currently does not support macos.
 grain = [


### PR DESCRIPTION
This PR adds `OrbaxStateBuilder` and refactors `TensorStoreStateBuilder`, and prepares for Orbax emergency checkpointing, which cannot be meaningfully represented as a path. Therefore, we add support of using `base_dir` and `step` as arguments to Builder, which abstracts away the underlying checkpoint structure. This paves the way of letting users restore state from the results of emergency checkpoint.

This PR also upgrades orbax slightly so it supports concurrent save and restore gb. 