### PR TITLE
Transpose kv cache for better decode performance

### DIFF
--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -2769,7 +2769,7 @@ class MultiheadAttentionTest(TestCase):
         self.assertTrue(jnp.all(time_step == initial_states["i_proj"]["time_step"]))
         for proj in ["key", "value"]:
             self.assertEqual(
-                (batch_size, tgt_len, num_kv_heads or num_heads, model_dim // num_heads),
+                (batch_size, num_kv_heads or num_heads, model_dim // num_heads, tgt_len),
                 initial_states["i_proj"][proj].shape,
             )
             self.assertEqual(


### PR DESCRIPTION
Transposing KV state as a TPU fusion optimization improves decode step time.