### PR TITLE
Simplifies ScheduleResults.job_verdicts

### DIFF
--- a/axlearn/cloud/common/bastion.py
+++ b/axlearn/cloud/common/bastion.py
@@ -750,7 +750,11 @@ class Bastion(Configurable):
     ):
         now = datetime.now(timezone.utc)
         for project_id, limits in schedule_results.project_limits.items():
-            job_verdicts = schedule_results.job_verdicts.get(project_id, {})
+            job_verdicts = {
+                job_id: verdict
+                for job_id, verdict in schedule_results.job_verdicts.items()
+                if jobs[job_id].project_id == project_id
+            }
             verdicts = []
             for job_id, verdict in job_verdicts.items():
                 verdicts.append((job_id, verdict.should_run(), verdict.metadata))
@@ -1076,56 +1080,55 @@ class Bastion(Configurable):
             verbosity=schedule_options["verbosity"],
         )
         self._append_to_project_history(schedulable_jobs, schedule_results)
-        for verdicts in schedule_results.job_verdicts.values():
-            for job_name, verdict in verdicts.items():
-                job = self._active_jobs[job_name]
-                assert job.state.status in {JobStatus.PENDING, JobStatus.ACTIVE}
+        for job_name, verdict in schedule_results.job_verdicts.items():
+            job = self._active_jobs[job_name]
+            assert job.state.status in {JobStatus.PENDING, JobStatus.ACTIVE}
 
-                if verdict:
-                    old_tier = job.state.metadata.get("tier")
-                    new_tier = verdict.metadata.get("tier")
-                    changed_tiers = old_tier != new_tier
+            if verdict:
+                old_tier = job.state.metadata.get("tier")
+                new_tier = verdict.metadata.get("tier")
+                changed_tiers = old_tier != new_tier
 
-                    jobspec_changed = job.state.metadata.get("updated")
+                jobspec_changed = job.state.metadata.get("updated")
 
-                    # Jobspec changed, trigger a restart of the runner.
-                    if jobspec_changed:
-                        self._append_to_job_history(
-                            job,
-                            msg="UPDATING: Detected updated jobspec. Will restart the runner "
-                            "by sending to PENDING state",
-                            state=JobLifecycleState.UPDATING,
-                        )
-                        job.state.status = JobStatus.PENDING
-                    elif job.state.status == JobStatus.PENDING or not changed_tiers:
-                        # Resume if not running, or keep running if scheduling tier did not change.
-                        job.state.status = JobStatus.ACTIVE
-                    else:
-                        # Job changed scheduling tiers, and must be restarted on the new tier.
-                        # NOTE: this can possibly lead to thrashing of jobs that frequently switch
-                        # tiers. One option is track per-job tier changes and hold off on promoting
-                        # low priority to high priority if it was demoted recently.
-                        # TODO(markblee): Add instrumentation to track frequency of tier changes to
-                        # see whether this is necessary.
-                        assert job.state.status == JobStatus.ACTIVE and changed_tiers
-                        self._append_to_job_history(
-                            job,
-                            msg=f"Rescheduling at a different tier from {old_tier} to {new_tier}",
-                            state=JobLifecycleState.RESCHEDULING,
-                        )
-                        job.state.status = JobStatus.PENDING
+                # Jobspec changed, trigger a restart of the runner.
+                if jobspec_changed:
+                    self._append_to_job_history(
+                        job,
+                        msg="UPDATING: Detected updated jobspec. Will restart the runner "
+                        "by sending to PENDING state",
+                        state=JobLifecycleState.UPDATING,
+                    )
+                    job.state.status = JobStatus.PENDING
+                elif job.state.status == JobStatus.PENDING or not changed_tiers:
+                    # Resume if not running, or keep running if scheduling tier did not change.
+                    job.state.status = JobStatus.ACTIVE
                 else:
-                    # Pre-empt/stay queued.
-                    if job.command_proc is not None and _is_proc_complete(job.command_proc):
-                        # As a slight optimization, we avoid pre-empting ACTIVE jobs that are
-                        # complete, since we can directly transition to CLEANING.
-                        job.state.status = JobStatus.ACTIVE
-                    else:
-                        job.state.status = JobStatus.PENDING
-                        # Pending jobs which are not rescheduled should have no tier information.
-                        verdict.metadata.pop("tier", None)
+                    # Job changed scheduling tiers, and must be restarted on the new tier.
+                    # NOTE: this can possibly lead to thrashing of jobs that frequently switch
+                    # tiers. One option is track per-job tier changes and hold off on promoting
+                    # low priority to high priority if it was demoted recently.
+                    # TODO(markblee): Add instrumentation to track frequency of tier changes to
+                    # see whether this is necessary.
+                    assert job.state.status == JobStatus.ACTIVE and changed_tiers
+                    self._append_to_job_history(
+                        job,
+                        msg=f"Rescheduling at a different tier from {old_tier} to {new_tier}",
+                        state=JobLifecycleState.RESCHEDULING,
+                    )
+                    job.state.status = JobStatus.PENDING
+            else:
+                # Pre-empt/stay queued.
+                if job.command_proc is not None and _is_proc_complete(job.command_proc):
+                    # As a slight optimization, we avoid pre-empting ACTIVE jobs that are
+                    # complete, since we can directly transition to CLEANING.
+                    job.state.status = JobStatus.ACTIVE
+                else:
+                    job.state.status = JobStatus.PENDING
+                    # Pending jobs which are not rescheduled should have no tier information.
+                    verdict.metadata.pop("tier", None)
 
-                job.state.metadata = verdict.metadata
+            job.state.metadata = verdict.metadata
 
         # TODO(markblee): Parallelize this.
         for job_name, job in self._active_jobs.items():

--- a/axlearn/cloud/common/cleaner.py
+++ b/axlearn/cloud/common/cleaner.py
@@ -89,6 +89,6 @@ class UnschedulableCleaner(Cleaner):
             schedule_result = scheduler.schedule(
                 dict(my_job=job_spec.metadata),
             )
-            if schedule_result.job_verdicts[job_spec.metadata.project_id]["my_job"].over_limits:
+            if schedule_result.job_verdicts["my_job"].over_limits:
                 result.append(job_name)
         return result

--- a/axlearn/cloud/common/scheduler.py
+++ b/axlearn/cloud/common/scheduler.py
@@ -155,6 +155,9 @@ class BaseScheduler(Configurable):
             project_limits: The effective resource limits.
             project_usages: The resource usages.
             job_verdicts: A mapping of job_id -> run_or_not.
+                The entries will be ordered by descending scheduling priorities (not necessarily
+                JobMetadata.priority), where the higher priority jobs will be scheduled before
+                lower priority ones. The jobs not getting scheduled will also be ordered.
         """
 
         project_limits: ProjectResourceMap[int]

--- a/axlearn/cloud/common/scheduler.py
+++ b/axlearn/cloud/common/scheduler.py
@@ -494,8 +494,6 @@ class JobScheduler(Configurable):
             schedule_results = BaseScheduler.ScheduleResults(
                 project_limits=schedule_results.project_limits,
                 project_usages=project_usages,
-                job_verdicts={
-                    job_name: JobVerdict() for job_name in schedule_results.job_verdicts
-                },
+                job_verdicts={job_name: JobVerdict() for job_name in schedule_results.job_verdicts},
             )
         return schedule_results

--- a/axlearn/cloud/common/scheduler.py
+++ b/axlearn/cloud/common/scheduler.py
@@ -154,12 +154,12 @@ class BaseScheduler(Configurable):
         Attributes:
             project_limits: The effective resource limits.
             project_usages: The resource usages.
-            job_verdicts: A mapping of project_id -> (job_id -> run_or_not).
+            job_verdicts: A mapping of job_id -> run_or_not.
         """
 
         project_limits: ProjectResourceMap[int]
         project_usages: ProjectResourceMap[int]
-        job_verdicts: dict[str, dict[str, JobVerdict]]
+        job_verdicts: dict[str, JobVerdict]
 
     def schedule(
         self,
@@ -345,8 +345,8 @@ class TierScheduler(BaseScheduler):
                     break
             return tier_usages
 
-        job_verdicts = collections.defaultdict(dict)
-        while not project_queue.empty() and remaining_limits:
+        job_verdicts = {}
+        while not project_queue.empty():
             project_usage_ratio, _, project_id = project_queue.get()
             job_id, job_metadata = project_jobs[project_id].popleft()
 
@@ -381,16 +381,9 @@ class TierScheduler(BaseScheduler):
                     "Schedule %s(%s)/%s: %s", project_id, project_usage_ratio, job_id, verdict
                 )
 
-            job_verdicts[project_id][job_id] = verdict
+            job_verdicts[job_id] = verdict
             if project_jobs[project_id]:
                 project_queue.put(project_queue_item(project_id))
-
-        # Remaining jobs are rejected.
-        for project_id, job_queue in project_jobs.items():
-            for job_id, job_metadata in job_queue:
-                job_verdicts[project_id][job_id] = JobVerdict(
-                    over_limits=set(job_metadata.resources.keys())
-                )
 
         return BaseScheduler.ScheduleResults(
             # Treat the usages as the limits.
@@ -472,14 +465,15 @@ class JobScheduler(Configurable):
             logging.info("")
             logging.info("==Begin scheduling report")
             logging.info("Total resource limits: %s", resource_limits)
-            for project_id, project_verdicts in schedule_results.job_verdicts.items():
+            for project_id, project_job_queue in project_jobs.items():
                 logging.info(
                     "Verdicts for Project [%s] Quota [%s] Effective limits [%s]:",
                     project_id,
                     project_quotas.get(project_id, {}),
                     schedule_results.project_limits.get(project_id, {}),
                 )
-                for job_name, job_verdict in project_verdicts.items():
+                for job_name, job_metadata in project_job_queue:
+                    job_verdict = schedule_results.job_verdicts[job_name]
                     logging.info(
                         "Job %s: Resources [%s] Over limits [%s] Should Run? [%s] Metadata [%s]",
                         job_name,
@@ -501,8 +495,7 @@ class JobScheduler(Configurable):
                 project_limits=schedule_results.project_limits,
                 project_usages=project_usages,
                 job_verdicts={
-                    project_id: {job_name: JobVerdict() for job_name in project_verdicts}
-                    for project_id, project_verdicts in schedule_results.job_verdicts.items()
+                    job_name: JobVerdict() for job_name in schedule_results.job_verdicts
                 },
             )
         return schedule_results

--- a/axlearn/cloud/common/scheduler_test.py
+++ b/axlearn/cloud/common/scheduler_test.py
@@ -220,7 +220,9 @@ class TierSchedulerTest(parameterized.TestCase):
             },
             expected_project_limits={"a": {"v4": 5}, "b": {"v4": 5}},
             expected_verdicts={"a1": True, "b1": True, "b2": True},
-            expected_tiers={"a1": 0, "b1": 0, "b2": 0},
+            # The order of entries in `expected_tiers` should reflect the job priorities.
+            # Here "b1" is ahead of "a1" because it requests less resources.
+            expected_tiers={"b1": 0, "a1": 0, "b2": 0},
         ),
         # Test tie-break. Although both are requesting the same amount, "b" is requesting more
         # relative to its quota, so "a" will be prioritized.
@@ -271,7 +273,7 @@ class TierSchedulerTest(parameterized.TestCase):
             },
             expected_project_limits={"a": {"v4": 12}, "b": {"v4": 3}},
             expected_verdicts={"a1": True, "b1": True, "b2": True},
-            expected_tiers={"a1": 1, "b1": 0, "b2": 0},
+            expected_tiers={"b1": 0, "b2": 0, "a1": 1},
         ),
         # In this case, "a" is requesting much more relative to its quota than "b", so "b" gets to
         # go first (so "a" doesn't fit).
@@ -286,7 +288,7 @@ class TierSchedulerTest(parameterized.TestCase):
             },
             expected_project_limits={"a": {"v4": 0}, "b": {"v4": 6}},
             expected_verdicts={"a1": False, "b1": True, "b2": True},
-            expected_tiers={"a1": None, "b1": 0, "b2": 0},
+            expected_tiers={"b1": 0, "b2": 0, "a1": None},
         ),
         # Test that leftover resources from reserved tier are schedulable by subsequent tiers.
         dict(
@@ -300,7 +302,8 @@ class TierSchedulerTest(parameterized.TestCase):
             },
             expected_project_limits={"a": {"v4": 7}, "b": {"v4": 8}},
             expected_verdicts={"a1": True, "b1": True, "b2": True},
-            expected_tiers={"a1": 0, "b1": 0, "b2": 1},
+            # "b1" is ahead of "a1" since it requests less resource.
+            expected_tiers={"b1": 0, "a1": 0, "b2": 1},
         ),
         # Test load balance.
         dict(
@@ -328,10 +331,13 @@ class TierSchedulerTest(parameterized.TestCase):
                 "c0": 0,
                 "a1": 1,
                 "b1": 1,
-                "a2": None,
-                "b2": None,
+                # While the rest of the jobs are not scheduled, the order still reflects
+                # their priorities.
+                # Since "c" gets the least resource, its jobs take priority over those from a/b.
                 "c1": None,
                 "c2": None,
+                "a2": None,
+                "b2": None,
             },
         ),
         # Test projects with no quotas.
@@ -356,14 +362,16 @@ class TierSchedulerTest(parameterized.TestCase):
                 for i in range(3)
             },
             expected_tiers={
+                # "b" has quota for "v4", so its jobs get priorities.
                 "b0": 0,
                 "b1": 0,
                 "b2": 1,
+                # "a" and "c" jobs are interleaved in scheduling.
                 "a0": 2,
                 "c0": 2,
                 "a1": None,
-                "a2": None,
                 "c1": None,
+                "a2": None,
                 "c2": None,
             },
         ),
@@ -413,7 +421,7 @@ class TierSchedulerTest(parameterized.TestCase):
             resource_limits=[{"v4": 3}],
             expected_project_limits={"a": {"v4": 0, "v3": 0}, "b": {"v4": 2}},
             expected_verdicts={"a1": False, "b1": True, "b2": False},
-            expected_tiers={"a1": None, "b1": 0, "b2": None},
+            expected_tiers={"b1": 0, "b2": None, "a1": None},
         ),
         # Test that we can accumulate across tiers. Jobs should schedule onto the final tier.
         dict(
@@ -428,7 +436,7 @@ class TierSchedulerTest(parameterized.TestCase):
             resource_limits=[{"v4": 1}, {"v4": 1}, {"v4": 1}],
             expected_project_limits={"a": {"v4": 0, "v3": 0}, "b": {"v4": 3}},
             expected_verdicts={"a1": False, "b1": True, "b2": False},
-            expected_tiers={"a1": None, "b1": 2, "b2": None},
+            expected_tiers={"b1": 2, "b2": None, "a1": None},
         ),
         # Test that we can accumulate across tiers across resource types.
         dict(
@@ -513,7 +521,7 @@ class TierSchedulerTest(parameterized.TestCase):
             },
             expected_project_limits={"a": {"v4": 5}, "b": {"unknown": 0, "v4": 1}},
             expected_verdicts={"a1": True, "a2": False, "b1": False, "b2": True},
-            expected_tiers={"a1": 0, "a2": None, "b1": None, "b2": 0},
+            expected_tiers={"b2": 0, "a1": 0, "a2": None, "b1": None},
         ),
     )
     def test_schedule(
@@ -557,8 +565,8 @@ class TierSchedulerTest(parameterized.TestCase):
                 for job_name, job_verdict in job_verdicts.items()
             },
         )
-        # Check that the order of jobs in `job_verdicts` matches that in `expected_verdicts`.
-        self.assertEqual(list(job_verdicts.keys()), list(expected_verdicts.keys()))
+        # Check that the order of jobs in `job_verdicts` matches that in `expected_tiers`.
+        self.assertEqual(list(job_verdicts.keys()), list(expected_tiers.keys()))
 
 
 def _mock_get_resource_limits(*args):

--- a/axlearn/cloud/common/scheduler_test.py
+++ b/axlearn/cloud/common/scheduler_test.py
@@ -220,7 +220,7 @@ class TierSchedulerTest(parameterized.TestCase):
             expected_project_limits={"a": {"v4": 5}, "b": {"v4": 5}},
             expected_verdicts={"a1": True, "b1": True, "b2": True},
             # The order of entries in `expected_tiers` should reflect the job priorities.
-            # Here "b1" is ahead of "a1" because it requests less resources.
+            # Here "b1" is ahead of "a1" because it requests fewer resources.
             expected_tiers={"b1": 0, "a1": 0, "b2": 0},
         ),
         # Test tie-break. Although both are requesting the same amount, "b" is requesting more
@@ -301,7 +301,7 @@ class TierSchedulerTest(parameterized.TestCase):
             },
             expected_project_limits={"a": {"v4": 7}, "b": {"v4": 8}},
             expected_verdicts={"a1": True, "b1": True, "b2": True},
-            # "b1" is ahead of "a1" since it requests less resource.
+            # "b1" is ahead of "a1" since it requests fewer resource.
             expected_tiers={"b1": 0, "a1": 0, "b2": 1},
         ),
         # Test load balance.

--- a/axlearn/cloud/common/scheduler_test.py
+++ b/axlearn/cloud/common/scheduler_test.py
@@ -15,7 +15,6 @@ from axlearn.cloud.common.scheduler import (
     JobMetadata,
     JobQueue,
     JobScheduler,
-    JobVerdict,
     ProjectJobSorter,
     TierScheduler,
     _compute_total_limits,

--- a/axlearn/cloud/common/scheduler_test.py
+++ b/axlearn/cloud/common/scheduler_test.py
@@ -435,6 +435,8 @@ class TierSchedulerTest(parameterized.TestCase):
             resource_limits=[{"v4": 1}, {"v4": 1}, {"v4": 1}],
             expected_project_limits={"a": {"v4": 0, "v3": 0}, "b": {"v4": 3}},
             expected_verdicts={"a1": False, "b1": True, "b2": False},
+            # While both "a1" and "b2" are not scheduled, "b2" is ranked ahead of "a1" because
+            # its demand/limit ratio is lower (there's no v3 resource, so a1's ratio is infinite).
             expected_tiers={"b1": 2, "b2": None, "a1": None},
         ),
         # Test that we can accumulate across tiers across resource types.


### PR DESCRIPTION
... so that its entries are ordered by the global priorities.

This allows the caller to export the job priorities and eventually surface the information on the Bastion UI.