### PR TITLE
:sparkles: Add cache for CloudBuild API location queries

### DIFF
--- a/axlearn/cloud/gcp/cloud_build_test.py
+++ b/axlearn/cloud/gcp/cloud_build_test.py
@@ -1,7 +1,9 @@
-# Copyright © 2024 Apple Inc.
+# Copyright © 2025 Apple Inc.
 
 """Tests cloud_build module."""
+
 from unittest import mock
+from unittest.mock import MagicMock
 
 from absl.testing import parameterized
 from google.cloud.compute_v1 import ListRegionsRequest, RegionsClient
@@ -10,8 +12,10 @@ from google.cloud.devtools.cloudbuild_v1 import Build, ListBuildsRequest
 from axlearn.cloud.gcp.cloud_build import (
     CloudBuildStatus,
     _get_build_request_filter,
-    _get_cloud_build_status_for_region,
+    _get_latest_build_status_in_region,
+    _last_known_region_for_build,
     _list_available_regions,
+    _list_builds_in_region,
     get_cloud_build_status,
 )
 from axlearn.common.test_utils import TestCase
@@ -40,7 +44,7 @@ class CloudBuildTest(TestCase):
             expected_filter='(tags = tag1) OR results.images.name="image"',
         ),
     )
-    def test_get_cloud_build_status(self, image_name, tags, expected_filter):
+    def test_get_build_request_filter(self, image_name, tags, expected_filter):
         self.assertEqual(
             _get_build_request_filter(image_name=image_name, tags=tags), expected_filter
         )
@@ -70,17 +74,20 @@ class CloudBuildTest(TestCase):
         mock_client.list.side_effect = Exception("API error")
         mock_regions_client.return_value = mock_client
 
-        with self.assertRaises(Exception) as context:
+        with self.assertRaisesRegex(Exception, "API error"):
             _list_available_regions(project_id)
 
-        self.assertIn("API error", str(context.exception))
         mock_log_error.assert_called_once_with(
-            "Failed to look up regions for project: %s", mock_client.list.side_effect
+            "Failed to look up regions for project '%s': %s",
+            "test-project",
+            mock_client.list.side_effect,
         )
         mock_client.list.assert_called_once_with(request=ListRegionsRequest(project=project_id))
 
-    @mock.patch("google.cloud.devtools.cloudbuild_v1.CloudBuildClient")
-    def test_get_cloud_build_status_for_region_success(self, mock_cloudbuild_client):
+    @mock.patch("axlearn.cloud.gcp.cloud_build._list_builds_in_region")
+    def test_get_latest_build_status_in_region_with_one_region_success(
+        self, mock_list_builds_in_region
+    ):
         project_id = "test-project"
         image_name = "test-image"
         tags = ["tag-1", "tag-2"]
@@ -96,99 +103,20 @@ class CloudBuildTest(TestCase):
             "2023-07-31T00:00:00Z"  # Mock the creation time of a newer build.
         )
 
-        mock_client = mock.Mock()
-        mock_client.list_builds.return_value = [mock_build_1, mock_build_2]
-        mock_cloudbuild_client.return_value = mock_client
+        mock_list_builds_in_region.return_value = [mock_build_1, mock_build_2]
         expected_status = CloudBuildStatus.SUCCESS
 
-        # Call the function with the mocked client.
-        status = _get_cloud_build_status_for_region(
-            project_id=project_id, image_name=image_name, tags=tags, region=region
+        status = _get_latest_build_status_in_region(
+            project_id=project_id, image_name=image_name, tags=tuple(tags), region=region
         )
 
-        self.assertEqual(status, expected_status)
-        mock_client.list_builds.assert_called_once_with(
-            request=ListBuildsRequest(
-                parent=f"projects/{project_id}/locations/{region}",
-                project_id=project_id,
-                filter=_get_build_request_filter(image_name=image_name, tags=tags),
-            )
-        )
-
-    @mock.patch("google.cloud.devtools.cloudbuild_v1.CloudBuildClient")
-    def test_get_cloud_build_status_for_region_failure(self, mock_cloudbuild_client):
-        project_id = "test-project"
-        image_name = "test-image"
-        tags = ["tag-1", "tag-2"]
-        region = "us-central1"
-        mock_build_1 = mock.Mock()
-        mock_build_1.status = Build.Status.WORKING
-        mock_build_1.create_time = (
-            "2023-07-30T00:00:00Z"  # Mock the creation time of an older build.
-        )
-        mock_build_2 = mock.Mock()
-        mock_build_2.status = Build.Status.FAILURE
-        mock_build_2.create_time = (
-            "2023-07-31T00:00:00Z"  # Mock the creation time of a newer build.
-        )
-
-        mock_client = mock.Mock()
-        mock_client.list_builds.return_value = [mock_build_1, mock_build_2]
-        mock_cloudbuild_client.return_value = mock_client
-        expected_status = CloudBuildStatus.FAILURE
-
-        # Call the function with the mocked client.
-        status = _get_cloud_build_status_for_region(
-            project_id=project_id, image_name=image_name, tags=tags, region=region
-        )
-
-        self.assertEqual(status, expected_status)
-        mock_client.list_builds.assert_called_once_with(
-            request=ListBuildsRequest(
-                parent=f"projects/{project_id}/locations/{region}",
-                project_id=project_id,
-                filter=_get_build_request_filter(image_name=image_name, tags=tags),
-            )
-        )
-
-    @mock.patch("google.cloud.devtools.cloudbuild_v1.CloudBuildClient")
-    def test_get_cloud_build_status_for_region_status_unknown(self, mock_cloudbuild_client):
-        project_id = "test-project"
-        image_name = "test-image"
-        tags = ["tag-1", "tag-2"]
-        region = "us-central1"
-        mock_build_1 = mock.Mock()
-        mock_build_1.status = Build.Status.WORKING
-        mock_build_1.create_time = (
-            "2023-07-30T00:00:00Z"  # Mock the creation time of an older build.
-        )
-        mock_build_2 = mock.Mock()
-        mock_build_2.status = Build.Status.STATUS_UNKNOWN
-        mock_build_2.create_time = (
-            "2023-07-31T00:00:00Z"  # Mock the creation time of a newer build.
-        )
-
-        mock_client = mock.Mock()
-        mock_client.list_builds.return_value = [mock_build_1, mock_build_2]
-        mock_cloudbuild_client.return_value = mock_client
-        expected_status = CloudBuildStatus.STATUS_UNKNOWN
-
-        # Call the function with the mocked client.
-        status = _get_cloud_build_status_for_region(
-            project_id=project_id, image_name=image_name, tags=tags, region=region
-        )
-
-        self.assertEqual(status, expected_status)
-        mock_client.list_builds.assert_called_once_with(
-            request=ListBuildsRequest(
-                parent=f"projects/{project_id}/locations/{region}",
-                project_id=project_id,
-                filter=_get_build_request_filter(image_name=image_name, tags=tags),
-            )
+        self.assertEqual(expected_status, status)
+        mock_list_builds_in_region.assert_called_once_with(
+            project_id=project_id, image_name=image_name, tags=tuple(tags), region=region
         )
 
     @mock.patch("axlearn.cloud.gcp.cloud_build.cloudbuild_v1.CloudBuildClient")
-    def test_get_cloud_build_status_for_region_raises_exception(self, mock_cloud_build_client):
+    def test_get_latest_build_status_in_region_raises_exception(self, mock_cloud_build_client):
         project_id = "test-project"
         image_name = "test-image"
         tags = ["tag1", "tag2"]
@@ -198,10 +126,11 @@ class CloudBuildTest(TestCase):
         mock_client.list_builds.side_effect = Exception("Failed to find image")
 
         with self.assertRaises(Exception) as cm:
-            _get_cloud_build_status_for_region(
-                project_id=project_id, image_name=image_name, tags=tags, region=region
+            _get_latest_build_status_in_region(
+                project_id=project_id, image_name=image_name, tags=tuple(tags), region=region
             )
-            self.assertEqual(str(cm.exception), "Failed to find image")
+
+        self.assertEqual(str(cm.exception), "Failed to find image")
 
         mock_client.list_builds.assert_called_once_with(
             request=ListBuildsRequest(
@@ -211,10 +140,10 @@ class CloudBuildTest(TestCase):
             )
         )
 
-    @mock.patch("axlearn.cloud.gcp.cloud_build._get_cloud_build_status_for_region")
+    @mock.patch("axlearn.cloud.gcp.cloud_build._get_latest_build_status_in_region")
     @mock.patch("axlearn.cloud.gcp.cloud_build._list_available_regions")
     def test_get_cloud_build_status_success_with_two_regions(
-        self, mock_list_available_regions, mock_get_cloud_build_status_for_region
+        self, mock_list_available_regions, mock_get_latest_build_status_in_region
     ):
         project_id = "test-project"
         image_name = "test-image"
@@ -222,32 +151,38 @@ class CloudBuildTest(TestCase):
 
         mock_list_available_regions.return_value = ["us-central1", "europe-west1"]
         # Mock the return value for each region to simulate a build found in us-central1.
-        mock_get_cloud_build_status_for_region.side_effect = [
+        mock_get_latest_build_status_in_region.side_effect = [
             None,  # No builds found in 'global' region.
             CloudBuildStatus.SUCCESS,  # Successful build found in us-central1 region.
             None,  # No builds found in 'europe-west1' region.
         ]
-        expected_status = CloudBuildStatus.SUCCESS
+
+        # Reset the _last_known_region_for_build memoization
+        _last_known_region_for_build.clear()
+
         build_status = get_cloud_build_status(
             project_id=project_id, image_name=image_name, tags=tags
         )
+        expected_status = CloudBuildStatus.SUCCESS
         self.assertEqual(build_status, expected_status)
         mock_list_available_regions.assert_called_once_with(project_id)
 
         # Assert that the function was called twice, once for global and once for us-central1.
         # Tests that the last region was short-circuited given that a build was found earlier
         calls = [
-            mock.call(project_id=project_id, image_name=image_name, tags=tags, region="global"),
             mock.call(
-                project_id=project_id, image_name=image_name, tags=tags, region="us-central1"
+                project_id=project_id, image_name=image_name, tags=tuple(tags), region="global"
+            ),
+            mock.call(
+                project_id=project_id, image_name=image_name, tags=tuple(tags), region="us-central1"
             ),
         ]
-        mock_get_cloud_build_status_for_region.assert_has_calls(calls, any_order=False)
+        mock_get_latest_build_status_in_region.assert_has_calls(calls, any_order=False)
 
-    @mock.patch("axlearn.cloud.gcp.cloud_build._get_cloud_build_status_for_region")
+    @mock.patch("axlearn.cloud.gcp.cloud_build._get_latest_build_status_in_region")
     @mock.patch("axlearn.cloud.gcp.cloud_build._list_available_regions")
     def test_get_cloud_build_status_failure_with_two_regions(
-        self, mock_list_available_regions, mock_get_cloud_build_status_for_region
+        self, mock_list_available_regions, mock_get_latest_build_status_in_region
     ):
         project_id = "test-project"
         image_name = "test-image"
@@ -255,11 +190,15 @@ class CloudBuildTest(TestCase):
 
         mock_list_available_regions.return_value = ["us-central1", "europe-west1"]
         # Mock the return value for each region to simulate a build found in "europe-west1".
-        mock_get_cloud_build_status_for_region.side_effect = [
+        mock_get_latest_build_status_in_region.side_effect = [
             None,  # No builds found in 'global' region.
             None,  # No builds found in 'us-central1' region.
             CloudBuildStatus.FAILURE,  # Failed build found in 'europe-west1' region.
         ]
+
+        # Reset the _last_known_region_for_build memoization
+        _last_known_region_for_build.clear()
+
         expected_status = CloudBuildStatus.FAILURE
         build_status = get_cloud_build_status(
             project_id=project_id, image_name=image_name, tags=tags
@@ -269,20 +208,83 @@ class CloudBuildTest(TestCase):
 
         # Assert that the function was called three times: once for global and once for each region.
         calls = [
-            mock.call(project_id=project_id, image_name=image_name, tags=tags, region="global"),
             mock.call(
-                project_id=project_id, image_name=image_name, tags=tags, region="us-central1"
+                project_id=project_id, image_name=image_name, tags=tuple(tags), region="global"
             ),
             mock.call(
-                project_id=project_id, image_name=image_name, tags=tags, region="europe-west1"
+                project_id=project_id, image_name=image_name, tags=tuple(tags), region="us-central1"
+            ),
+            mock.call(
+                project_id=project_id,
+                image_name=image_name,
+                tags=tuple(tags),
+                region="europe-west1",
             ),
         ]
-        mock_get_cloud_build_status_for_region.assert_has_calls(calls, any_order=False)
+        mock_get_latest_build_status_in_region.assert_has_calls(calls, any_order=False)
 
-    @mock.patch("axlearn.cloud.gcp.cloud_build._get_cloud_build_status_for_region")
+    @mock.patch("axlearn.cloud.gcp.cloud_build._get_latest_build_status_in_region")
     @mock.patch("axlearn.cloud.gcp.cloud_build._list_available_regions")
-    def test_get_cloud_build_status_success_with_no_regions(
-        self, mock_list_available_regions, mock_get_cloud_build_status_for_region
+    def test_get_cloud_build_status_correctly_sets_last_known_region_for_build(
+        self, mock_list_available_regions, mock_get_latest_build_status_in_region
+    ):
+        project_id = "test-project"
+        image_name = "test-image"
+        tags = ["tag1", "tag2"]
+
+        mock_list_available_regions.return_value = ["us-central1", "europe-west1"]
+        # Mock the return value for each region to simulate a build found in "europe-west1".
+        mock_get_latest_build_status_in_region.side_effect = [
+            None,  # No builds found in 'global' region.
+            None,  # No builds found in 'us-central1' region.
+            CloudBuildStatus.FAILURE,  # Failed build found in 'europe-west1' region.
+        ]
+
+        # Reset the _last_known_region_for_build memoization
+        _last_known_region_for_build.clear()
+
+        expected_status = CloudBuildStatus.FAILURE
+        build_status = get_cloud_build_status(
+            project_id=project_id, image_name=image_name, tags=tags
+        )
+
+        self.assertEqual(build_status, expected_status)
+        mock_list_available_regions.assert_called_once_with(project_id)
+
+        # Verify that the _last_known_region_for_build variable is updated with the correct region
+        self.assertEqual(
+            _last_known_region_for_build[(project_id, image_name, tuple(tags))], "europe-west1"
+        )
+
+    @mock.patch("axlearn.cloud.gcp.cloud_build._get_latest_build_status_in_region")
+    @mock.patch("axlearn.cloud.gcp.cloud_build._list_available_regions")
+    def test_get_cloud_build_status_correctly_uses_preset_last_known_region_for_build(
+        self, mock_list_available_regions, mock_get_latest_build_status_in_region
+    ):
+        project_id = "test-project"
+        image_name = "test-image"
+        tags = ["tag1", "tag2"]
+
+        # Manually set the _last_known_region_for_build memoization
+        _last_known_region_for_build[(project_id, image_name, tuple(tags))] = "europe-west1"
+
+        # Mock the return value for each region to simulate a build found in "europe-west1".
+        mock_get_latest_build_status_in_region.side_effect = [
+            CloudBuildStatus.WORKING,  # Working build found in 'europe-west1' region.
+        ]
+
+        expected_status = CloudBuildStatus.WORKING
+        build_status = get_cloud_build_status(
+            project_id=project_id, image_name=image_name, tags=tags
+        )
+
+        self.assertEqual(build_status, expected_status)
+        mock_list_available_regions.assert_not_called()
+
+    @mock.patch("axlearn.cloud.gcp.cloud_build._get_latest_build_status_in_region")
+    @mock.patch("axlearn.cloud.gcp.cloud_build._list_available_regions")
+    def test_get_cloud_build_status_success_with_only_global_region(
+        self, mock_list_available_regions, mock_get_latest_build_status_in_region
     ):
         project_id = "test-project"
         image_name = "test-image"
@@ -290,9 +292,13 @@ class CloudBuildTest(TestCase):
 
         mock_list_available_regions.return_value = []
         # Mock the return value for each region to simulate a build found in 'global' region.
-        mock_get_cloud_build_status_for_region.side_effect = [
+        mock_get_latest_build_status_in_region.side_effect = [
             CloudBuildStatus.SUCCESS,  # Successful build found in 'global' region.
         ]
+
+        # Reset the _last_known_region_for_build memoization
+        _last_known_region_for_build.clear()
+
         expected_status = CloudBuildStatus.SUCCESS
         build_status = get_cloud_build_status(
             project_id=project_id, image_name=image_name, tags=tags
@@ -300,8 +306,249 @@ class CloudBuildTest(TestCase):
         self.assertEqual(build_status, expected_status)
         mock_list_available_regions.assert_called_once_with(project_id)
 
-        # Assert that the function was called once for 'global' region.
         calls = [
-            mock.call(project_id=project_id, image_name=image_name, tags=tags, region="global"),
+            mock.call(
+                project_id=project_id, image_name=image_name, tags=tuple(tags), region="global"
+            ),
         ]
-        mock_get_cloud_build_status_for_region.assert_has_calls(calls)
+        mock_get_latest_build_status_in_region.assert_has_calls(calls)
+
+    @mock.patch("axlearn.cloud.gcp.cloud_build._get_latest_build_status_in_region")
+    @mock.patch("axlearn.cloud.gcp.cloud_build._list_available_regions")
+    def test_get_cloud_build_status_returns_none_with_no_regions(
+        self, mock_list_available_regions, mock_get_latest_build_status_in_region
+    ):
+        project_id = "test-project"
+        image_name = "test-image"
+        tags = ["tag1", "tag2"]
+
+        mock_list_available_regions.return_value = []
+        mock_get_latest_build_status_in_region.return_value = None
+
+        # Reset the _last_known_region_for_build memoization
+        _last_known_region_for_build.clear()
+
+        build_status = get_cloud_build_status(
+            project_id=project_id, image_name=image_name, tags=tags
+        )
+        self.assertIsNone(build_status)
+        mock_list_available_regions.assert_called_once_with(project_id)
+
+        calls = [
+            mock.call(
+                project_id=project_id, image_name=image_name, tags=tuple(tags), region="global"
+            ),
+        ]
+        mock_get_latest_build_status_in_region.assert_has_calls(calls)
+
+    @mock.patch("axlearn.cloud.gcp.cloud_build.cloudbuild_v1.CloudBuildClient")
+    def test_list_builds_in_region_success_with_global_region(self, mock_client):
+        project_id = "test-project"
+        image_name = "test-image"
+        tags = ("tag1", "tag2")
+        region = "global"
+
+        mock_build = MagicMock(spec=Build)
+        mock_build.project_id = project_id
+        mock_build.images = [image_name]
+        mock_build.tags = tags
+
+        mock_client.return_value.list_builds.return_value = [mock_build]
+
+        builds = _list_builds_in_region(
+            project_id=project_id, image_name=image_name, tags=tags, region=region
+        )
+
+        self.assertEqual(1, len(builds))
+        self.assertEqual(project_id, builds[0].project_id)
+        self.assertEqual([image_name], builds[0].images)
+        self.assertEqual(tags, builds[0].tags)
+
+        mock_client.assert_called_once_with()
+        mock_client.return_value.list_builds.assert_called_once_with(
+            request=ListBuildsRequest(
+                parent=f"projects/{project_id}/locations/{region}",
+                project_id=project_id,
+                filter=_get_build_request_filter(image_name=image_name, tags=list(tags)),
+            )
+        )
+
+    @mock.patch("axlearn.cloud.gcp.cloud_build.cloudbuild_v1.CloudBuildClient")
+    def test_list_builds_in_region_success_with_non_global_region(self, mock_client):
+        project_id = "test-project"
+        image_name = "test-image"
+        tags = ("tag1", "tag2")
+        region = "us-central1"
+
+        mock_build = MagicMock(spec=Build)
+        mock_build.project_id = project_id
+        mock_build.images = [image_name]
+        mock_build.tags = tags
+
+        mock_client.return_value.list_builds.return_value = [mock_build]
+
+        builds = _list_builds_in_region(project_id, image_name, tags, region)
+
+        self.assertEqual(1, len(builds))
+        self.assertEqual(project_id, builds[0].project_id)
+        self.assertEqual([image_name], builds[0].images)
+        self.assertEqual(tags, builds[0].tags)
+
+        mock_client.assert_called_once_with()
+        mock_client.return_value.list_builds.assert_called_once_with(
+            request=ListBuildsRequest(
+                parent=f"projects/{project_id}/locations/{region}",
+                project_id=project_id,
+                filter=_get_build_request_filter(image_name=image_name, tags=list(tags)),
+            )
+        )
+
+    @mock.patch("axlearn.cloud.gcp.cloud_build.cloudbuild_v1.CloudBuildClient")
+    def test_list_builds_in_region_failure_with_list_builds_exception(self, mock_client):
+        project_id = "test-project"
+        image_name = "test-image"
+        tags = ("tag1", "tag2")
+        region = "global"
+
+        mock_client.return_value.list_builds.side_effect = Exception("Test Exception")
+
+        with self.assertRaises(Exception) as excinfo:
+            _list_builds_in_region(project_id, image_name, tags, region)
+
+        self.assertEqual("Test Exception", str(excinfo.exception))
+
+        mock_client.assert_called_once_with()
+        mock_client.return_value.list_builds.assert_called_once_with(
+            request=ListBuildsRequest(
+                parent=f"projects/{project_id}/locations/{region}",
+                project_id=project_id,
+                filter=_get_build_request_filter(image_name=image_name, tags=list(tags)),
+            )
+        )
+
+    @mock.patch("axlearn.cloud.gcp.cloud_build.cloudbuild_v1.CloudBuildClient")
+    def test_list_builds_in_region_success_with_empty_builds(self, mock_client):
+        project_id = "test-project"
+        image_name = "test-image"
+        tags = ("tag1", "tag2")
+        region = "global"
+
+        mock_client.return_value.list_builds.return_value = []
+
+        builds = _list_builds_in_region(project_id, image_name, tags, region)
+
+        self.assertEqual(0, len(builds))
+
+        mock_client.assert_called_once_with()
+        mock_client.return_value.list_builds.assert_called_once_with(
+            request=ListBuildsRequest(
+                parent=f"projects/{project_id}/locations/{region}",
+                project_id=project_id,
+                filter=_get_build_request_filter(image_name=image_name, tags=list(tags)),
+            )
+        )
+
+    @mock.patch("axlearn.cloud.gcp.cloud_build._list_builds_in_region")
+    def test_get_latest_build_status_in_region_returns_success_status(
+        self, mock_list_builds_in_region
+    ):
+        project_id = "test-project"
+        image_name = "test-image"
+        tags = ("tag1", "tag2")
+        region = "us-central1"
+
+        # Mock the return value of _list_builds_in_region to return a list of builds.
+        mock_build_1 = mock.Mock()
+        mock_build_1.status = Build.Status.WORKING
+        mock_build_1.create_time = "2023-07-30T00:00:00Z"
+        mock_build_2 = mock.Mock()
+        mock_build_2.status = Build.Status.SUCCESS
+        mock_build_2.create_time = "2023-07-31T00:00:00Z"
+        mock_list_builds_in_region.return_value = [mock_build_1, mock_build_2]
+
+        status = _get_latest_build_status_in_region(
+            project_id=project_id, image_name=image_name, tags=tags, region=region
+        )
+
+        # Assert that the status of the latest build (mock_build_2) is returned.
+        self.assertEqual(status, CloudBuildStatus.SUCCESS)
+        mock_list_builds_in_region.assert_called_once_with(
+            project_id=project_id, image_name=image_name, tags=tags, region=region
+        )
+
+    @mock.patch("axlearn.cloud.gcp.cloud_build._list_builds_in_region")
+    def test_get_latest_build_status_in_region_returns_failure_status(
+        self, mock_list_builds_in_region
+    ):
+        project_id = "test-project"
+        image_name = "test-image"
+        tags = ("tag1", "tag2")
+        region = "us-central1"
+
+        # Mock the return value of _list_builds_in_region to return a list of builds.
+        mock_build_1 = mock.Mock()
+        mock_build_1.status = Build.Status.WORKING
+        mock_build_1.create_time = "2023-07-30T00:00:00Z"
+        mock_build_2 = mock.Mock()
+        mock_build_2.status = Build.Status.FAILURE
+        mock_build_2.create_time = "2023-07-31T00:00:00Z"
+        mock_list_builds_in_region.return_value = [mock_build_1, mock_build_2]
+
+        status = _get_latest_build_status_in_region(
+            project_id=project_id, image_name=image_name, tags=tags, region=region
+        )
+
+        # Assert that the status of the latest build (mock_build_2) is returned.
+        self.assertEqual(status, CloudBuildStatus.FAILURE)
+        mock_list_builds_in_region.assert_called_once_with(
+            project_id=project_id, image_name=image_name, tags=tags, region=region
+        )
+
+    @mock.patch("axlearn.cloud.gcp.cloud_build._list_builds_in_region")
+    def test_get_latest_build_status_in_region_returns_status_unknown(
+        self, mock_list_builds_in_region
+    ):
+        project_id = "test-project"
+        image_name = "test-image"
+        tags = ("tag1", "tag2")
+        region = "us-central1"
+
+        # Mock the return value of _list_builds_in_region to return a list of builds.
+        mock_build_1 = mock.Mock()
+        mock_build_1.status = Build.Status.WORKING
+        mock_build_1.create_time = "2023-07-30T00:00:00Z"
+        mock_build_2 = mock.Mock()
+        mock_build_2.status = Build.Status.STATUS_UNKNOWN
+        mock_build_2.create_time = "2023-07-31T00:00:00Z"
+        mock_list_builds_in_region.return_value = [mock_build_1, mock_build_2]
+
+        status = _get_latest_build_status_in_region(
+            project_id=project_id, image_name=image_name, tags=tags, region=region
+        )
+
+        # Assert that the status of the latest build (mock_build_2) is returned.
+        self.assertEqual(status, CloudBuildStatus.STATUS_UNKNOWN)
+        mock_list_builds_in_region.assert_called_once_with(
+            project_id=project_id, image_name=image_name, tags=tags, region=region
+        )
+
+    @mock.patch("axlearn.cloud.gcp.cloud_build._list_builds_in_region")
+    def test_get_latest_build_status_in_region_returns_none_with_empty_builds(
+        self, mock_list_builds_in_region
+    ):
+        project_id = "test-project"
+        image_name = "test-image"
+        tags = ("tag1", "tag2")
+        region = "us-central1"
+
+        mock_list_builds_in_region.return_value = []
+
+        status = _get_latest_build_status_in_region(
+            project_id=project_id, image_name=image_name, tags=tags, region=region
+        )
+
+        # Assert that None is returned when no builds are found in the region.
+        self.assertIsNone(status)
+        mock_list_builds_in_region.assert_called_once_with(
+            project_id=project_id, image_name=image_name, tags=tags, region=region
+        )


### PR DESCRIPTION
When looking up CloudBuild builds, the current approach is extremely naive and inefficient - iterating through every available GCP region to find a specific build with the corresponding image and tags. The status of the build is queried at a 30 second interval in the `gcp/bundler/wait_until_finished` function. Since the region of the build in question cannot be modified while the build is progress, we can use an local memoized variable `_last_known_region_for_build` to cache the build region of a particular build in order to more efficiently retrieve the status at a 30s interval. This should save a significant amount of cycles on the server-side.

A new private function `_list_builds_in_region()` was extracted in order to separate build caching concerns from build status logic in the `_get_cloud_build_status_for_region` function. This allows for more specialized unit testing as well.