### PR TITLE
use "true" and "false" instead of 0 and 1

### DIFF
--- a/axlearn/common/compiler_options.py
+++ b/axlearn/common/compiler_options.py
@@ -138,7 +138,7 @@ def xla_flags_from_options(xla_options: dict[str, Union[str, bool, int]]) -> str
     flags = []
     for k, v in xla_options.items():
         if isinstance(v, bool):
-            v = "1" if v else "0"
+            v = "true" if v else "false"
         flags.append(f"--{k}={v}")
     return " ".join(flags)
 


### PR DESCRIPTION
Jax/XLA seem to expect true and false strings instead of using 0 and 1.