### PR TITLE
Update RoformerQKVLinear to support kv_state

### DIFF
--- a/axlearn/common/lora.py
+++ b/axlearn/common/lora.py
@@ -516,8 +516,15 @@ class LoraFusedQKVLinear(BaseQKVLinear):
         *,
         key: Optional[Tensor] = None,
         value: Optional[Tensor] = None,
+        kv_state: Optional[Tensor] = None,
         time_step: Optional[Tensor] = None,
     ) -> BaseQKVLinear.Output:
+        if kv_state is not None:
+            raise ValueError(
+                "LoraFusedQKVLinear computes key and value projections "
+                "and does not expect external `kv_state`."
+            )
+
         cfg = self.config
         if key is None and value is None:
             inputs = query


### PR DESCRIPTION
When attaching QLinear under a Roformer, kv_state is needed as an input, and it is not supported before this PR.

Additionally, since the key is pre-rotated already, we allow the option of not rotating the key again.