### PR TITLE
Add additional_node_networks config to support multi-nic for v6e

### DIFF
--- a/axlearn/cloud/gcp/job.py
+++ b/axlearn/cloud/gcp/job.py
@@ -319,6 +319,7 @@ class GKEJob(GCPJob):
             name=cfg.name,
             command=cfg.command,
             accelerator=cfg.accelerator,
+            project=cfg.project,
             env_vars=cfg.env_vars,
             service_account=cfg.service_account,
             enable_pre_provisioner=cfg.enable_pre_provisioner,


### PR DESCRIPTION
Add a `additional_node_networks` config field to support multi NIC. When such config is provided:
1. Extra annotation will be added for during pod yaml construction
2. `hostNetwork` will be enabled for the pod