### PR TITLE
Migrate from Legacy JAX APIs jax.tree_util to jax.tree

### DIFF
--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -378,9 +378,7 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
 
         asyncio.run(_run_serializer())
 
-        self._add_futures(
-            jax.tree_util.tree_flatten(commit_futures)[0] + (additional_futures or [])
-        )
+        self._add_futures(jax.tree.flatten(commit_futures)[0] + (additional_futures or []))
 
         # Used in wait_until_finished to check on process != 0, if the checkpoint
         # has finished writing.

--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -5161,7 +5161,7 @@ class StackedTransformerTest(BaseTransformerTest):
             lambda path, spec: spec if has_prebuilt_layers(path) else None, param_specs
         )
         if prebuilt_layers:
-            self.assertNotEmpty(jax.tree_util.tree_leaves(prebuilt_specs))
+            self.assertNotEmpty(jax.tree.leaves(prebuilt_specs))
         initialized_state = layer.initialize_parameters_recursively(
             prng_key=jax.random.PRNGKey(123), prebuilt=prebuilt_specs
         )

--- a/axlearn/common/checkpointer.py
+++ b/axlearn/common/checkpointer.py
@@ -572,9 +572,7 @@ class TensorStoreStateStorage(StateStorage):
             else:
                 raise RuntimeError(f"Unknown index entry '{value}'")
 
-        restored_state = jax.tree_util.tree_unflatten(
-            jax.tree_util.tree_structure(state), state_leaves
-        )
+        restored_state = jax.tree.unflatten(jax.tree.structure(state), state_leaves)
         multihost_utils.sync_global_devices(ckpt_dir)
         return restored_state
 

--- a/axlearn/common/checkpointer_test.py
+++ b/axlearn/common/checkpointer_test.py
@@ -425,9 +425,7 @@ class CheckpointerTest(test_utils.TestCase):
             step, restored_state = ckpt.restore(step=None, state=state0)
             self.assertEqual(100, step)
             self.assertEqual(type(restored_state), custom_dict_type)
-            self.assertIn(
-                custom_dict_type.__name__, str(jax.tree_util.tree_structure(restored_state))
-            )
+            self.assertIn(custom_dict_type.__name__, str(jax.tree.structure(restored_state)))
             self.assertNestedEqual(state0, restored_state)
             ckpt.stop()
 

--- a/axlearn/common/inference.py
+++ b/axlearn/common/inference.py
@@ -108,7 +108,7 @@ class MethodRunner:
                 isinstance(x, jax.Array) and len(x.devices()) == 1
             ) or isinstance(x, np.ndarray)
             all_host_local_inputs = all(
-                is_host_local_input_check(t) for t in jax.tree_util.tree_leaves(input_batch)
+                is_host_local_input_check(t) for t in jax.tree.leaves(input_batch)
             )
 
             if all_host_local_inputs:

--- a/axlearn/common/inference_output.py
+++ b/axlearn/common/inference_output.py
@@ -199,7 +199,7 @@ class OutputRecordWriter(BaseOutputWriter):
             output_batch: A NestedTensor whose leaves must be tensors of shape [batch_size, ...].
         """
         local_data = dict(input=input_batch, output=output_batch)
-        local_batch_size = jax.tree_util.tree_leaves(local_data)[0].shape[0]
+        local_batch_size = jax.tree.leaves(local_data)[0].shape[0]
 
         for i in range(local_batch_size):
             example = jax.tree.map(lambda x, index=i: x[index], local_data)

--- a/axlearn/common/inference_pipeline.py
+++ b/axlearn/common/inference_pipeline.py
@@ -138,7 +138,7 @@ class InferencePipeline(Module):
             self.summary_writer(step=batch_index, values=output.summaries)
 
             if (batch_index + 1) % 10 == 0:
-                global_batch_size = len(jax.tree_util.tree_leaves(global_input_batch)[0])
+                global_batch_size = len(jax.tree.leaves(global_input_batch)[0])
                 logging.info(
                     "Processed %d batches and %d examples",
                     batch_index + 1,

--- a/axlearn/common/learner.py
+++ b/axlearn/common/learner.py
@@ -427,9 +427,7 @@ class CompositeLearner(BaseLearner):
             tree_paths(params),
         )
         # Check that all params is covered.
-        if not jax.tree_util.tree_reduce(
-            lambda x, y: x and (y != ""), learner_name_tree, initializer=True
-        ):
+        if not jax.tree.reduce(lambda x, y: x and (y != ""), learner_name_tree, initializer=True):
             raise ValueError("Composite learner rules do not update all model params.")
         return learner_name_tree
 

--- a/axlearn/common/learner_test.py
+++ b/axlearn/common/learner_test.py
@@ -165,8 +165,8 @@ class LearnerTest(TestCase):
         self.assertGreater(forward_outputs.aux["discriminator_loss"], 0.0)
         # The structure of updated params and Adam mu states are same.
         self.assertNestedEqual(
-            jax.tree_util.tree_structure(updated_model_params),
-            jax.tree_util.tree_structure(learner_state["optimizer"][1].mu),
+            jax.tree.structure(updated_model_params),
+            jax.tree.structure(learner_state["optimizer"][1].mu),
         )
 
     @parameterized.product(ema_decay=(None, 0.9), method=("update", "forward_and_backward"))
@@ -983,14 +983,14 @@ class CompositeLearnerTest(TestCase):
         # The structure of updated params and optimizer states are same.
         opt_state_leaf_fn = lambda x: isinstance(x, (Tensor, optax.MaskedNode))
         self.assertNestedEqual(
-            jax.tree_util.tree_structure(updated_model_params),
-            jax.tree_util.tree_structure(
+            jax.tree.structure(updated_model_params),
+            jax.tree.structure(
                 learner_state["encoder"]["optimizer"][0].trace, is_leaf=opt_state_leaf_fn
             ),
         )
         self.assertNestedEqual(
-            jax.tree_util.tree_structure(updated_model_params),
-            jax.tree_util.tree_structure(
+            jax.tree.structure(updated_model_params),
+            jax.tree.structure(
                 learner_state["decoder"]["optimizer"][1].mu, is_leaf=opt_state_leaf_fn
             ),
         )
@@ -1156,7 +1156,7 @@ class CompositeLearnerTest(TestCase):
                 summaries={},
                 module_outputs={},
             )
-            result = jax.tree_util.tree_reduce(lambda x, y: x.sum() + y.sum(), model_params)
+            result = jax.tree.reduce(lambda x, y: x.sum() + y.sum(), model_params)
             return ForwardOutputs(loss=result, aux={}, output_collection=output_collection)
 
         grads = jax.tree_map(lambda p: jnp.ones_like(p.value), params)

--- a/axlearn/common/metrics_test.py
+++ b/axlearn/common/metrics_test.py
@@ -51,8 +51,8 @@ class TestMetricAccumulator(test_utils.TestCase):
         )
 
         chex.assert_trees_all_equal_structs(result, expected)
-        result = jax.tree_util.tree_leaves(result)
-        expected = jax.tree_util.tree_leaves(expected)
+        result = jax.tree.leaves(result)
+        expected = jax.tree.leaves(expected)
         chex.assert_trees_all_close(result, expected)
 
     def test_flatten_unflatten_metric_accumulator(self):
@@ -75,10 +75,10 @@ class TestMetricAccumulator(test_utils.TestCase):
         for s in summaries_copy:
             acc.update(s)
 
-        flat, tree = jax.tree_util.tree_flatten(acc)
-        unflattened = jax.tree_util.tree_unflatten(tree, flat)
-        expected = jax.tree_util.tree_leaves(acc.summaries())
-        result = jax.tree_util.tree_leaves(unflattened.summaries())
+        flat, tree = jax.tree.flatten(acc)
+        unflattened = jax.tree.unflatten(tree, flat)
+        expected = jax.tree.leaves(acc.summaries())
+        result = jax.tree.leaves(unflattened.summaries())
         chex.assert_trees_all_close(result, expected)
 
     @parameterized.parameters(

--- a/axlearn/common/mixture_of_experts.py
+++ b/axlearn/common/mixture_of_experts.py
@@ -991,7 +991,7 @@ def convert_dense_to_moe_parameters(
             ) from e
         # The target layer is a RepeatedTransformerLayer.
         target_parameters = {"repeat": VDict({"layer": {}})}
-        num_stages = jax.tree_util.tree_leaves(stage_parameter_specs)[0].shape[0]
+        num_stages = jax.tree.leaves(stage_parameter_specs)[0].shape[0]
         # The target stage is expected to be a StackedTransformerLayer.
         num_layers_per_stage = len(stage_parameter_specs)
         for layer_i in range(num_layers_per_stage):

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -202,7 +202,7 @@ def propagate_repeated_output_collections(
     # if a repeated layer outputs a scalar summary value, it will have shape [N].
     # Below we split the stacked values and output them separately under scope
     # "{child_name_prefix}{i}" so that scalar summaries can be handled correctly.
-    summary_values = jax.tree_util.tree_leaves(repeated_output_collection.summaries)
+    summary_values = jax.tree.leaves(repeated_output_collection.summaries)
     if summary_values:
         first_summary_value = summary_values[0]
         assert first_summary_value.shape, "Stacked summaries should have a leading stack dimension."

--- a/axlearn/common/optimizers.py
+++ b/axlearn/common/optimizers.py
@@ -1351,7 +1351,7 @@ def skip_and_clip_by_global_norm(
                 return is_valid, new_drop_stats
 
         # Check if every gradient is finite.
-        flat_updates = jax.tree_util.tree_flatten(updates)[0]
+        flat_updates = jax.tree.flatten(updates)[0]
         is_finite = jnp.all(jnp.array([jnp.all(jnp.isfinite(p)) for p in flat_updates]))
         g_norm = optax.global_norm(updates)
         if drop_norm is not None:

--- a/axlearn/common/pipeline.py
+++ b/axlearn/common/pipeline.py
@@ -766,7 +766,7 @@ class Pipeline(BaseLayer):
         cfg: Pipeline.Config = self.config
         self.vlog(1, "carry=%s xs=%s", shapes(carry), shapes(xs))
 
-        carry_leaves = jax.tree_util.tree_leaves(carry)
+        carry_leaves = jax.tree.leaves(carry)
         if not carry_leaves:
             raise ValueError("Expected at least one input leaf.")
         if carry_leaves[0].ndim < 2:

--- a/axlearn/common/repeat.py
+++ b/axlearn/common/repeat.py
@@ -190,7 +190,7 @@ class Repeat(BaseLayer):
         with child_context("layer", output_collection=layer_output_collection) as layer_context:
             # Note, actual `num_layers` might be smaller than `cfg.num_layers` depending on
             # the invocation context.
-            num_layers = jax.tree_util.tree_reduce(
+            num_layers = jax.tree.reduce(
                 lambda num, x: min(num, x.shape[0]),
                 tree=(layer_context.state, xs),
                 initializer=cfg.num_layers,

--- a/axlearn/common/rnn_test.py
+++ b/axlearn/common/rnn_test.py
@@ -185,11 +185,9 @@ class StackedRNNTest(TestCase):
             final_states_list.append(output_collections.module_outputs["final_states"])
 
         # Stack the tree leaves.
-        tree_leaves = [jax.tree_util.tree_flatten(t)[0] for t in final_states_list]
-        tree_def = jax.tree_util.tree_structure(final_states_list[0])
-        final_states = jax.tree_util.tree_unflatten(
-            tree_def, [jnp.stack(leaf) for leaf in zip(*tree_leaves)]
-        )
+        tree_leaves = [jax.tree.flatten(t)[0] for t in final_states_list]
+        tree_def = jax.tree.structure(final_states_list[0])
+        final_states = jax.tree.unflatten(tree_def, [jnp.stack(leaf) for leaf in zip(*tree_leaves)])
         self.assertEqual(shapes(final_states), shapes(init_states))
 
         forward_outputs, forward_collections = F(

--- a/axlearn/common/state_builder_test.py
+++ b/axlearn/common/state_builder_test.py
@@ -673,9 +673,7 @@ class TestConv2DStateBuilders(TestCase):
         **extra_converter_config_kwargs,
     ):
         source_state = _mock_state(source_cfg, seed=0)
-        initial_trainer_state_tree_structure = jax.tree_util.tree_structure(
-            source_state.trainer_state
-        )
+        initial_trainer_state_tree_structure = jax.tree.structure(source_state.trainer_state)
 
         builder = (
             builder_cls.default_config()
@@ -689,7 +687,7 @@ class TestConv2DStateBuilders(TestCase):
         source_model = source_state.trainer_state.model
 
         converted_state = builder(deepcopy(source_state))
-        assert initial_trainer_state_tree_structure == jax.tree_util.tree_structure(
+        assert initial_trainer_state_tree_structure == jax.tree.structure(
             converted_state.trainer_state
         )
         converted_model = converted_state.trainer_state.model

--- a/axlearn/common/struct_test.py
+++ b/axlearn/common/struct_test.py
@@ -58,7 +58,7 @@ class StructTest(absltest.TestCase):
 
     def test_pytree_nodes(self):
         p = _Point(x=1, y=2, meta={"abc": True})
-        leaves = jax.tree_util.tree_leaves(p)
+        leaves = jax.tree.leaves(p)
         self.assertEqual(leaves, [1, 2])
         new_p = jax.tree.map(lambda x: x + x, p)
         self.assertEqual(new_p, _Point(x=2, y=4, meta={"abc": True}))
@@ -104,7 +104,7 @@ class StructTest(absltest.TestCase):
             )
             # tree_flatten_with_path is not preserved because Chex does not support this so the
             # fallback jax implementation with numbered keys gets used.
-            flattened.append(jax.tree_util.tree_leaves(instance))
+            flattened.append(jax.tree.leaves(instance))
         chex.assert_trees_all_equal(*flattened)
 
     def test_constructor_order(self):
@@ -133,7 +133,7 @@ class StructTest(absltest.TestCase):
             field_b: int
             field_a: int
 
-        result = jax.tree_util.tree_leaves(C(field_b=1, field_a=2))
+        result = jax.tree.leaves(C(field_b=1, field_a=2))
         expected = (1, 2)
         self.assertSequenceEqual(result, expected)
 

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -196,8 +196,8 @@ class TestCase(parameterized.TestCase):
         # Optionally, test that trees also have the same structure.
         if require_same_tree_structure:
             # Prune empty subtrees so we don't require empty dicts for layers with no params.
-            ref_structure = jax.tree_util.tree_structure(prune_empty(params_from_ref))
-            test_structure = jax.tree_util.tree_structure(prune_empty(layer_params))
+            ref_structure = jax.tree.structure(prune_empty(params_from_ref))
+            test_structure = jax.tree.structure(prune_empty(layer_params))
             self.assertEqual(
                 ref_structure, test_structure, msg=f"\nRef: {ref_structure}\nTest: {test_structure}"
             )
@@ -428,8 +428,8 @@ def _complete_param_init_spec_tree(
     params_with_nones = jax.tree_map(
         partial(replace_keys, mapping={k: None for k in delegates}), params, is_leaf=is_leaf
     )
-    _, treedef = jax.tree_util.tree_flatten(params_with_nones)
-    inits_with_nones = jax.tree_util.tree_unflatten(treedef, param_init_specs)
+    _, treedef = jax.tree.flatten(params_with_nones)
+    inits_with_nones = jax.tree.unflatten(treedef, param_init_specs)
 
     # Replace the Nones with a delegate.
     return jax.tree_map(partial(replace_keys, mapping=delegates), inits_with_nones, is_leaf=is_leaf)
@@ -563,9 +563,7 @@ def read_per_param_settings(
         model_params = model.initialize_parameters_recursively(jax.random.PRNGKey(0))
 
         model_specs = model.create_parameter_specs_recursively()
-        model_specs = complete_partition_spec_tree(
-            jax.tree_util.tree_structure(model_params), model_specs
-        )
+        model_specs = complete_partition_spec_tree(jax.tree.structure(model_params), model_specs)
         opt_params = jax.tree.map(
             lambda param, spec: OptParam(
                 value=param,

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -604,7 +604,7 @@ class SpmdTrainer(Module):
         """Returns a tree of OptParam for Learner.{init,update}."""
         # self._model_param_specs can be incomplete. Complete it first.
         specs = utils.complete_partition_spec_tree(
-            jax.tree_util.tree_structure(model_params), self._model_param_specs
+            jax.tree.structure(model_params), self._model_param_specs
         )
         return jax.tree.map(
             lambda param, spec: OptParam(
@@ -852,7 +852,7 @@ class SpmdTrainer(Module):
         # Log trainer state tree.
         if not self.step and jax.process_index() == 0:
             with fs.open(os.path.join(cfg.dir, "trainer_state_tree.txt"), "w") as f:
-                f.write(str(jax.tree_util.tree_structure(self._trainer_state)))
+                f.write(str(jax.tree.structure(self._trainer_state)))
 
             with fs.open(os.path.join(cfg.dir, "model_analysis.txt"), "w") as f:
                 f.write(model_analysis)

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -579,9 +579,7 @@ class TrainerTest(test_utils.TestCase):
         trainer: SpmdTrainer = cfg.instantiate(parent=None)
         compiled_without_args = trainer.compile_train_step()
         # pylint: disable=protected-access
-        input_batch = jax.tree_util.tree_map(
-            jnp.array, next(trainer.input.batches(trainer._input_iter))
-        )
+        input_batch = jax.tree.map(jnp.array, next(trainer.input.batches(trainer._input_iter)))
         # pylint: enable=protected-access
         compiled_with_input_batch = trainer.compile_train_step(input_batch=input_batch)
         # In a single-host environment, both compiled functions should match.

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -377,9 +377,9 @@ class TreeUtilsTest(TestCase):
         # Note that 'None' is considered part of the tree structure, not tree leaves.
         self.assertEqual(
             "PyTreeDef(CustomNode(VDict[('a', 'b', 'c')], [*, *, None]))",
-            str(jax.tree_util.tree_structure(tree)),
+            str(jax.tree.structure(tree)),
         )
-        self.assertLen(jax.tree_util.tree_leaves(tree), 2)
+        self.assertLen(jax.tree.leaves(tree), 2)
 
     def test_vectorized_tree_map(self):
         tree = VDict(a=jnp.arange(10), b=jnp.arange(7) - 3)
@@ -678,9 +678,7 @@ class TreeUtilsTest(TestCase):
         partition_by_x = PartitionSpec("x")
         partial_partition_spec = dict(replicated=None, sharded=partition_by_x)
         self.assertEqual(
-            complete_partition_spec_tree(
-                jax.tree_util.tree_structure(data), partial_partition_spec
-            ),
+            complete_partition_spec_tree(jax.tree.structure(data), partial_partition_spec),
             dict(
                 replicated=dict(a=None, b=None), sharded=VDict(c=partition_by_x, d=partition_by_x)
             ),
@@ -692,7 +690,7 @@ class TreeUtilsTest(TestCase):
         )
         self.assertEqual(
             complete_partition_spec_tree(
-                jax.tree_util.tree_structure(data), dict(replicated=None, sharded=param_spec)
+                jax.tree.structure(data), dict(replicated=None, sharded=param_spec)
             ),
             dict(replicated=dict(a=None, b=None), sharded=VDict(c=param_spec, d=param_spec)),
         )

--- a/axlearn/vision/virtex.py
+++ b/axlearn/vision/virtex.py
@@ -146,7 +146,7 @@ class ImageBackboneModelMixin(Module):
             pass
 
         def _paths(x):
-            return jax.tree_util.tree_leaves(tree_paths(x))
+            return jax.tree.leaves(tree_paths(x))
 
         raise ValueError(
             f"Cannot find visual features at {cfg.visual_feature_layer_name}. "


### PR DESCRIPTION
### Description

This PR migrates the axlearn codebase from Legacy JAX APIs (`jax.tree_util`) to the recommended `jax.tree` module.

The jax.tree API was introduced in JAX v0.4.25 and is now the preferred approach over `jax.tree_util`. Upgrading to `jax.tree` ensures better compatibility with future JAX versions and improves code maintainability.


[jax.tree doc](https://docs.jax.dev/en/latest/jax.tree.html)

[jax.tree_util doc](https://docs.jax.dev/en/latest/jax.tree_util.html)

#### pre-commit
```
$ pre-commit run -a      
Check Yaml...............................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
black....................................................................Passed
isort....................................................................Passed
pylint...................................................................Passed
```

#### pytype
```
$ pytype -j auto axlearn
...
Success: no errors found
```

#### pytest
```
pytest -v -n 96 -m "not (gs_login or tpu or high_cpu or fp64)" axlearn/common

========== 0 failed, 6220 passed, 10364 skipped in 734.23s (0:12:14) ==========
```