### PR TITLE
Remove redundant import logging

### DIFF
--- a/axlearn/open_api/evaluator.py
+++ b/axlearn/open_api/evaluator.py
@@ -2,7 +2,6 @@
 
 """Evaluates and computes metrics for responses from generator."""
 import asyncio
-import logging
 import os
 from datetime import timedelta
 from typing import Optional

--- a/axlearn/open_api/generator.py
+++ b/axlearn/open_api/generator.py
@@ -4,7 +4,6 @@
 Input format is json line with each line in OpenAI requests style.
 """
 import asyncio
-import logging
 import os
 from datetime import timedelta
 from typing import Any, Optional


### PR DESCRIPTION
### Summary
This PR removes unnecessary `import logging` statements from evaluator.py and generator.py, as `absl.logging` is imported later.

### pre-commit run
```
$ pre-commit run --files $(git diff --name-only HEAD~1)
Check Yaml...........................................(no files to check)Skipped
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
black....................................................................Passed
isort....................................................................Passed
pylint...................................................................Passed
```