### PR TITLE
Repeat KV heads in Flash Attention

### DIFF
--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -115,7 +115,11 @@ class FlashAttention(GroupedQueryAttention):
         """Repeats key or value heads dim to be shardable."""
         partition_spec = self.config.mha_dim_to_partition_spec["bsnh"]
         global_mesh = thread_resources.env.physical_mesh
-        if partition_spec == PartitionSpec(None) or partition_spec[2] is None:
+        if (
+            partition_spec == PartitionSpec(None)
+            or len(partition_spec) < 3
+            or partition_spec[2] is None
+        ):
             return key_or_value
 
         axis = partition_spec[2]

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -110,6 +110,16 @@ class FlashAttention(GroupedQueryAttention):
         cfg = self.config
         return attention_logit_biases.partition_spec(cfg.mha_dim_to_partition_spec)
 
+    def _repeat_kv_heads(self, key_or_value: Tensor) -> Tensor:
+        """Repeats key or value heads dim to match the query.
+        TODO(dhwang2): optimize computation like GroupedQueryAttention.
+        """
+        num_head_repeats = self.config.num_heads // key_or_value.shape[-2]
+        if num_head_repeats == 1:
+            return key_or_value
+        # Repeat along the num_heads dim: [batch, source_length, num_heads, per_head_dim].
+        return jnp.repeat(key_or_value, num_head_repeats, axis=-2)
+
     def _compute_attention(
         self,
         *,
@@ -120,6 +130,10 @@ class FlashAttention(GroupedQueryAttention):
     ) -> tuple[Tensor, Tensor]:
         cfg: FlashAttention.Config = self.config
         backend = self._backend()
+
+        # Repeats key/value heads dim if necessary.
+        k_proj = self._repeat_kv_heads(k_proj)
+        v_proj = self._repeat_kv_heads(v_proj)
 
         batch, target_len, num_heads, _ = q_proj.shape
         _, source_len, _, _ = k_proj.shape
@@ -155,9 +169,8 @@ class FlashAttention(GroupedQueryAttention):
             in_specs=(
                 # Q [batch_size, seq_len, num_heads, per_head_dim].
                 cfg.mha_dim_to_partition_spec["btnh"],
-                # KV [batch_size, seq_len, num_kv_heads, per_head_dim].
-                # Note: while num_kv_heads can be different from num_heads, their partition spec
-                # should be the same.
+                # KV [batch_size, seq_len, num_heads, per_head_dim].
+                # TODO(hanzhi713, changlan): Do not repeat kv heads and shard properly.
                 cfg.mha_dim_to_partition_spec["bsnh"],
                 cfg.mha_dim_to_partition_spec["bsnh"],
                 # Bias that can broadcast to [batch_size, num_heads, seq_len, seq_len].

--- a/axlearn/common/flash_attention/layer_test.py
+++ b/axlearn/common/flash_attention/layer_test.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 """Tests FlashAttention layers."""
+
 # pylint: disable=ungrouped-imports
 import math
 import os
@@ -24,7 +25,7 @@ from absl.testing import parameterized
 from jax.experimental import mesh_utils
 from jax.sharding import Mesh
 
-from axlearn.common.attention import Dropout, GroupedQueryAttention
+from axlearn.common.attention import Dropout, GroupedQKVLinear, GroupedQueryAttention, QKVLinear
 from axlearn.common.attention_bias import (
     CompositeAttentionBias,
     SegmentIdAttentionBias,
@@ -92,6 +93,7 @@ def _fake_inputs(
 def _prepare_layers(
     *,
     num_heads,
+    num_kv_heads,
     per_head_dim,
     mesh_axis_names,
     causal,
@@ -108,6 +110,9 @@ def _prepare_layers(
         num_heads=num_heads,
         dtype=jnp.bfloat16,
         dropout=Dropout.default_config().set(rate=dropout_rate),
+        input_linear=GroupedQKVLinear.default_config().set(num_kv_heads=num_kv_heads)
+        if num_kv_heads is not None
+        else QKVLinear.default_config(),
     )
     ref_cfg = GroupedQueryAttention.default_config().set(**kwargs)
 
@@ -180,6 +185,16 @@ class TestFlashAttention(TestCase):
             batch=2,
             seq_len=384,
             num_heads=4,
+            num_kv_heads=None,
+            per_head_dim=32,
+            mesh=(1, 1),
+            mesh_axis_names=("data", "model"),
+        ),
+        dict(
+            batch=2,
+            seq_len=384,
+            num_heads=4,
+            num_kv_heads=1,
             per_head_dim=32,
             mesh=(1, 1),
             mesh_axis_names=("data", "model"),
@@ -188,6 +203,7 @@ class TestFlashAttention(TestCase):
             batch=2,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(1, 1),
             mesh_axis_names=("data", "model"),
@@ -196,6 +212,7 @@ class TestFlashAttention(TestCase):
             batch=2,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(1, 1),
             mesh_axis_names=("data", "fsdp"),
@@ -204,6 +221,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(2, 2),
             mesh_axis_names=("data", "fsdp"),
@@ -212,6 +230,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(8, 1),
             mesh_axis_names=("data", "model"),
@@ -220,6 +239,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(4, 1),
             mesh_axis_names=("data", "model"),
@@ -228,6 +248,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(2, 2),
             mesh_axis_names=("data", "model"),
@@ -236,6 +257,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=128,
             mesh=(2, 2),
             mesh_axis_names=("data", "model"),
@@ -244,6 +266,16 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=2,
+            per_head_dim=128,
+            mesh=(1, 4),
+            mesh_axis_names=("data", "model"),
+        ),
+        dict(
+            batch=8,
+            seq_len=2048,
+            num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(1, 1, 8, 1),
             mesh_axis_names=("data", "expert", "fsdp", "model"),
@@ -252,6 +284,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(1, 1, 4, 1),
             mesh_axis_names=("data", "expert", "fsdp", "model"),
@@ -260,6 +293,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(1, 1, 8),
             mesh_axis_names=("data", "expert", "fsdp"),
@@ -268,6 +302,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(1, 1, 4),
             mesh_axis_names=("data", "expert", "fsdp"),
@@ -276,6 +311,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(1, 2, 4, 1),
             mesh_axis_names=("data", "expert", "fsdp", "model"),
@@ -284,6 +320,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(1, 2, 2, 1),
             mesh_axis_names=("data", "expert", "fsdp", "model"),
@@ -292,6 +329,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(1, 1, 2, 2),
             mesh_axis_names=("data", "expert", "fsdp", "model"),
@@ -300,6 +338,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(1, 2, 1, 2, 1),
             mesh_axis_names=("data", "seq", "expert", "fsdp", "model"),
@@ -308,6 +347,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=64,
             mesh=(1, 2, 2, 2),
             mesh_axis_names=("data", "expert", "fsdp", "model"),
@@ -316,6 +356,7 @@ class TestFlashAttention(TestCase):
             batch=8,
             seq_len=2048,
             num_heads=4,
+            num_kv_heads=None,
             per_head_dim=128,
             mesh=(1, 2, 1, 2, 2),
             mesh_axis_names=("data", "seq", "expert", "fsdp", "model"),
@@ -338,20 +379,66 @@ class TestFlashAttention(TestCase):
                 dropout=OtherDropout.default_config(), **required_kwargs
             ).instantiate(parent=None)
 
-    @parameterized.parameters(
-        [kwargs for kwargs in _TEST_CONFIGS if math.prod(kwargs["mesh"]) == 1]
-    )
-    def test_backend(self, batch, seq_len, num_heads, per_head_dim, mesh, mesh_axis_names):
-        del batch, seq_len
-        mock_device = mock.Mock(spec=jax.Device)
-        mock_device.platform = "tpu"
-        mock_device.coords = (0, 0, 0)
-        mock_device.core_on_chip = 0
-        devices = [mock_device]
+    def test_gqa_kv_heads(self):
+        """Tests _maybe_repeat_kv_heads."""
+        batch_size = 8
+        num_heads = 8
+        num_kv_heads = 4
+        seq_len = 2048
+        per_head_dim = 128
 
+        hidden_dim = num_heads * per_head_dim
+
+        mesh = (1, 8)
+        mesh_axis_names = ("data", "model")
+        devices = [
+            mock.Mock(spec=jax.Device, platform="tpu", coords=(0, 0, i), core_on_chip=0)
+            for i in range(math.prod(mesh))
+        ]
         with Mesh(mesh_utils.create_device_mesh(mesh, devices), mesh_axis_names):
+            kwargs = dict(
+                query_dim=hidden_dim,
+                key_dim=hidden_dim,
+                value_dim=hidden_dim,
+                num_heads=num_heads,
+                dtype=jnp.bfloat16,
+                input_linear=GroupedQKVLinear.default_config().set(num_kv_heads=num_kv_heads)
+                if num_kv_heads is not None
+                else QKVLinear.default_config(),
+                mha_dim_to_partition_spec={
+                    "btnh": PartitionSpec("data", None, "model", None),
+                    "bsnh": PartitionSpec("data", None, "model", None),
+                    "bnts": PartitionSpec("data", None, "model", None),
+                },
+            )
+            cfg = FlashAttention.default_config().set(**kwargs)
+            layer = cfg.set(name="test").instantiate(parent=None)
+
+            kv = jnp.zeros((batch_size, seq_len, num_kv_heads, per_head_dim))
+            repeated = layer._maybe_repeat_kv_heads(kv)  # pylint: disable=protected-access
+            self.assertEqual(repeated.shape[2], 8)
+
+    @parameterized.parameters(_TEST_CONFIGS)
+    def test_backend(
+        self, batch, seq_len, num_heads, num_kv_heads, per_head_dim, mesh, mesh_axis_names
+    ):
+        del batch, seq_len
+        devices = [
+            mock.Mock(spec=jax.Device, platform="tpu", coords=(0, 0, i), core_on_chip=0)
+            for i in range(math.prod(mesh))
+        ]
+
+        with Mesh(
+            mesh_utils.create_device_mesh(
+                mesh,
+                devices,
+                allow_split_physical_axes=True,
+            ),
+            mesh_axis_names,
+        ):
             test_layer, _, _, _ = _prepare_layers(
                 num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
                 per_head_dim=per_head_dim,
                 mesh_axis_names=mesh_axis_names,
                 causal=True,
@@ -361,7 +448,9 @@ class TestFlashAttention(TestCase):
             self.assertEqual(backend, "tpu")
 
     @parameterized.parameters(_TEST_CONFIGS)
-    def test_shard_biases(self, batch, seq_len, num_heads, per_head_dim, mesh, mesh_axis_names):
+    def test_shard_biases(
+        self, batch, seq_len, num_heads, num_kv_heads, per_head_dim, mesh, mesh_axis_names
+    ):
         if not is_supported_mesh_shape(mesh):
             pytest.skip(reason=f"Unsupported mesh {mesh}.")
 
@@ -377,6 +466,7 @@ class TestFlashAttention(TestCase):
         with Mesh(mesh_utils.create_device_mesh(mesh), mesh_axis_names):
             test_layer, _, _, _ = _prepare_layers(
                 num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
                 per_head_dim=per_head_dim,
                 mesh_axis_names=mesh_axis_names,
                 causal=True,
@@ -424,6 +514,7 @@ class TestFlashAttention(TestCase):
         batch,
         seq_len,
         num_heads,
+        num_kv_heads,
         per_head_dim,
         mesh,
         mesh_axis_names,
@@ -453,6 +544,7 @@ class TestFlashAttention(TestCase):
         with Mesh(mesh_utils.create_device_mesh(mesh), mesh_axis_names):
             test_layer, ref_layer, params, hidden_dim = _prepare_layers(
                 num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
                 per_head_dim=per_head_dim,
                 mesh_axis_names=mesh_axis_names,
                 causal=causal,
@@ -509,6 +601,7 @@ class TestFlashAttention(TestCase):
         batch,
         seq_len,
         num_heads,
+        num_kv_heads,
         per_head_dim,
         mesh,
         mesh_axis_names,
@@ -555,6 +648,9 @@ class TestFlashAttention(TestCase):
                 causal=causal and (mask_fn is None),
                 mask=mask_fn,
                 dropout=Dropout.default_config().set(rate=dropout_rate),
+                input_linear=GroupedQKVLinear.default_config().set(num_kv_heads=num_kv_heads)
+                if num_kv_heads is not None
+                else QKVLinear.default_config(),
             )
             ref_cfg = DummyModel.default_config().set(
                 layer=GroupedQueryAttention.default_config().set(**kwargs),
@@ -608,6 +704,9 @@ class TestFlashAttention(TestCase):
             # pylint: disable-next=protected-access
             elif dropout_rate > 0.0 and test_layer.layer._backend() == "gpu":
                 atol, rtol = 2.5e-4, 1e-3
+            # pylint: disable-next=protected-access
+            elif num_kv_heads and test_layer.layer._backend() == "cpu":
+                atol, rtol = 1e-4, 1e-2
             # Can be 1e-5 on x86_64/GPU/TPU, needed to be slightly higher on ARM.
             else:
                 atol, rtol = 1e-4, 1e-3
@@ -627,6 +726,7 @@ class TestFlashAttention(TestCase):
         batch,
         seq_len,
         num_heads,
+        num_kv_heads,
         per_head_dim,
         mesh,
         mesh_axis_names,
@@ -655,6 +755,7 @@ class TestFlashAttention(TestCase):
         with Mesh(mesh_utils.create_device_mesh(mesh), mesh_axis_names):
             test_layer, ref_layer, params, hidden_dim = _prepare_layers(
                 num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
                 per_head_dim=per_head_dim,
                 mesh_axis_names=mesh_axis_names,
                 causal=causal,

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -277,7 +277,7 @@ def check_tpu_splash_attention(
     head_dim = query.shape[3]
 
     if has_bias:
-        return False  # SplashAttention does not support specifying a bias.
+        raise SplashAttentionUnsupportedError("SplashAttention does not support specifying a bias.")
     with jax.ensure_compile_time_eval():
         if jnp.any(
             jnp.asarray([target_len, source_len, head_dim]) % splash_attention_kernel.NUM_LANES != 0


### PR DESCRIPTION
Recent PRs removed `_repeat_kv_heads` from Flash Attention for GQA optimization to reduce HBM footprint. However the actual HBM gain would be limited in the model-parallel setting, as the heads are already sharded across devices. It also introduces additional limitation which breaks some of the existing sharding configurations.

For example, let's say num_heads = 8 and num_kv_heads = 4. When we repeat KV heads, we can set the model axis as 8 so that each device will have only one Q, K, V head; Without repeat_kv_heads, the max value of model axis is 4, and each device will have 2 Q heads as a result, increasing the actual HBM usage per device.

To address this issue, we repeat the kv heads to the extent where the heads can be sharded across the model axis in the mesh.