### PR TITLE
Makes Bastion write scheduler history files

### DIFF
--- a/axlearn/cloud/common/bastion.py
+++ b/axlearn/cloud/common/bastion.py
@@ -756,7 +756,7 @@ class Bastion(Configurable):
         ) as f:
             for job_id, verdict in schedule_results.job_verdicts.items():
                 job_metadata = jobs[job_id]
-                f.write(f"{job_id} {job_metadata}\n")
+                f.write(f"{job_id} [{job_metadata}] {verdict}\n")
         for project_id, limits in schedule_results.project_limits.items():
             job_verdicts = {
                 job_id: verdict

--- a/axlearn/cloud/common/bastion.py
+++ b/axlearn/cloud/common/bastion.py
@@ -702,6 +702,8 @@ class Bastion(Configurable):
         tf_io.gfile.makedirs(self._job_history_dir)
         self._project_history_dir = os.path.join(self._output_dir, "history", "projects")
         tf_io.gfile.makedirs(self._project_history_dir)
+        self._scheduler_history_dir = os.path.join(self._output_dir, "history", "scheduler")
+        tf_io.gfile.makedirs(self._scheduler_history_dir)
         # Mapping from project_id to previous job verdicts.
         self._project_history_previous_verdicts = {}
         # Jobs that have fully completed.
@@ -745,10 +747,16 @@ class Bastion(Configurable):
                 )
             )
 
-    def _append_to_project_history(
+    def _append_to_history(
         self, jobs: dict[str, JobMetadata], schedule_results: BaseScheduler.ScheduleResults
     ):
         now = datetime.now(timezone.utc)
+        with tf_io.gfile.GFile(
+            os.path.join(self._scheduler_history_dir, now.strftime("%Y%m%d-%H%M%S")), "a"
+        ) as f:
+            for job_id, verdict in schedule_results.job_verdicts.items():
+                job_metadata = jobs[job_id]
+                f.write(f"{job_id} {job_metadata}\n")
         for project_id, limits in schedule_results.project_limits.items():
             job_verdicts = {
                 job_id: verdict
@@ -1079,7 +1087,7 @@ class Bastion(Configurable):
             dry_run=schedule_options["dry_run"],
             verbosity=schedule_options["verbosity"],
         )
-        self._append_to_project_history(schedulable_jobs, schedule_results)
+        self._append_to_history(schedulable_jobs, schedule_results)
         for job_name, verdict in schedule_results.job_verdicts.items():
             job = self._active_jobs[job_name]
             assert job.state.status in {JobStatus.PENDING, JobStatus.ACTIVE}

--- a/axlearn/cloud/common/bastion_test.py
+++ b/axlearn/cloud/common/bastion_test.py
@@ -1484,7 +1484,7 @@ class BastionTest(parameterized.TestCase):
     ):
         with self._patch_bastion() as mock_bastion:
             patch_update = mock.patch.object(mock_bastion, "_update_single_job")
-            patch_history = mock.patch.object(mock_bastion, "_append_to_project_history")
+            patch_history = mock.patch.object(mock_bastion, "_append_to_history")
             patch_scheduler = mock.patch.object(mock_bastion, "_scheduler")
 
             with patch_update, patch_history, patch_scheduler as mock_scheduler:


### PR DESCRIPTION
Each history file will have path `<bastion_dir>/history/scheduler/<date_time>`.

It will contain one line per job, where jobs are ordered by their scheduling priorities.