### PR TITLE
Add prefill hidden states as module outputs.

### DIFF
--- a/axlearn/common/decoder.py
+++ b/axlearn/common/decoder.py
@@ -659,6 +659,7 @@ class Decoder(BaseLayer):
             ),
             **kwargs,
         )
+        self.add_module_output("prefill_hidden_states", outputs["hidden_states"])
         states = dict(time_step=time_step, input_ids=input_ids, **states)
         return states, outputs
 

--- a/axlearn/common/decoder_test.py
+++ b/axlearn/common/decoder_test.py
@@ -613,8 +613,14 @@ class TestDecoder(TestCase):
                     side_effect=mock_tokens_to_scores,
                 )
 
+            # Drop any module outputs added in `method` to avoid leaking tracers via checkify.
+            def method_fn(*args, **kwargs):
+                out = getattr(decoder, method)(*args, **kwargs)
+                decoder.get_invocation_context().get_module_outputs().clear()
+                return out
+
             # Checkify the decoding method being called.
-            decoder._checked_method = checkify.checkify(getattr(decoder, method))
+            decoder._checked_method = checkify.checkify(method_fn)
 
             # pylint: enable=protected-access
             with mock_ctx:


### PR DESCRIPTION
Some use cases involve reusing hidden states from the decoding prefix. cc @kevinye0108