### PR TITLE
Eliminating Unnecessary Quadratic Memory Usage in KV Cache Prefill

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -751,31 +751,50 @@ class KVCache(BaseKVCache):
         v_proj: Tensor,
         time_step: Tensor,
     ) -> tuple[Nested[Tensor], BaseKVCache.Output]:
-        # Update the cache via one-hot broadcast and addition.
-        # NB: Cache updates can also be done via dynamic slice update. However it was observed
-        # that RLHF training got stuck in some cases.
-        # TODO(ds-hwang): Investigate the root cause.
         cached_key: Tensor = cached_states["key"]
         cached_value: Tensor = cached_states["value"]
 
-        query_positions = jnp.arange(k_proj.shape[1])[None] + time_step[:, None]  # [batch, steps]
-        source_len = cached_key.shape[-1]
+        step_size = k_proj.shape[1]
+        query_positions = jnp.arange(step_size)[None] + time_step[:, None]  # [batch, steps]
 
         # [B, T, N, H] --> [B, N, H, T].
         k_proj = jnp.einsum("btnh->bnht", k_proj)
         v_proj = jnp.einsum("btnh->bnht", v_proj)
 
-        # Create a dispatch matrix of shape [B, T=step, S].
-        oh_indices = jax.nn.one_hot(query_positions, source_len, dtype=cached_key.dtype)
-        # Create a mask of shape [B, 1, 1, S].
-        negated_oh_indices = (1 - oh_indices.sum(axis=1))[:, None, None, :]
+        # On GPU, dynamic_update_slice_in_dim becomes faster when step size ≈ 32.
+        # On TPU, dynamic_update_slice_in_dim becomes faster when step size ≈ 1024.
+        threshold = 32 if jax.default_backend() != "tpu" else 1024
 
-        k_proj = jnp.einsum("b...t,bts->b...s", k_proj, oh_indices)
-        v_proj = jnp.einsum("b...t,bts->b...s", v_proj, oh_indices)
+        # dynamic_update_slice_in_dim is typically used for updating tensors, but we found that
+        # when step_size is small, one-hot matmul is 10-20% faster on both TPU and GPU.
+        if step_size < threshold:
+            source_len = cached_key.shape[-1]
+            # Create a dispatch matrix of shape [B, T=step, S].
+            oh_indices = jax.nn.one_hot(query_positions, source_len, dtype=cached_key.dtype)
+            # Create a mask of shape [B, 1, 1, S].
+            negated_oh_indices = (1 - oh_indices.sum(axis=1))[:, None, None, :]
 
-        # Ensure that we accumulate using the original dtype.
-        cached_key = cached_key * negated_oh_indices + k_proj.astype(cached_key.dtype)
-        cached_value = cached_value * negated_oh_indices + v_proj.astype(cached_value.dtype)
+            k_proj = jnp.einsum("b...t,bts->b...s", k_proj, oh_indices)
+            v_proj = jnp.einsum("b...t,bts->b...s", v_proj, oh_indices)
+
+            # Ensure that we accumulate using the original dtype.
+            cached_key = cached_key * negated_oh_indices + k_proj.astype(cached_key.dtype)
+            cached_value = cached_value * negated_oh_indices + v_proj.astype(cached_value.dtype)
+        else:
+            # Note: KV transpose is an optimization for one-hot matmul and is not related to
+            # dynamic_update_slice_in_dim. As a result, KV transpose only adds overhead for it.
+            # Since small step_size scenarios are more frequent, we accept slowdown in this case.
+
+            # Function to update the cache for a single batch element.
+            def update_single(cached_kv_slice, kv_proj_slice, time_idx):
+                return jax.lax.dynamic_update_slice_in_dim(
+                    cached_kv_slice, kv_proj_slice, time_idx, axis=-1
+                )
+
+            # Use jax.vmap to vectorize over the batch dimension.
+            vmap_update = jax.vmap(update_single)
+            cached_key = vmap_update(cached_key, k_proj, time_step)
+            cached_value = vmap_update(cached_value, v_proj, time_step)
 
         updated_state = dict(key=cached_key, value=cached_value)
         chex.assert_equal_shape((updated_state["key"], cached_key))


### PR DESCRIPTION
Eliminating Unnecessary Quadratic Memory Usage in KV Cache Prefill

When updating the KV cache, the current approach temporarily creates a [B,
step, kv_len] one-hot vector.
* This is fine when step is small, but problematic when step is large.
* For example, if video is used as a prefill, the KV cache update could cause
OOM errors.

Solution
* When step size is large, we update the KV cache using
  dynamic_update_slice_in_dim instead.

Benchmark Results
* On TPU, dynamic_update_slice_in_dim becomes faster when step size ≈ 1024.
* On GPU, dynamic_update_slice_in_dim becomes faster when step size ≈ 32.

Thus, we set different thresholds per platform.

Note:
* On GPU, dynamic_update_slice_in_dim significantly reduces memory usage.
* On TPU, however, both methods use about the same amount of memory as GPU's
  dynamic_update_slice_in_dim.

It seems that TPU's XLA compilation performs a "magical" memory optimization
for one-hot matmul somehow.

---

TPU v5p
* one-hot matmul
```
QkvLinearExtendStepBenchmark/2048/16/1024/1           0.380 ms        0.086 ms         8462
QkvLinearExtendStepBenchmark/2048/16/4096/1           0.599 ms        0.092 ms         8487
QkvLinearExtendStepBenchmark/2048/16/4096/64          0.562 ms        0.080 ms         8242
QkvLinearExtendStepBenchmark/2048/16/4096/512         0.654 ms        0.078 ms         8862
QkvLinearExtendStepBenchmark/2048/16/32768/1           2.18 ms        0.082 ms         8627 3.05 GB
QkvLinearExtendStepBenchmark/2048/16/32768/1024        2.77 ms        0.080 ms         1000 3.08 GB
QkvLinearExtendStepBenchmark/2048/16/32768/8192        15.6 ms        0.215 ms         1000 3.30 GB
QkvLinearExtendStepBenchmark/2048/16/32768/32768       53.5 ms        0.224 ms          100 4.05 GB
MHADecodeBenchmark/2048/16/1024/1                     0.358 ms        0.072 ms         9105
MHADecodeBenchmark/2048/16/4096/1                     0.542 ms        0.066 ms         9443
MHADecodeBenchmark/2048/16/4096/64                    0.556 ms        0.073 ms         9444
MHADecodeBenchmark/2048/16/4096/512                   0.710 ms        0.071 ms         9273
MHADecodeBenchmark/2048/16/32768/1                     1.95 ms        0.073 ms         9139 2.07 GB
MHADecodeBenchmark/2048/16/32768/1024                  7.36 ms        0.070 ms         1000 6.11 GB
MHADecodeBenchmark/2048/16/32768/8192                  55.7 ms        0.210 ms          100 34.38 GB
```

* dynamic_update_slice_in_dim
```
QkvLinearExtendStepBenchmark/2048/16/1024/1           0.374 ms        0.078 ms         8875
QkvLinearExtendStepBenchmark/2048/16/4096/1           0.572 ms        0.079 ms         8471
QkvLinearExtendStepBenchmark/2048/16/4096/64          0.575 ms        0.077 ms         9208
QkvLinearExtendStepBenchmark/2048/16/4096/512         0.666 ms        0.080 ms         8590
QkvLinearExtendStepBenchmark/2048/16/32768/1           2.15 ms        0.082 ms         8296 3.05 GB
QkvLinearExtendStepBenchmark/2048/16/32768/1024        2.34 ms        0.083 ms         8352 3.08 GB
QkvLinearExtendStepBenchmark/2048/16/32768/8192        4.17 ms        0.085 ms         1000 3.30 GB
QkvLinearExtendStepBenchmark/2048/16/32768/32768       10.8 ms        0.131 ms         1000 4.05 GB
MHADecodeBenchmark/2048/16/1024/1                     0.370 ms        0.071 ms        10258
MHADecodeBenchmark/2048/16/4096/1                     0.510 ms        0.070 ms        10296
MHADecodeBenchmark/2048/16/4096/64                     2.06 ms        0.070 ms        10345
MHADecodeBenchmark/2048/16/4096/512                    13.1 ms        0.207 ms         1000
MHADecodeBenchmark/2048/16/32768/1                     1.78 ms        0.074 ms        10033 2.07 GB
MHADecodeBenchmark/2048/16/32768/1024                  7.59 ms        0.068 ms         1000 6.11 GB
MHADecodeBenchmark/2048/16/32768/8192                  52.8 ms        0.206 ms          100 34.38 GB
```

A100
* one-hot matmul
```
QkvLinearExtendStepBenchmark/2048/16/1024/1           0.322 ms        0.180 ms         3523
QkvLinearExtendStepBenchmark/2048/16/4096/1           0.455 ms        0.201 ms         4016
QkvLinearExtendStepBenchmark/2048/16/4096/64          0.620 ms        0.188 ms         3524
QkvLinearExtendStepBenchmark/2048/16/4096/512         0.826 ms        0.218 ms         3551
QkvLinearExtendStepBenchmark/2048/16/32768/1           1.48 ms        0.203 ms         3608
QkvLinearExtendStepBenchmark/2048/16/32768/1024        4.36 ms        0.279 ms         1000 3.11 GB
QkvLinearExtendStepBenchmark/2048/16/32768/8192        18.0 ms        0.328 ms         1000 5.30 GB
QkvLinearExtendStepBenchmark/2048/16/32768/32768        108 ms        0.352 ms          100 12.05 GB
MHADecodeBenchmark/2048/16/1024/1                     0.307 ms        0.155 ms         4497
MHADecodeBenchmark/2048/16/4096/1                     0.389 ms        0.145 ms         4729
MHADecodeBenchmark/2048/16/4096/64                    0.586 ms        0.143 ms         4593
MHADecodeBenchmark/2048/16/4096/512                    1.16 ms        0.174 ms         4493
MHADecodeBenchmark/2048/16/32768/1                     1.16 ms        0.153 ms         4506
MHADecodeBenchmark/2048/16/32768/1024                  12.9 ms        0.257 ms         1000
MHADecodeBenchmark/2048/16/32768/8192                  88.7 ms        0.375 ms          100 66.31 GB
```

* dynamic_update_slice_in_dim
```
QkvLinearExtendStepBenchmark/2048/16/1024/1           0.345 ms        0.171 ms         3952
QkvLinearExtendStepBenchmark/2048/16/4096/1           0.502 ms        0.178 ms         3879
QkvLinearExtendStepBenchmark/2048/16/4096/64          0.544 ms        0.199 ms         3823
QkvLinearExtendStepBenchmark/2048/16/4096/512         0.583 ms        0.177 ms         3912
QkvLinearExtendStepBenchmark/2048/16/32768/1           2.04 ms        0.199 ms         3357
QkvLinearExtendStepBenchmark/2048/16/32768/1024        2.20 ms        0.218 ms         3322 3.08 GB
QkvLinearExtendStepBenchmark/2048/16/32768/8192        3.76 ms        0.264 ms         1000 3.30 GB
QkvLinearExtendStepBenchmark/2048/16/32768/32768       8.84 ms        0.282 ms         1000 4.05 GB
MHADecodeBenchmark/2048/16/1024/1                     0.299 ms        0.140 ms         5119
MHADecodeBenchmark/2048/16/4096/1                     0.473 ms        0.143 ms         4915
MHADecodeBenchmark/2048/16/4096/64                    0.591 ms        0.143 ms         4937
MHADecodeBenchmark/2048/16/4096/512                    1.01 ms        0.149 ms         4696
MHADecodeBenchmark/2048/16/32768/1                     1.50 ms        0.146 ms         4711
MHADecodeBenchmark/2048/16/32768/1024                  11.3 ms        0.250 ms         1000
MHADecodeBenchmark/2048/16/32768/8192                  74.1 ms        0.275 ms          100 66.31 GB
```