### PR TITLE
GoodPut minor fix: only process 0 should start goodput uploader

### DIFF
--- a/axlearn/cloud/gcp/measurement.py
+++ b/axlearn/cloud/gcp/measurement.py
@@ -107,5 +107,6 @@ class GoodputRecorder(measurement.Recorder):
                 include_badput_breakdown=True,
             )
 
-        self._monitor.start_goodput_uploader(*args, **kwargs)
-        logging.info("Started Goodput upload to Tensorboard in the background!")
+        if jax.process_index() == 0:
+            self._monitor.start_goodput_uploader(*args, **kwargs)
+            logging.info("Started Goodput upload to Tensorboard in the background!")

--- a/axlearn/cloud/gcp/measurement_test.py
+++ b/axlearn/cloud/gcp/measurement_test.py
@@ -111,3 +111,23 @@ class GoodputRecorderTest(parameterized.TestCase):
             with self.assertRaises(Exception):
                 recorder.start_monitoring()
             self.assertIsNone(recorder._monitor)
+
+    def test_non_zero_process_index(self):
+        fv = flags.FlagValues()
+        measurement.define_flags(flag_values=fv)
+        fv.set_default(
+            "recorder_spec",
+            ["name=test-name", "upload_dir=/test/path/to/upload", "upload_interval=15"],
+        )
+        fv.mark_as_parsed()
+
+        recorder = GoodputRecorder.from_flags(fv)
+        self.assertIsNone(recorder._monitor)
+
+        with mock.patch("jax.process_index") as mock_process_index:
+            mock_process_index.return_value = 1  # Simulate a non-zero process index
+
+            try:
+                recorder.start_monitoring()
+            except AttributeError:
+                self.fail("AttributeError was raised unexpectedly.")


### PR DESCRIPTION
Line 106 in this file specifies that only worker 0 (`jax.process_index() == 0`) will create a GoodputMonitor object and return it. All other processes will return nothing and therefore introduce an error in `self._monitor.start_goodput_uploader(*args, **kwargs)`. Example error: 

```
 File "/root/axlearn/common/measurement.py", line 148, in start_monitoring
    global_recorder.start_monitoring()
  File "/root/axlearn/cloud/gcp/measurement.py", line 110, in start_monitoring
    self._monitor.start_goodput_uploader(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/ml_goodput_measurement/src/monitoring.py", line 137, in start_goodput_uploader
    if self._uploader_thread_running:
AttributeError: 'GoodputMonitor' object has no attribute '_uploader_thread_running'
```

This PR fixes this error. cc @dipannita08 @markblee 