### PR TITLE
Async context invocation for checkpointing

### DIFF
--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -413,6 +413,10 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
             )
             return await asyncio.gather(*future_writer)
 
+        # Note: We need to run the coroutine in another event loop driven by a separate thread.
+        # The current event loop might be already running an async function when `serialize` is
+        # invoked from a coroutine, in which case asyncio.get_running_loop().run_until_complete()
+        # would not be able to execute another coroutine to completion.
         asyncio.run_coroutine_threadsafe(_run_serializer(), self._loop).result()
 
         self._add_futures(

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -423,6 +423,8 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
         # has finished writing.
         self._start_async_commit(on_commit_callback)
 
+    # Copied from (with modifications)
+    # https://github.com/jax-ml/jax/blob/66037d10e7742c4fcadd07f0459a00813ec7ed5f/jax/experimental/array_serialization/serialization.py#L413-L429
     def deserialize(
         self,
         shardings: Sequence[Union[jax.sharding.Sharding, layout.Layout]],


### PR DESCRIPTION
If `save_to_dir` / `restore_from_dir` are invoked from an async context, it will raise `RuntimeError: asyncio.run() cannot be called from a running event loop` due to the use of `asyncio.run` in `GlobalAsyncCheckpointManager`. 

This PR refactored the `GlobalAsyncCheckpointManager` implementation to create a separate event loop that runs in a dedicated thread for running async serializer and deserializer. With this change, `save_to_dir` / `restore_from_dir` can be invoked from both async and non-async context.