### PR TITLE
Allow parallel gpu tests

### DIFF
--- a/axlearn/common/flash_attention/conftest.py
+++ b/axlearn/common/flash_attention/conftest.py
@@ -1,0 +1,14 @@
+# Copyright © 2024 Apple Inc.
+
+"""Configures pytest to distribute tests to multiple GPUs.
+
+Usage on 8 GPU machines: PARALLEL_GPU_TEST=1 pytest -n 8 gpu_attention_test.py
+"""
+import os
+
+
+def pytest_configure(_):
+    if "PARALLEL_GPU_TEST" not in os.environ:
+        return
+    worker_id = os.getenv("PYTEST_XDIST_WORKER", "gw0")
+    os.environ["CUDA_VISIBLE_DEVICES"] = worker_id.lstrip("gw")

--- a/axlearn/common/flash_attention/conftest.py
+++ b/axlearn/common/flash_attention/conftest.py
@@ -7,7 +7,8 @@ Usage on 8 GPU machines: PARALLEL_GPU_TEST=1 pytest -n 8 gpu_attention_test.py
 import os
 
 
-def pytest_configure(_):
+# pylint: disable-next=unused-argument
+def pytest_configure(config):
     if "PARALLEL_GPU_TEST" not in os.environ:
         return
     worker_id = os.getenv("PYTEST_XDIST_WORKER", "gw0")

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,11 @@
 
 """Configures pytest to distribute tests to multiple GPUs.
 
-Usage on 8 GPU machines: PARALLEL_GPU_TEST=1 pytest -n 8 gpu_attention_test.py
+This is not enabled by default and requires explicit opt-in by setting the environment variable
+PARALLEL_GPU_TEST. This is because not all GPU tests are single-GPU tests.
+
+Example usage on 8 GPU machines:
+PARALLEL_GPU_TEST=1 pytest -n 8 axlearn/common/flash_attention/gpu_attention_test.py
 """
 import os
 


### PR DESCRIPTION
Configures pytest to distribute tests to multiple GPUs.

This is not enabled by default and requires explicit opt-in by setting the environment variable
PARALLEL_GPU_TEST. This is because not all GPU tests are single-GPU tests.

Example usage on 8 GPU machines:
```
PARALLEL_GPU_TEST=1 pytest -n 8 axlearn/common/flash_attention/gpu_attention_test.py
```