### PR TITLE
Allows the kwargs given in `cfg.instantiate(**kwargs)` override field values in `cfg` for FunctionConfigBase and ClassConfigBase.

### DIFF
--- a/axlearn/common/config.py
+++ b/axlearn/common/config.py
@@ -829,10 +829,6 @@ def _prepare_args_and_kwargs(
     """
     args = []
 
-    def insert_to_kwargs(k, v):
-        if k not in kwargs:
-            kwargs[k] = v
-
     for name, param in sig.parameters.items():
         if name == "self":
             continue
@@ -841,12 +837,12 @@ def _prepare_args_and_kwargs(
             args = value
         elif param.kind == inspect.Parameter.VAR_KEYWORD:
             for k, v in value.items():
-                insert_to_kwargs(k, v)
+                kwargs.setdefault(k, v)
         elif param.kind in (
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
             inspect.Parameter.KEYWORD_ONLY,
         ):
-            insert_to_kwargs(name, value)
+            kwargs.setdefault(name, value)
         else:
             raise NotImplementedError(f"Unsupported param kind {param.kind}: {name}")
 

--- a/axlearn/common/config_test.py
+++ b/axlearn/common/config_test.py
@@ -520,7 +520,7 @@ class ConfigTest(parameterized.TestCase):
         @struct.dataclass
         class Bias:
             shape: tuple[int, ...] = struct.field(kw_only=True, pytree_node=False)
-            positions: Optional[np.array] = None
+            positions: Optional[np.ndarray] = None
 
         cfg = config.config_for_class(Bias).set(shape=[1, 2])
         positions = np.asarray([0, 1])

--- a/axlearn/common/config_test.py
+++ b/axlearn/common/config_test.py
@@ -17,7 +17,7 @@ import numpy as np
 import wrapt
 from absl.testing import absltest, parameterized
 
-from axlearn.common import config
+from axlearn.common import config, struct
 from axlearn.common.config import (
     REQUIRED,
     ConfigBase,
@@ -516,6 +516,17 @@ class ConfigTest(parameterized.TestCase):
 
         self.assertEqual(param_shapes(layer1), param_shapes(layer2))
 
+    def test_class_with_tensor_fields(self):
+        @struct.dataclass
+        class Bias:
+            shape: tuple[int, ...] = struct.field(kw_only=True, pytree_node=False)
+            positions: Optional[np.array] = None
+
+        cfg = config.config_for_class(Bias).set(shape=[1, 2])
+        positions = np.asarray([0, 1])
+        bias = cfg.instantiate(positions=positions)
+        np.testing.assert_array_equal(bias.positions, positions)
+
     def test_instantiable_config_from_function_signature(self):
         def load(name: str, *, split: Optional[str] = None, download: bool = True):
             del name, split, download
@@ -549,8 +560,8 @@ class ConfigTest(parameterized.TestCase):
         cfg.var_kwargs = {"a": 1, "b": 2}
         self.assertEqual(cfg.var_kwargs, cfg.instantiate())
 
-        with self.assertRaisesRegex(ValueError, "already specified"):
-            self.assertEqual(cfg.var_kwargs, cfg.instantiate(a=3))
+        # Override the value of 'a' during instantiate().
+        self.assertEqual({"a": 3, "b": 2}, cfg.instantiate(a=3))
 
     @parameterized.parameters(
         # Test some basic cases.

--- a/axlearn/common/config_test.py
+++ b/axlearn/common/config_test.py
@@ -17,7 +17,7 @@ import numpy as np
 import wrapt
 from absl.testing import absltest, parameterized
 
-from axlearn.common import config, struct
+from axlearn.common import config
 from axlearn.common.config import (
     REQUIRED,
     ConfigBase,
@@ -517,9 +517,9 @@ class ConfigTest(parameterized.TestCase):
         self.assertEqual(param_shapes(layer1), param_shapes(layer2))
 
     def test_class_with_tensor_fields(self):
-        @struct.dataclass
+        @dataclasses.dataclass
         class Bias:
-            shape: tuple[int, ...] = struct.field(kw_only=True, pytree_node=False)
+            shape: tuple[int, ...]
             positions: Optional[np.ndarray] = None
 
         cfg = config.config_for_class(Bias).set(shape=[1, 2])


### PR DESCRIPTION
This makes it easier for `config_for_function` and `config_for_class` to be used for functions and classes that take args of types not allowed by Config fields, e.g., Tensor.