### PR TITLE
`AdaptiveLayerNormModulation` now supports sequence conditions.

### DIFF
--- a/axlearn/common/dit.py
+++ b/axlearn/common/dit.py
@@ -211,16 +211,16 @@ class AdaptiveLayerNormModulation(BaseLayer):
         """Generate the parameters for modulation.
 
         Args:
-            input: A tensor with shape [batch_size, dim].
+            input: A tensor with shape [batch_size, ..., dim].
 
         Returns:
             A list of tensors with length num_outputs.
-                Each tensor has shape [batch_size, dim].
+                Each tensor has shape [batch_size, ..., dim].
         """
         cfg = self.config
         x = get_activation_fn(cfg.activation)(input)
         output = self.linear(x)
-        output = jnp.split(output, cfg.num_outputs, axis=1)
+        output = jnp.split(output, cfg.num_outputs, axis=-1)
         return output
 
 


### PR DESCRIPTION
When using seq2seq models with DiT, the condition may have the same sequence length as the input.
For example:
- Input shape: `[batch, seq_len, dim]`
- Condition shape: `[batch, seq_len, cond_dim]`

The module has been modified to support such cases as well.