### PR TITLE
SplashAttention performance tuning for v6e

### DIFF
--- a/axlearn/common/loss_test.py
+++ b/axlearn/common/loss_test.py
@@ -24,6 +24,7 @@ from typing import Optional
 import chex
 import jax
 import jax.numpy as jnp
+import jax.scipy.special
 import numpy as np
 import optax
 import pytest

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1-flash.txt
@@ -151,6 +151,8 @@ mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[1][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[1][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[1][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[2][0]: 'tpu-v6e-256'
 mesh_rules[2][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
@@ -167,9 +169,11 @@ mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
-mesh_rules[2][1].config_modifiers[2].grad_acc_steps: 4
-mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
-mesh_rules[2][1].config_modifiers[2].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
+mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[2][1].config_modifiers[2].tpu_block_size: 1024
+mesh_rules[2][1].config_modifiers[3].grad_acc_steps: 4
+mesh_rules[2][1].config_modifiers[3].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
+mesh_rules[2][1].config_modifiers[3].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
 mesh_rules[2][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[3][0]: 'gpu-(p5.48xlarge|p4de.24xlarge)-(512|1024)'
 mesh_rules[3][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1.txt
@@ -151,6 +151,8 @@ mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[1][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[1][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[1][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[2][0]: 'tpu-v6e-256'
 mesh_rules[2][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
@@ -167,9 +169,11 @@ mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
-mesh_rules[2][1].config_modifiers[2].grad_acc_steps: 4
-mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
-mesh_rules[2][1].config_modifiers[2].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
+mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[2][1].config_modifiers[2].tpu_block_size: 1024
+mesh_rules[2][1].config_modifiers[3].grad_acc_steps: 4
+mesh_rules[2][1].config_modifiers[3].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
+mesh_rules[2][1].config_modifiers[3].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
 mesh_rules[2][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[3][0]: 'gpu-(p5.48xlarge|p4de.24xlarge)-(512|1024)'
 mesh_rules[3][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2-flash.txt
@@ -151,6 +151,8 @@ mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[1][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[1][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[1][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[2][0]: 'tpu-v6e-256'
 mesh_rules[2][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
@@ -167,9 +169,11 @@ mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
-mesh_rules[2][1].config_modifiers[2].grad_acc_steps: 4
-mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
-mesh_rules[2][1].config_modifiers[2].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
+mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[2][1].config_modifiers[2].tpu_block_size: 1024
+mesh_rules[2][1].config_modifiers[3].grad_acc_steps: 4
+mesh_rules[2][1].config_modifiers[3].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
+mesh_rules[2][1].config_modifiers[3].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
 mesh_rules[2][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[3][0]: 'gpu-(p5.48xlarge|p4de.24xlarge)-(512|1024)'
 mesh_rules[3][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2.txt
@@ -151,6 +151,8 @@ mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[1][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[1][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[1][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[2][0]: 'tpu-v6e-256'
 mesh_rules[2][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
@@ -167,9 +169,11 @@ mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
-mesh_rules[2][1].config_modifiers[2].grad_acc_steps: 4
-mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
-mesh_rules[2][1].config_modifiers[2].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
+mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[2][1].config_modifiers[2].tpu_block_size: 1024
+mesh_rules[2][1].config_modifiers[3].grad_acc_steps: 4
+mesh_rules[2][1].config_modifiers[3].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
+mesh_rules[2][1].config_modifiers[3].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
 mesh_rules[2][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[3][0]: 'gpu-(p5.48xlarge|p4de.24xlarge)-(512|1024)'
 mesh_rules[3][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-flash.txt
@@ -151,6 +151,8 @@ mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[1][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[1][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[1][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[2][0]: 'tpu-v6e-256'
 mesh_rules[2][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
@@ -167,9 +169,11 @@ mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
-mesh_rules[2][1].config_modifiers[2].grad_acc_steps: 4
-mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
-mesh_rules[2][1].config_modifiers[2].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
+mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[2][1].config_modifiers[2].tpu_block_size: 1024
+mesh_rules[2][1].config_modifiers[3].grad_acc_steps: 4
+mesh_rules[2][1].config_modifiers[3].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
+mesh_rules[2][1].config_modifiers[3].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
 mesh_rules[2][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[3][0]: 'gpu-(p5.48xlarge|p4de.24xlarge)-(512|1024)'
 mesh_rules[3][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken-flash.txt
@@ -151,6 +151,8 @@ mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[1][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[1][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[1][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[2][0]: 'tpu-v6e-256'
 mesh_rules[2][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
@@ -167,9 +169,11 @@ mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
-mesh_rules[2][1].config_modifiers[2].grad_acc_steps: 4
-mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
-mesh_rules[2][1].config_modifiers[2].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
+mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[2][1].config_modifiers[2].tpu_block_size: 1024
+mesh_rules[2][1].config_modifiers[3].grad_acc_steps: 4
+mesh_rules[2][1].config_modifiers[3].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
+mesh_rules[2][1].config_modifiers[3].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
 mesh_rules[2][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[3][0]: 'gpu-(p5.48xlarge|p4de.24xlarge)-(512|1024)'
 mesh_rules[3][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken.txt
@@ -151,6 +151,8 @@ mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[1][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[1][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[1][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[2][0]: 'tpu-v6e-256'
 mesh_rules[2][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
@@ -167,9 +169,11 @@ mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
-mesh_rules[2][1].config_modifiers[2].grad_acc_steps: 4
-mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
-mesh_rules[2][1].config_modifiers[2].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
+mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[2][1].config_modifiers[2].tpu_block_size: 1024
+mesh_rules[2][1].config_modifiers[3].grad_acc_steps: 4
+mesh_rules[2][1].config_modifiers[3].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
+mesh_rules[2][1].config_modifiers[3].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
 mesh_rules[2][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[3][0]: 'gpu-(p5.48xlarge|p4de.24xlarge)-(512|1024)'
 mesh_rules[3][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3.txt
@@ -151,6 +151,8 @@ mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[1][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[1][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[1][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[1][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[2][0]: 'tpu-v6e-256'
 mesh_rules[2][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
@@ -167,9 +169,11 @@ mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[2][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
-mesh_rules[2][1].config_modifiers[2].grad_acc_steps: 4
-mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
-mesh_rules[2][1].config_modifiers[2].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
+mesh_rules[2][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[2][1].config_modifiers[2].tpu_block_size: 1024
+mesh_rules[2][1].config_modifiers[3].grad_acc_steps: 4
+mesh_rules[2][1].config_modifiers[3].klass: 'axlearn.common.trainer_config_modifier.GradientAccumulationModifier'
+mesh_rules[2][1].config_modifiers[3].metric_accumulator.klass: 'axlearn.common.metrics.MetricAccumulator'
 mesh_rules[2][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[3][0]: 'gpu-(p5.48xlarge|p4de.24xlarge)-(512|1024)'
 mesh_rules[3][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1-flash-single-host.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1-flash-single-host.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1-flash.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1-single-host.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1-single-host.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v1.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2-flash-single-host.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2-flash-single-host.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2-flash.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2-single-host.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2-single-host.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v2.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3-flash-single-host.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3-flash-single-host.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3-flash.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3-single-host.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3-single-host.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-7B-v3.txt
@@ -187,6 +187,8 @@ mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.l
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: None
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: 'pinned_host'
 mesh_rules[4][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: 'device'
+mesh_rules[4][1].config_modifiers[2].klass: 'axlearn.experiments.trainer_config_utils.V6eFlashConfigModifier'
+mesh_rules[4][1].config_modifiers[2].tpu_block_size: 1024
 mesh_rules[4][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModifier'
 mesh_rules[5][0]: 'tpu-v5p-.*'
 mesh_rules[5][1][0]: 1

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -56,7 +56,7 @@ from axlearn.experiments.text.gpt.common import (
 )
 from axlearn.experiments.text.gpt.common import model_config as common_model_config
 from axlearn.experiments.text.gpt.common import scaled_hidden_dim
-from axlearn.experiments.trainer_config_utils import TrainerConfigFn
+from axlearn.experiments.trainer_config_utils import TrainerConfigFn, V6eFlashConfigModifier
 
 MODEL_SIZES = ("test", "1B", "3B", "7B", "8B", "70B")
 
@@ -320,6 +320,7 @@ def get_trainer_kwargs(
                                     ),
                                 }
                             ),
+                            V6eFlashConfigModifier.default_config(),
                         ],
                     ),
                 ),
@@ -475,6 +476,7 @@ def get_trainer_kwargs(
                                     ),
                                 }
                             ),
+                            V6eFlashConfigModifier.default_config(),
                         ],
                     ),
                 ),
@@ -494,6 +496,7 @@ def get_trainer_kwargs(
                                     ),
                                 }
                             ),
+                            V6eFlashConfigModifier.default_config(),
                             GradientAccumulationModifier.default_config().set(grad_acc_steps=4),
                         ],
                     ),

--- a/axlearn/experiments/trainer_config_utils.py
+++ b/axlearn/experiments/trainer_config_utils.py
@@ -5,7 +5,8 @@ from typing import Optional
 
 from typing_extensions import Protocol
 
-from axlearn.common.config import InstantiableConfig
+from axlearn.common.config import InstantiableConfig, config_class
+from axlearn.common.flash_attention.layer import FlashBlockSizeModifier
 
 
 class TrainerConfigFn(Protocol):
@@ -28,3 +29,13 @@ def with_overrides(trainer_config_fn: TrainerConfigFn, **kwargs) -> TrainerConfi
         return trainer_cfg
 
     return wrapped_fn
+
+
+class V6eFlashConfigModifier(FlashBlockSizeModifier):
+    """Modified the tpu_block_size config for better performance on TPU v6e."""
+
+    @config_class
+    class Config(FlashBlockSizeModifier.Config):
+        """Configures V6eFlashConfigModifier."""
+
+        tpu_block_size: int = 1024

--- a/axlearn/experiments/trainer_config_utils_test.py
+++ b/axlearn/experiments/trainer_config_utils_test.py
@@ -4,11 +4,13 @@
 import jax.numpy as jnp
 from absl.testing import absltest, parameterized
 
+from axlearn.common.flash_attention.layer_test import DummyModel as FlashDummyModel
+from axlearn.common.flash_attention.layer_test import FlashAttention
 from axlearn.common.input_fake import FakeLmInput
 from axlearn.common.test_utils import mock_trainer_config
 from axlearn.common.trainer_test import DummyModel
 from axlearn.experiments import TrainerConfigFn
-from axlearn.experiments.trainer_config_utils import with_overrides
+from axlearn.experiments.trainer_config_utils import V6eFlashConfigModifier, with_overrides
 
 
 def _create_fake_trainer_config_fn() -> TrainerConfigFn:
@@ -38,6 +40,13 @@ class TrainerConfigUtilsTest(parameterized.TestCase):
         new_trainer_config = new_trainer_config_fn()
         for k, v in kwargs.items():
             self.assertEqual(getattr(new_trainer_config, k), v)
+
+    def test_flash_config_modifier(self):
+        cfg: FlashDummyModel.Config = FlashDummyModel.default_config()
+        cfg.layer = FlashAttention.default_config()
+        cfg_modifier = V6eFlashConfigModifier.default_config().instantiate()
+        cfg = cfg_modifier(cfg)
+        self.assertEqual(cfg.layer.tpu_block_size, 1024)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a config modifier to modify the block size of SplashAttention. By setting it to 1024, it improves the performance of SplashKernel by 1/3 compared to baseline on v6e.