### PR TITLE
Cache AoT compilation result

### DIFF
--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -202,9 +202,9 @@ class SpmdTrainer(Module):
 
         # If True, assumes the train_step may need to be recompiled and go through the lowering
         # and compilation process every train step and rely on compilation cache to prevent
-        # excessive recompilations. Note: this could introduce overhead during the pre-compilation
-        # stage (such as sharding check) that increases the step time for some models. Note that
-        # this cache is always disable when at steps when xsc is enabled.
+        # excessive recompilations. Note: this could introduce overhead to training due to
+        # pre-compilation checks (such as sharding check) that increases the step time for some
+        # models. Note that this cache is always disabled at steps when xsc is enabled.
         disable_python_train_step_cache: Optional[bool] = None
 
     def __init__(

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -206,7 +206,7 @@ class SpmdTrainer(Module):
         # pre-compilation checks (such as sharding check) that increases the step time for some
         # models. Note that this cache is always disabled at steps when xsc is enabled.
         # Defaults to None which is interpreted as True.
-        cache_python_train_step: Optional[bool] = None
+        cache_compiled_train_step: Optional[bool] = None
 
     def __init__(
         self,
@@ -974,7 +974,7 @@ class SpmdTrainer(Module):
         """Build a fully compiled train step function.
 
         Relies on the JAX pjit cache to avoid recompilation when with_xsc=True or
-        cache_python_train_step=False.
+        cache_compiled_train_step=False.
 
         Args:
             train_state: A TrainerState instance.
@@ -988,7 +988,7 @@ class SpmdTrainer(Module):
             RuntimeError: If `with_xsc` is requested on heterogenous device kinds.
         """
         if (
-            not (self.config.cache_python_train_step is False)
+            not (self.config.cache_compiled_train_step is False)
             and not with_xsc
             and self._compiled_train_step is not None
         ):

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -279,8 +279,6 @@ class SpmdTrainer(Module):
                     "xsc_check_policy was set for non-TPU XLA backend. Running without XSC."
                 )
             else:
-                if cfg.cache_python_train_step is True:
-                    raise ValueError("cache_python_train_step cannot be True when xsc is enabled.")
                 xsc_check_policy = maybe_instantiate(cfg.xsc_check_policy)
         self._xsc_check_policy: Optional[Callable[[int], bool]] = xsc_check_policy
         self._compiled_train_step: Optional[jax.stages.Compiled] = None

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -488,7 +488,7 @@ class TrainerTest(test_utils.TestCase):
         cfg.vlog = 2
         # Set XSC policy.
         cfg.xsc_check_policy = lambda step: (step in [7, 8])
-        cfg.enable_python_train_step_cache = enable_python_cache
+        cfg.cache_python_train_step = enable_python_cache
 
         # Test training run.
         trainer: SpmdTrainer = cfg.set(max_step=12).instantiate(parent=None)

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -488,7 +488,7 @@ class TrainerTest(test_utils.TestCase):
         cfg.vlog = 2
         # Set XSC policy.
         cfg.xsc_check_policy = lambda step: (step in [7, 8])
-        cfg.cache_python_train_step = enable_python_cache
+        cfg.cache_compiled_train_step = enable_python_cache
 
         # Test training run.
         trainer: SpmdTrainer = cfg.set(max_step=12).instantiate(parent=None)

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -452,20 +452,23 @@ class TrainerTest(test_utils.TestCase):
         # The prng_key per step is deterministic.
         np.testing.assert_array_equal(output_a["aux"]["prng_key"], output_b["aux"]["prng_key"])
 
-    @parameterized.parameters(
-        {"platform": "cpu", "mesh_shape": (1, 1)},
-        {"platform": "tpu", "mesh_shape": (4, 1)},
+    @parameterized.product(
+        [{"platform": "cpu", "mesh_shape": (1, 1)}, {"platform": "tpu", "mesh_shape": (4, 1)}],
+        disable_python_cache=[True, False],
     )
     # pylint: enable=duplicate-code
-    def test_xsc_check_policy(
+    def test_xsc_check_policy_and_compilation_cache(
         self,
         *,
         platform,
         mesh_shape,
+        disable_python_cache,
     ):
         if not test_utils.is_supported_platform(platform):
             return
-        cfg = SpmdTrainer.default_config().set(name="test_trainer", train_dtype=jnp.bfloat16)
+        cfg: SpmdTrainer.Config = SpmdTrainer.default_config().set(
+            name="test_trainer", train_dtype=jnp.bfloat16
+        )
         cfg.dir = tempfile.mkdtemp()
         cfg.mesh_axis_names = ("data", "model")
         cfg.mesh_shape = mesh_shape
@@ -485,6 +488,7 @@ class TrainerTest(test_utils.TestCase):
         cfg.vlog = 2
         # Set XSC policy.
         cfg.xsc_check_policy = lambda step: (step in [7, 8])
+        cfg.disable_python_train_step_cache = disable_python_cache
 
         # Test training run.
         trainer: SpmdTrainer = cfg.set(max_step=12).instantiate(parent=None)
@@ -508,13 +512,25 @@ class TrainerTest(test_utils.TestCase):
             output_a = trainer.run(prng_key=jax.random.PRNGKey(123))
             end_cache_hits = pjit_lib._pjit_lower_cached.cache_info().hits
             # pylint: enable=protected-access
-            # We expect to have hit the lowering cache on all but one step.
-            self.assertEqual(end_cache_hits - start_cache_hits, cfg.max_step - 1)
-            self.assertEqual(mocked_compile_fn.call_count, cfg.max_step)
             if platform == "tpu":
+                if disable_python_cache:
+                    # We expect to have hit the lowering cache on all but one step.
+                    self.assertEqual(end_cache_hits - start_cache_hits, cfg.max_step - 1)
+                    self.assertEqual(mocked_compile_fn.call_count, cfg.max_step)
+                else:
+                    # We expect to have hit the lowering cache on xsc steps.
+                    self.assertEqual(end_cache_hits - start_cache_hits, 2)
+                    self.assertEqual(mocked_compile_fn.call_count, 3)
                 # Should have been called with compile options on two steps.
                 self.assertEqual(compiled_with_options_call_count[0], 2)
             else:
+                if disable_python_cache:
+                    self.assertEqual(end_cache_hits - start_cache_hits, cfg.max_step - 1)
+                    self.assertEqual(mocked_compile_fn.call_count, cfg.max_step)
+                else:
+                    # We won't hit any cache since we have python cache.
+                    self.assertEqual(end_cache_hits - start_cache_hits, 0)
+                    self.assertEqual(mocked_compile_fn.call_count, 1)
                 # XSC check should be disabled.
                 self.assertEqual(compiled_with_options_call_count[0], 0)
 


### PR DESCRIPTION
This improves the step time of some models on v6e by 2x. See the comments of `cache_compiled_train_step `.