### PR TITLE
Fix v6e boolean flags

### DIFF
--- a/axlearn/common/compiler_options.py
+++ b/axlearn/common/compiler_options.py
@@ -53,28 +53,28 @@ def default_xla_options(
             megascale_grpc_premap_memory_bytes=17179869184,
             # Improved performance for v6e.
             xla_tpu_scoped_vmem_limit_kib=98304,
-            xla_tpu_enable_async_collective_fusion=True,
-            xla_tpu_enable_async_collective_fusion_fuse_all_gather=True,
-            xla_tpu_enable_async_collective_fusion_multiple_steps=True,
-            xla_tpu_overlap_compute_collective_tc=True,
-            xla_enable_async_all_gather=True,
+            xla_tpu_enable_async_collective_fusion="true",
+            xla_tpu_enable_async_collective_fusion_fuse_all_gather="true",
+            xla_tpu_enable_async_collective_fusion_multiple_steps="true",
+            xla_tpu_overlap_compute_collective_tc="true",
+            xla_enable_async_all_gather="true",
             # Host offloading flags
-            xla_tpu_enable_all_experimental_scheduler_features=True,
+            xla_tpu_enable_all_experimental_scheduler_features="true",
             # Flag to enable memory tracking scheduling. The default AUTO only enables
             # it in some situations. Not needed if
             # xla_tpu_enable_all_experimental_scheduler_features is set to true already.
-            xla_tpu_enable_scheduler_memory_pressure_tracking=True,
+            xla_tpu_enable_scheduler_memory_pressure_tracking="true",
             # Flag controlling the maximum number of overlapping host offloadings.
             xla_tpu_host_transfer_overlap_limit=24,
             # Flag to enable the aggressive removal of opt-barriers.
-            xla_tpu_aggressive_opt_barrier_removal=True,
+            xla_tpu_aggressive_opt_barrier_removal="true",
             # Flag to enable more aggressive scheduling for async ops, such as pushing
             # the async start to the beginning of the loop body.
-            xla_lhs_prioritize_async_depth_over_stall=True,
+            xla_lhs_prioritize_async_depth_over_stall="true",
             # Flag to enable pipelining of cross-DCN all-gathers.
-            xla_tpu_enable_ag_backward_pipelining=True,
-            xla_should_allow_loop_variant_parameter_in_chain=True,
-            xla_should_add_loop_invariant_op_in_chain=True,
+            xla_tpu_enable_ag_backward_pipelining="true",
+            xla_should_allow_loop_variant_parameter_in_chain="true",
+            xla_should_add_loop_invariant_op_in_chain="true",
             # Flag controlling the maximum number of overlapping cross-DCN send/recv.
             xla_max_concurrent_host_send_recv=100,
             # Flag controlling the HBM memory limit as a percentage of the total HBM size.
@@ -92,16 +92,16 @@ def default_xla_options(
             # though, may make the scheduler weighting too much on the memory usage instead
             # of latency side.
             xla_latency_hiding_scheduler_rerun=2,
-            xla_tpu_use_enhanced_launch_barrier=True,
+            xla_tpu_use_enhanced_launch_barrier="true",
             # Sparsecore offloading for all reduce.
             # Uncomment below flags to enable it.
-            # xla_sc_disable_megacore_partitioning=True,
-            # xla_tpu_use_tc_device_shape_on_sc=True,
-            # tpu_use_continuations=True,
+            # xla_sc_disable_megacore_partitioning="true",
+            # xla_tpu_use_tc_device_shape_on_sc="true",
+            # tpu_use_continuations="true",
             # xla_jf_crs_combiner_threshold_count=10,
             # xla_sc_enable_instruction_fusion="false",
             # xla_sc_disjoint_spmem="false",
-            # xla_tpu_enable_sparse_core_collective_offload_all_reduce=True,
+            # xla_tpu_enable_sparse_core_collective_offload_all_reduce="true",
         )
         # This flag can be removed after upgrading to Jax 0.4.38.
         # Uncomment for sparsecore offloading.

--- a/axlearn/common/compiler_options.py
+++ b/axlearn/common/compiler_options.py
@@ -31,7 +31,7 @@ def default_xla_options(
     if backend != "tpu":
         raise NotImplementedError(backend)
     version = infer_tpu_version(infer_tpu_type(instance_type))
-    options: Dict[str, Union[int, str, bool]] = dict(
+    options: Dict[str, Union[str, bool, int]] = dict(
         xla_tpu_spmd_rng_bit_generator_unsafe=True,  # SPMD partition-aware RngBitGenerator.
         xla_tpu_enable_latency_hiding_scheduler="true",  # Try to schedule ops efficiently.
         xla_tpu_perform_spmd_cse_prevention="false",

--- a/axlearn/common/compiler_options.py
+++ b/axlearn/common/compiler_options.py
@@ -51,30 +51,8 @@ def default_xla_options(
             # further if you see "Allocator failed to allocate". A feature
             # to dynamically allocate may come later: b/380514965
             megascale_grpc_premap_memory_bytes=17179869184,
-            # Improved performance for v6e.
-            xla_tpu_scoped_vmem_limit_kib=98304,
-            xla_tpu_enable_async_collective_fusion="true",
-            xla_tpu_enable_async_collective_fusion_fuse_all_gather="true",
-            xla_tpu_enable_async_collective_fusion_multiple_steps="true",
-            xla_tpu_overlap_compute_collective_tc="true",
-            xla_enable_async_all_gather="true",
-            # Host offloading flags
-            xla_tpu_enable_all_experimental_scheduler_features="true",
-            # Flag to enable memory tracking scheduling. The default AUTO only enables
-            # it in some situations. Not needed if
-            # xla_tpu_enable_all_experimental_scheduler_features is set to true already.
-            xla_tpu_enable_scheduler_memory_pressure_tracking="true",
             # Flag controlling the maximum number of overlapping host offloadings.
             xla_tpu_host_transfer_overlap_limit=24,
-            # Flag to enable the aggressive removal of opt-barriers.
-            xla_tpu_aggressive_opt_barrier_removal="true",
-            # Flag to enable more aggressive scheduling for async ops, such as pushing
-            # the async start to the beginning of the loop body.
-            xla_lhs_prioritize_async_depth_over_stall="true",
-            # Flag to enable pipelining of cross-DCN all-gathers.
-            xla_tpu_enable_ag_backward_pipelining="true",
-            xla_should_allow_loop_variant_parameter_in_chain="true",
-            xla_should_add_loop_invariant_op_in_chain="true",
             # Flag controlling the maximum number of overlapping cross-DCN send/recv.
             xla_max_concurrent_host_send_recv=100,
             # Flag controlling the HBM memory limit as a percentage of the total HBM size.
@@ -92,6 +70,31 @@ def default_xla_options(
             # though, may make the scheduler weighting too much on the memory usage instead
             # of latency side.
             xla_latency_hiding_scheduler_rerun=2,
+            # Improved performance for v6e.
+            xla_tpu_scoped_vmem_limit_kib=98304,
+        )
+        options.update(
+            # Improved performance for v6e.
+            xla_tpu_enable_async_collective_fusion="true",
+            xla_tpu_enable_async_collective_fusion_fuse_all_gather="true",
+            xla_tpu_enable_async_collective_fusion_multiple_steps="true",
+            xla_tpu_overlap_compute_collective_tc="true",
+            xla_enable_async_all_gather="true",
+            # Host offloading flags
+            xla_tpu_enable_all_experimental_scheduler_features="true",
+            # Flag to enable memory tracking scheduling. The default AUTO only enables
+            # it in some situations. Not needed if
+            # xla_tpu_enable_all_experimental_scheduler_features is set to true already.
+            xla_tpu_enable_scheduler_memory_pressure_tracking="true",
+            # Flag to enable the aggressive removal of opt-barriers.
+            xla_tpu_aggressive_opt_barrier_removal="true",
+            # Flag to enable more aggressive scheduling for async ops, such as pushing
+            # the async start to the beginning of the loop body.
+            xla_lhs_prioritize_async_depth_over_stall="true",
+            # Flag to enable pipelining of cross-DCN all-gathers.
+            xla_tpu_enable_ag_backward_pipelining="true",
+            xla_should_allow_loop_variant_parameter_in_chain="true",
+            xla_should_add_loop_invariant_op_in_chain="true",
             xla_tpu_use_enhanced_launch_barrier="true",
             # Sparsecore offloading for all reduce.
             # Uncomment below flags to enable it.


### PR DESCRIPTION
This is to fix the issue in https://github.com/apple/axlearn/pull/887/files#r1882934115

```
I1212 21:41:11.645763 132689403348992 launch.py:112] LIBTPU_INIT_ARGS='--xla_tpu_spmd_rng_bit_generator_unsafe=1 --xla_tpu_enable_latency_hiding_scheduler=true --xla_tpu_perform_spmd_cse_prevention=false --megascale_grpc_premap_memory_bytes=17179869184 --xla_tpu_scoped_vmem_limit_kib=98304 --xla_tpu_enable_async_collective_fusion=1 --xla_tpu_enable_async_collective_fusion_fuse_all_gather=1 --xla_tpu_enable_async_collective_fusion_multiple_steps=1 --xla_tpu_overlap_compute_collective_tc=1 --xla_enable_async_all_gather=1 --xla_tpu_enable_all_experimental_scheduler_features=1 --xla_tpu_enable_scheduler_memory_pressure_tracking=1 --xla_tpu_host_transfer_overlap_limit=24 --xla_tpu_aggressive_opt_barrier_removal=1 --xla_lhs_prioritize_async_depth_over_stall=1 --xla_tpu_enable_ag_backward_pipelining=1 --xla_should_allow_loop_variant_parameter_in_chain=1 --xla_should_add_loop_invariant_op_in_chain=1 --xla_max_concurrent_host_send_recv=100 --xla_tpu_scheduler_percent_shared_memory_limit=90 --xla_latency_hiding_scheduler_rerun=2 --xla_tpu_use_enhanced_launch_barrier=1'
2024-12-12 21:41:14.669321: I external/tsl/tsl/platform/default/grpc_credentials.cc:30] gRPC insecure client credentials are used.
I1212 21:41:14.670917 132689403348992 distributed.py:119] Connecting to JAX distributed service on ethanli-fuji-70b-v2-test1-job-0-0.ethanli-fuji-70b-v2-test1:8476
2024-12-12 21:41:14.999583: I external/xla/xla/pjrt/distributed/client.cc:135] Connected to distributed JAX controller
ERROR: Illegal value '1' specified for flag 'xla_tpu_enable_async_collective_fusion_fuse_all_gather'; expected one of true/enabled, false/disabled or auto
ERROR: Illegal value '1' specified for flag 'xla_enable_async_all_gather'; expected one of true/enabled, false/disabled or auto
ERROR: Illegal value '1' specified for flag 'xla_tpu_enable_scheduler_memory_pressure_tracking'; expected one of true/enabled, false/disabled or auto
ERROR: Illegal value '1' specified for flag 'xla_tpu_aggressive_opt_barrier_removal'; expected one of true/enabled, false/disabled or auto
ERROR: Illegal value '1' specified for flag 'xla_lhs_prioritize_async_depth_over_stall'; expected one of true/enabled, false/disabled or auto
ERROR: Illegal value '1' specified for flag 'xla_should_allow_loop_variant_parameter_in_chain'; expected one of true/enabled, false/disabled or auto
ERROR: Illegal value '1' specified for flag 'xla_should_add_loop_invariant_op_in_chain'; expected one of true/enabled, false/disabled or auto

```


It worked after this PR
```
I1212 22:10:21.491460 134459869403136 launch.py:112] LIBTPU_INIT_ARGS='--xla_tpu_spmd_rng_bit_generator_unsafe=1 --xla_tpu_enable_latency_hiding_scheduler=true --xla_tpu_perform_spmd_cse_prevention=false --megascale_grpc_premap_memory_bytes=17179869184 --xla_tpu_scoped_vmem_limit_kib=98304 --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --xla_tpu_enable_all_experimental_scheduler_features=true --xla_tpu_enable_scheduler_memory_pressure_tracking=true --xla_tpu_host_transfer_overlap_limit=24 --xla_tpu_aggressive_opt_barrier_removal=true --xla_lhs_prioritize_async_depth_over_stall=true --xla_tpu_enable_ag_backward_pipelining=true --xla_should_allow_loop_variant_parameter_in_chain=true --xla_should_add_loop_invariant_op_in_chain=true --xla_max_concurrent_host_send_recv=100 --xla_tpu_scheduler_percent_shared_memory_limit=90 --xla_latency_hiding_scheduler_rerun=2 --xla_tpu_use_enhanced_launch_barrier=true'
2024-12-12 22:10:21.494834: I external/xla/xla/tsl/platform/default/grpc_credentials.cc:30] gRPC insecure client credentials are used.
INFO:2024-12-12 22:10:21,497:jax._src.distributed:138: Connecting to JAX distributed service on ethantest-2024121214-job-0-0.ethantest-2024121214:8476
I1212 22:10:21.497929 134459869403136 distributed.py:138] Connecting to JAX distributed service on ethantest-2024121214-job-0-0.ethantest-2024121214:8476
2024-12-12 22:11:08.400685: I external/xla/xla/pjrt/distributed/client.cc:118] Connected to distributed JAX controller
...
I1212 22:11:20.128365 134459869403136 trainer.py:356] imagenet_trainer process   0 step       -1] Global mesh: Mesh('data': 16, 'model': 1)
```