### PR TITLE
Use Accuracy from cross_entropy in causal_lm.py::CrossEntropyLossMetrics

### DIFF
--- a/axlearn/common/loss.py
+++ b/axlearn/common/loss.py
@@ -68,6 +68,8 @@ def _reduce_loss(
     if sample_weight is not None:
         loss = loss * sample_weight
 
+    # Initialize reduced_loss to prevent linter errors
+    reduced_loss = loss  # Default initialization
     if reduction == ReductionMethod.NONE:
         reduced_loss = loss
     elif reduction == ReductionMethod.SUM:
@@ -117,14 +119,18 @@ def cross_entropy(
             target_labels will only be used for inferring the live targets during loss calculation.
 
     Returns:
-        (loss, all_losses), where
+        (loss, loss_dict), where
         loss is a scalar tensor for the cross entropy loss;
-        all_losses is a dictionary containing:
+        loss_dict is a dictionary containing:
             * "total_loss": a scalar representing the overall
                 loss = cross_entropy_loss + z_loss_scale * z_loss.
-            * "cross_entropy_loss": the cross_entropy_loss.
             * "z_loss": the unscaled z_loss.
+            * "cross_entropy_loss": the cross_entropy_loss.
             * "per_target_loss": the loss per target, of the same shape as `target_labels`.
+            * "accuracy": the proportion of correctly predicted targets, computed as
+              the number of instances where the predicted class (argmax of logits)
+              matches the target label, weighted by `live_targets`, and normalized by
+              the total number of valid targets.
 
     Raises:
         ValueError: If z_loss_scale is negative.


### PR DESCRIPTION
### PR Description:

This PR updates the accuracy calculation in `causal_lm.py::CrossEntropyLossMetrics` to use the value stored in `loss_dict["accuracy"]` instead of recomputing it. The key changes include:

- Removing redundant accuracy computation in causal_lm.py.
- Ensuring loss_dict["accuracy"] is used directly in CrossEntropyLossMetrics.
- Updating the documentation in loss.py to clearly describe the accuracy computation method.
- These changes improve code clarity and maintain consistency across the loss computation functions.

The following models already use `loss_dict["accuracy"]` from `loss.py::cross_entropy()` function
- axlearn/audio/decoder_asr.py::LASDecoderModel::forward
- axlearn/common/encoder_decoder.py::EncoderDecoderModel::forward (via _metrics)

### Testing
Test command uses config fuji-test-v3, jax_backend is gpu
```
mkdir -p /tmp/gpt_c4_test
python3 -m axlearn.common.launch_trainer_main \
  --module=text.gpt.c4_trainer \
  --config=fuji-test-v3 \
  --trainer_dir=/tmp/gpt_c4_test\
  --data_dir=gs://axlearn-public/tensorflow_datasets \
  --jax_backend=gpu
```

tensorboard --logdir=train_train
- Accuracy before: https://ibb.co/kVj6ss9b
- Accuracy after: https://ibb.co/GQn2wfH4

### pre-commit
```
$ pre-commit run --files $(git diff --name-only HEAD~1)
Check Yaml...........................................(no files to check)Skipped
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
black....................................................................Passed
isort....................................................................Passed
pylint...................................................................Passed
```

### pytype
```
$ pytype -j auto $(git diff --name-only HEAD~1) 
Success: no errors found
```