### PR TITLE
Fix flash decoding in GPU.

### DIFF
--- a/axlearn/common/flash_attention/utils.py
+++ b/axlearn/common/flash_attention/utils.py
@@ -212,7 +212,7 @@ def flash_attention_implementation(
                 if mask is None or mask.target_positions is None:
                     raise RuntimeError("Cannot retrive MaskFnAttentionBias or target_positions.")
                 mask_fn = mask.mask
-                kv_seq_len = mask.target_positions + 1
+                kv_seq_len = mask.target_positions[:, -1] + 1
                 logging.info("Using mask_fn=%s for FlashDecoding.", mask_fn)
 
                 bias = explicit_bias.value()


### PR DESCRIPTION
target_positions used to be time_step, but after PR #995, it now represents the actual target positions with shape [batch, step_len]. https://github.com/apple/axlearn/pull/995

Updating the GPU decoding code to align with this change.

CI did not cover GPU unit tests.

TEST=test_extend_step10 of axlearn/common/flash_attention/layer_test.py in GPU