### PR TITLE
AOT compilation support for inference

### DIFF
--- a/axlearn/cloud/gcp/system_characteristics.py
+++ b/axlearn/cloud/gcp/system_characteristics.py
@@ -339,7 +339,7 @@ USER_FACING_NAME_TO_SYSTEM_CHARACTERISTICS = {
         2,
         "tpu-v5-lite-podslice",
         "ct5lp-hightpu-4t",
-        8,
+        4,
         AcceleratorType["TPU"],
         "v5litepod-8",
     ),

--- a/axlearn/common/aot_compilation.py
+++ b/axlearn/common/aot_compilation.py
@@ -46,6 +46,9 @@ USER_FACING_NAME_TO_SYSTEM_CHARACTERISTICS = {
     "v6e-128": SystemCharacteristics("tpu", "v6e:8x16", "default", (2, 2, 1), 128),
     "v6e-256": SystemCharacteristics("tpu", "v6e:16x16", "default", (2, 2, 1), 256),
     # v5e
+    "v5e-1": SystemCharacteristics("tpu", "v5e:1x1", "default", (1, 1, 1), 1),
+    "v5e-4": SystemCharacteristics("tpu", "v5e:2x2", "default", (2, 2, 1), 4),
+    "v5e-8": SystemCharacteristics("tpu", "v5e:2x4", "default", (2, 2, 1), 8),
     "v5e-16": SystemCharacteristics("tpu", "v5e:4x4", "default", (2, 2, 1), 16),
     "v5e-32": SystemCharacteristics("tpu", "v5e:4x8", "default", (2, 2, 1), 32),
     "v5e-64": SystemCharacteristics("tpu", "v5e:8x8", "default", (2, 2, 1), 64),

--- a/axlearn/common/inference.py
+++ b/axlearn/common/inference.py
@@ -191,7 +191,13 @@ class InferenceRunner(Module):
         )
         return cfg
 
-    def __init__(self, cfg: Config, *, parent: Optional[Module]):
+    def __init__(
+        self,
+        cfg: Config,
+        *,
+        parent: Optional[Module],
+        devices: Optional[np.ndarray] = None,
+    ):
         super().__init__(cfg, parent=parent)
 
         cfg = self.config
@@ -206,7 +212,8 @@ class InferenceRunner(Module):
             [device.platform for device in jax.local_devices()],
         )
         logging.info("Mesh shape: %s", cfg.mesh_shape)
-        devices = utils.create_device_mesh(cfg.mesh_shape)
+        if devices is None:
+            devices = utils.create_device_mesh(cfg.mesh_shape)
         mesh = jax.sharding.Mesh(devices, cfg.mesh_axis_names)
         logging.info("Global mesh: %s", mesh)
         self._mesh = mesh


### PR DESCRIPTION
* Add optional `devices` init argument to InferenceRunner for passing fake devices during AOT compilation.
* Add more v5e slice types.