### PR TITLE
Fix Parameter Redefinition in learner_test.py

### DIFF
--- a/axlearn/common/learner_test.py
+++ b/axlearn/common/learner_test.py
@@ -1452,7 +1452,6 @@ class CompositeLearnerTest(TestCase):
                     rule: The rule from `cfg.masking_rules` to check agains.
                 """
                 cfg = self.config
-                tree: dict
 
                 rule_dict: dict[str, Union[optax.MaskedNode, None]] = cfg.rules[rule]
 


### PR DESCRIPTION
### Description
Removed the line `tree: dict:`
Since tree is already defined as a parameter with type `Nested[Any]`, there's no need to redefine it as `dict`

#### Testing
```
pytest -v -n 96 -m "not (gs_login or tpu or high_cpu or fp64)"  \
axlearn/common/learner_test.py

35 passed
```