### PR TITLE
Replace jnp.ndarray with Tensor from axlearn.common.utils

### DIFF
--- a/axlearn/common/flash_attention/gpu_attention.py
+++ b/axlearn/common/flash_attention/gpu_attention.py
@@ -45,8 +45,7 @@ from jax.experimental import pallas as pl
 from axlearn.common.attention import NEG_INF, MaskFn
 from axlearn.common.flash_attention.remat import FLASH_ATTN_RESIDUAL_NAME
 from axlearn.common.layers import get_dropout_mask
-
-Tensor = jax.Array
+from axlearn.common.utils import Tensor
 
 
 class NoPopDict(dict):

--- a/axlearn/common/summary_writer.py
+++ b/axlearn/common/summary_writer.py
@@ -13,7 +13,6 @@ from typing import Any, Callable, Optional
 import jax
 import numpy as np
 from absl import logging
-from jax import numpy as jnp
 from tensorflow import summary as tf_summary
 
 from axlearn.common import file_system as fs
@@ -26,8 +25,6 @@ try:
     import wandb
 except ModuleNotFoundError:
     wandb = None
-
-Tensor = jnp.ndarray
 
 
 class CheckpointerAction(str, enum.Enum):

--- a/axlearn/vision/fpn.py
+++ b/axlearn/vision/fpn.py
@@ -40,8 +40,7 @@ from axlearn.common.param_init import (
     PerGroupInitializer,
     WeightInitializer,
 )
-
-Tensor = jnp.ndarray
+from axlearn.common.utils import Tensor
 
 
 def batch_norm():

--- a/axlearn/vision/resnet.py
+++ b/axlearn/vision/resnet.py
@@ -42,8 +42,7 @@ from axlearn.common.layers import (
     get_stochastic_depth_linear_rate,
 )
 from axlearn.common.module import Module
-
-Tensor = jnp.ndarray
+from axlearn.common.utils import Tensor
 
 
 def batch_norm():

--- a/axlearn/vision/virtex.py
+++ b/axlearn/vision/virtex.py
@@ -25,12 +25,16 @@ from axlearn.common.decoding import BeamSearchOutputs
 from axlearn.common.layers import Linear
 from axlearn.common.metrics import WeightedScalar
 from axlearn.common.module import Module, child_context
-from axlearn.common.utils import NestedTensor, get_recursively, tree_paths, validate_contains_paths
+from axlearn.common.utils import (
+    NestedTensor,
+    Tensor,
+    get_recursively,
+    tree_paths,
+    validate_contains_paths,
+)
 from axlearn.common.vision_transformer import VisionTransformer as ViTModel
 from axlearn.common.vision_transformer import named_model_configs as vit_named_model_configs
 from axlearn.vision.resnet import ResNet
-
-Tensor = jnp.ndarray
 
 
 class ImageBackboneModelMixin(Module):


### PR DESCRIPTION
### Summary
This PR replaces direct references to jnp.ndarray (or jax.Array) with Tensor from axlearn.common.utils. The change improves consistency and centralizes the definition of Tensor across the codebase.

### Changes
- Updated gpu_attention.py, summary_writer.py, fpn.py, resnet.py, and virtex.py to import Tensor from axlearn.common.utils instead of defining it locally as jnp.ndarray or jax.Array.
- Removed redundant jnp imports where they were only used for defining Tensor.
- Reformatted import statements where necessary for better readability.

### Motivation
- Ensures a single, unified definition of Tensor, making future updates easier.
- Improves maintainability by reducing redundant type definitions.
- Aligns with the existing codebase convention of using axlearn.common.utils.Tensor.

### Testing
- This change does not alter any functional behavior.
- Existing unit tests should continue to pass without modification.

### pre-commit run
```
$ pre-commit run --files $(git diff --name-only HEAD~1)
Check Yaml...........................................(no files to check)Skipped
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
black....................................................................Passed
isort....................................................................Passed
pylint...................................................................Passed
```