### PR TITLE
Some fixes for flash remat

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -111,6 +111,7 @@ from axlearn.common.config import (
     config_for_function,
     maybe_instantiate,
 )
+from axlearn.common.flash_attention.remat import FLASH_ATTN_RESIDUAL_NAME
 from axlearn.common.layers import (
     Dropout,
     LayerNorm,
@@ -4001,6 +4002,8 @@ def _save_and_offload_only_these_names_regex(
 
 # Regex patterns for matching remat names
 class RematRegexSavePatterns(enum.Enum):
+    """Common regex patterns for saving tensors in attention and feedforward layers."""
+
     QKV_PROJ = r".*[kqv]_proj"
     O_PROJ = r".*o_proj"
     CONTEXT = r".*context"
@@ -4009,6 +4012,8 @@ class RematRegexSavePatterns(enum.Enum):
     # This is called native attention because the "context" remat point only exists when using
     # native attention, e.g. `MultiheadAttention` or `GroupedQueryAttention`.
     NATIVE_ATTENTION = ".*([qkvo]_proj|context)"
+    FLASH_CONTEXT = f".*{FLASH_ATTN_RESIDUAL_NAME}"
+    FLASH_ATTENTION = "|".join([FLASH_CONTEXT, QKV_PROJ, O_PROJ])
     FEED_FORWARD = "|".join([LINEAR1_X, LINEAR2_X])
 
 

--- a/axlearn/common/flash_attention/remat.py
+++ b/axlearn/common/flash_attention/remat.py
@@ -1,13 +1,15 @@
 # Copyright © 2025 Apple Inc.
 """Remat policy for FlashAttention kernels."""
 
+from jax._src.ad_checkpoint import name_p
 from jax._src.cudnn.fused_attention_stablehlo import _dot_product_attention_fwd_p_wrapper
-from jax.custom_derivatives import custom_vjp_call_jaxpr_p
-from jax.experimental.pallas import pallas_call_p
 
-from axlearn.common.utils import Recompute, RematPolicy, RematType, Saveable
+from axlearn.common.utils import Offloadable, Recompute, RematPolicy, RematType, Saveable
+
+FLASH_ATTN_RESIDUAL_NAME = "flash_residuals"
 
 
+# TODO(hanzhi-zhou): simplify after cudnn attention supports passing checkpoint names.
 def save_or_offload_flash_attention_policy(remat_type: RematType = Saveable) -> RematPolicy:
     """Returns a remat policy for FlashAttention output.
 
@@ -15,9 +17,9 @@ def save_or_offload_flash_attention_policy(remat_type: RematType = Saveable) -> 
     commonly named "context". More precisely, it saves the attention output of GPU Pallas kernel,
     TPU Legacy Pallas kernel, TPU SplashAttention kernel, and cuDNN FlashAttention kernel.
 
-    Because cuDNN FlashAttention and TPU SplashAttention invocations are in Jax source code, it's
-    not feasible to save the output using `checkpoint_name`. Therefore, we match the Jax primitives
-    to implement this save policy.
+    Because cuDNN FlashAttention invocation is in Jax source code, it's not feasible to save the
+    output using `checkpoint_name`. Therefore, we match the Jax primitives to implement this save
+    policy.
 
     Note for users: for context length >= 4096, FlashAttention kernel takes noticeably longer on
     both TPU and GPU to execute than o_proj. Therefore, saving the output of FlashAttention is
@@ -25,34 +27,31 @@ def save_or_offload_flash_attention_policy(remat_type: RematType = Saveable) -> 
     capacity doesn't allow saving both.
 
     Args:
-        remat_type: Remat type. Defaults to Saveable (save to HBM) and only supports Saveable.
+        remat_type: Remat type. Defaults to Saveable (save to HBM). Note that Offloadable is not
+            supported when using cuDNN flash attention.
 
     Returns:
         A RematPolicy. Users can combine this remat policy with any existing policy with
             `axlearn.common.utils.combine_remat_policies`.
     """
-    # Jax bug: https://github.com/jax-ml/jax/issues/25841.
-    # TODO(hanzhi-zhou): add support for Offloadable when jax supports it.
-    if remat_type is not Saveable:
-        raise NotImplementedError(f"{remat_type=} is not implemented.")
 
     def policy(prim, *_, **params):
-        src_info = ""
         # Primitives could be copies if modules are reinitialized, so `is` check is unreliable.
         # Use string equality instead.
         prim_s = str(prim)
-        if prim_s == str(pallas_call_p):
-            src_info = str(params.get("name_and_src_info", ""))
-        if prim_s == str(custom_vjp_call_jaxpr_p):
-            src_info = str(params.get("fun_jaxpr", ""))
-        # GPU Pallas kernel.
-        if "_mha_forward_kernel" in src_info:
-            return remat_type
-        # TPU new and legacy Pallas kernel.
-        if "flash_attention_kernel" in src_info:
-            return remat_type
+        if prim_s == str(name_p):
+            if FLASH_ATTN_RESIDUAL_NAME in params["name"]:
+                return remat_type
         # cuDNN kernel.
         if prim_s == str(_dot_product_attention_fwd_p_wrapper):
+            if isinstance(remat_type, Offloadable):
+                # Raise a nice error message rather than a Jax internal error.
+                # See https://github.com/jax-ml/jax/issues/25841.
+                # TODO(hanzhi-zhou): the bug is fixed in nightly. Remove this restriction
+                # once we upgrade to jax 0.4.39 or newer.
+                raise NotImplementedError(
+                    "Offloading cuDNN attention is not supported due to a Jax bug."
+                )
             return remat_type
         return Recompute
 

--- a/axlearn/common/flash_attention/remat_test.py
+++ b/axlearn/common/flash_attention/remat_test.py
@@ -9,7 +9,6 @@ import os
 # pylint: disable=wrong-import-position
 os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
 os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
-from contextlib import nullcontext
 
 # pylint: enable=wrong-import-position
 import jax
@@ -19,6 +18,7 @@ from jax.ad_checkpoint import checkpoint_policies
 from jax.experimental import mesh_utils
 from jax.sharding import Mesh
 
+from axlearn.common.config import config_for_function
 from axlearn.common.flash_attention.layer import (
     FlashAttention,
     default_mha_dim_to_partition_spec,
@@ -115,30 +115,34 @@ class TestFlashAttentionRemat(TestCase):
         with mesh:
             no_remat = jax.value_and_grad(loss)
             full_remat = jax.value_and_grad(jax.remat(loss))
-            with self.assertRaises(NotImplementedError) if isinstance(
-                remat_type, Offloadable
-            ) else nullcontext():
-                save_flash = jax.value_and_grad(
-                    jax.remat(loss, policy=save_or_offload_flash_attention_policy(remat_type))
-                )
-            if isinstance(remat_type, Offloadable):
-                return
+            save_flash = jax.value_and_grad(
+                jax.remat(loss, policy=save_or_offload_flash_attention_policy(remat_type))
+            )
             fn_expected_fw_count = [
                 (no_remat, 1),
                 (full_remat, 2),
                 (save_flash, 1),
             ]
 
-            # Note: we don't use HLO for Pallas since HLO doesn't contain the kernel name.
             if jax.default_backend() == "gpu":
                 if use_segment_ids:
                     # Pallas kernel case.
                     for fn, count in fn_expected_fw_count:
                         self.assertEqual(
-                            str(jax.make_jaxpr(fn)(params, inputs)).count("_mha_forward_kernel"),
-                            count,
+                            jax.jit(fn)
+                            .lower(params, inputs)
+                            .as_text("hlo")
+                            .count('custom_call_target="__gpu$xla.gpu.triton"'),
+                            # +1 because this custom call also matches the backward call.
+                            # also +1 since the backward kernels are not fused. I.e. there are two
+                            # calls, one for dkdv and one for dq.
+                            count + 2,
                         )
                 else:
+                    if isinstance(remat_type, Offloadable):
+                        with self.assertRaises(NotImplementedError):
+                            jax.jit(save_flash).lower(params, inputs).as_text("hlo")
+                        return
                     # cuDNN case.
                     # Note: the backward kernel is called "__cudnn$fmhaSoftmaxBackward".
                     # Use " to distinguish forward and backward kernel.
@@ -212,8 +216,12 @@ class TestFlashAttentionRemat(TestCase):
                         loss,
                         policy=combine_remat_policies(
                             checkpoint_policies.everything_saveable,
-                            offload_dots_saveable("device", "pinned_host"),
-                            combine_fn=default_remat_combine_fn(preferred),
+                            config_for_function(offload_dots_saveable).set(
+                                offload_src="device", offload_dst="pinned_host"
+                            ),
+                            combine_fn=config_for_function(default_remat_combine_fn).set(
+                                preferred_remat_type=preferred
+                            ),
                         ),
                     )
                 )


### PR DESCRIPTION
Fixed some problems with remat
1. `combine_remat_policies` should allow passing `config_for_function`
2. `RematType` doesn't have a validator
3. The unit test to count kernel calls isn't robust to jax upgrade. Switched from counting in jaxpr to HLO instead.
4. Pallas primitive saving is buggy and introduces unexpected memory usage. Note that this memory usage bug does not apply to the cuDNN primitive. Since I noticed SplashAttention supports passing in checkpoint name, I change all pallas kernel remat to `checkpoint_name`. This also workarounds the Jax remat bug for multi-output primitive.
5. Changed custom vjp calling in gpu attention. Previously, we call the primal function in `fwd` rule of the custom vjp, which prohibits the successful insertion of remat names (not quite sure why). Separated the forward implementation to a function so it can be called from the primal function and fwd rule. 
6. Removed extraneous jit for gpu flash attn.

Before this PR, saving flash attention causes OOM due to probably a jax bug.