### PR TITLE
Fix crash in log-mel frontend when waveform samples are integers.

### DIFF
--- a/axlearn/audio/test_utils.py
+++ b/axlearn/audio/test_utils.py
@@ -23,8 +23,8 @@ def fake_audio(
         shape=[batch_size, seq_len],
         minval=-scale,
         maxval=scale,
-        dtype=dtype,
-    )
+        dtype=jnp.float32,
+    ).astype(dtype)
     lengths = jax.random.randint(length_key, shape=[batch_size, 1], minval=0, maxval=seq_len)
     paddings = (jnp.arange(seq_len)[None, :] >= lengths).astype(jnp.int32)
     return inputs, paddings


### PR DESCRIPTION
After updating JAX, this existing hidden bug started causing CI failures. When the sample dtype is int32 (which is valid), `jnp.finfo` returns None, even though `jnp.iinfo` is available.
The previous JAX version seemed to handle this case more forgivingly.

```
../axlearn/axlearn/audio/frontend_utils.py:297: in linear_to_log_spectrogram
    return jnp.log(jnp.maximum(x, jnp.finfo(x.dtype).tiny))
```