### PR TITLE
Fix Missing return statement in base_layer_test.py::ExplicitFanLayer::_compute_fan_axes

### DIFF
--- a/axlearn/common/base_layer_test.py
+++ b/axlearn/common/base_layer_test.py
@@ -614,7 +614,7 @@ class ComputeFanAxesTest(TestCase):
         def _compute_fan_axes(self, name: str, parameter_spec: ParameterSpec) -> Optional[FanAxes]:
             if name == "fan_axes_specified_weight":
                 raise RuntimeError("Should not be invoked.")
-            super()._compute_fan_axes(name, parameter_spec)
+            return super()._compute_fan_axes(name, parameter_spec)
 
     @parameterized.parameters(
         (


### PR DESCRIPTION
### Description

This PR addresses missing return statements in base_layer_test.py::ExplicitFanLayer::_compute_fan_axes

1. **`ComputeFanAxesTest`**:
   - Fixed the missing return statement in the `_compute_fan_axes` method to ensure it returns the result of `super()._compute_fan_axes(name, parameter_spec)` as intended.

#### pre-commit / pytype
```
$ pre-commit run --files $(git diff --name-only HEAD~1)
Check Yaml...........................................(no files to check)Skipped
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
black....................................................................Passed
isort....................................................................Passed
pylint...................................................................Passed
(axlearn-venv-cpu) 

$ pytype -j auto $(git diff --name-only HEAD~1)        
...
Success: no errors found
```