### PR TITLE
The codebook of the KmeansVectorQuantizer should be initialized with scale=1/sqrt(dim).

### DIFF
--- a/axlearn/common/quantizer.py
+++ b/axlearn/common/quantizer.py
@@ -432,14 +432,13 @@ class KmeansVectorQuantizer(BaseQuantizer):
     @classmethod
     def default_config(cls) -> Config:
         cfg: KmeansVectorQuantizer.Config = super().default_config()
-        # Fairseq uses Gaussian initialization with std=0.01.
-        # https://github.com/facebookresearch/fairseq/blob/d871f6169f8185837d1c11fb28da56abfd83841c/fairseq/modules/kmeans_vector_quantizer.py#L42
-        # Praxis uses uniform initialization with fan_in.
-        # https://github.com/google/praxis/blob/179774fb688aa8fe048307d2184c9f2b338e935f/praxis/layers/quantizer.py#L378
+        # The original VQ-VAE implementation initializes codebook by uniform(1/sqrt(dim)).
+        # https://github.com/google-deepmind/sonnet/blob/cd5b5fa48e15e4d020f744968f5209949ebe750f/sonnet/python/modules/nets/vqvae.py#L62C24-L64
+        # Note: fan_out of the codebook is `num_codebooks * codebook_dim`.
         cfg.param_init = DefaultInitializer.default_config().set(
             init_by_param_name={
                 ".*codebook$": WeightInitializer.default_config().set(
-                    scale=1.0, fan="fan_in", distribution="uniform"
+                    scale=1.0, fan="fan_out", distribution="uniform"
                 )
             }
         )


### PR DESCRIPTION
The initialization of the embedding tensor [num_classes, dim] is usually scale=1/sqrt(dim). However, curretnly KmeansVectorQuantizer initializes codebook by 1/sqrt(num_classes).

As a counter example, the embedding in axlearn is also initialized with 1/sqrt(dim). https://github.com/apple/axlearn/blob/3433f249de5c829c0f6dec4bac8e6652b248bca0/axlearn/common/layers.py#L811-L827

Note: axlearn default fan_in_axis=-2 and fan_out_axis=-1. https://github.com/apple/axlearn/blob/3433f249de5c829c0f6dec4bac8e6652b248bca0/axlearn/common/base_layer.py#L532

Reference: Original VQ-VAE implementation, which init by 1/sqrt(dim). https://github.com/google-deepmind/sonnet/blob/cd5b5fa48e15e4d020f744968f5209949ebe750f/sonnet/python/modules/nets/vqvae.py#L62C24-L64

In above tf code, tf.uniform_unit_scaling_initializer takes `dim = W.shape[0]` to init. https://www.tensorflow.org/api_docs/python/tf/compat/v1/uniform_unit_scaling_initializer

Noteworthy, the reason the VQ initialization code has been incorrect is that we referred to an incorrect praxis code from the beginning. praxis codebase is abandoned.