### PR TITLE
Remove version pin of typing-extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ core = [
     "tensorflow_text==2.16.1; platform_machine == 'x86_64'", # implied by seqio, but also used directly for text processing
     "tensorstore>=0.1.63",  # used for supporting GDA checkpoints
     "toml",  # for config management
-    "typing-extensions==4.11.0",
+    "typing-extensions",
     "scipy==1.12.0",  # to avoid "module 'scipy.linalg' has no attribute 'tril'"
     "seqio==0.0.18",  # used for inputs
     "aqtp==0.8.1", # Updated from 0.4.0; compatible with Python 3.10


### PR DESCRIPTION
The pinned version is pretty old. When I am using a modern pydantic, it complains the need of a newer version of typing-extentions.

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
pydantic 2.10.1 requires typing-extensions>=4.12.2, but you have typing-extensions 4.11.0 which is incompatible.
```