### PR TITLE
Add an option to break ties for top_k_logits when k = 1

### DIFF
--- a/axlearn/common/logit_modifiers.py
+++ b/axlearn/common/logit_modifiers.py
@@ -170,7 +170,7 @@ def top_k_logits(k: int, *, break_ties: Literal["all", "smallest_index"] = "all"
         # not required in those cases.
         if k != 1:
             raise NotImplementedError(
-                f"Only support k=1 for break_ties = lowest-token-id, but got {k}."
+                f"Only k=1 supportes for {break_ties=}, but got {k}."
             )
         # Note different from numpy.argmax, jnp.argmax doesn't mention it returns
         # the first maximum value. We assume it follows np.argmax and have a unit

--- a/axlearn/common/logit_modifiers.py
+++ b/axlearn/common/logit_modifiers.py
@@ -172,6 +172,9 @@ def top_k_logits(k: int, break_ties: Literal["all", "lowest-token-id"] = "all") 
             raise NotImplementedError(
                 f"Only support k=1 for break_ties = lowest-token-id, but got {k}."
             )
+        # Note different from numpy.argmax, jnp.argmax doesn't mention it returns
+        # the first maximum value. We assume it follows np.argmax and have a unit
+        # test to check this.
         mask = jax.nn.one_hot(jnp.argmax(logits, axis=-1), logits.shape[-1], axis=-1)
         return jnp.where(mask, logits, NEG_INF)
 

--- a/axlearn/common/logit_modifiers.py
+++ b/axlearn/common/logit_modifiers.py
@@ -113,7 +113,7 @@ def top_p_logits(p: float) -> LogitsToLogitsFn:
     return fn
 
 
-def top_k_logits(k: int, stable: bool = False) -> LogitsToLogitsFn:
+def top_k_logits(k: int, limit_to_k: bool = False) -> LogitsToLogitsFn:
     """Build a function that returns logits suitably normalized for top-k sampling.
 
     The returned function does many reductions over the last axis of the input array.
@@ -125,7 +125,7 @@ def top_k_logits(k: int, stable: bool = False) -> LogitsToLogitsFn:
 
     Args:
         k: The maximum rank of logit to consider for sampling.
-        stable: If false, return all logits with the tied value (in total more than k).
+        limit_to_k: If false, return all logits with the tied value (in total more than k).
             Otherwise, return the first k tied values. Currently this only supports for k = 1.
 
     Returns:
@@ -158,16 +158,16 @@ def top_k_logits(k: int, stable: bool = False) -> LogitsToLogitsFn:
         threshold = -1 * _float32_binary_search(batched_shape, predicate=predicate)
         return jnp.where(logits >= jnp.expand_dims(threshold, -1), logits, NEG_INF)
 
-    def stable_fn(logits: Tensor) -> Tensor:
-        # Returns the first maximum value if there are ties for k = 1.
+    def limit_to_k_fn(logits: Tensor) -> Tensor:
+        # Returns the first maximum value when there are ties for k = 1.
         # Note this only supports for k = 1. We may consider to extend to k > 1 in
-        # the future, but the benefits may be limited, as deterministic is usually
+        # the future, but the benefits may be limited as determinism is usually
         # not required in those cases.
-        assert k == 1, f"Only support k=1 for stable top_k, but got {k}."
+        assert k == 1, f"Only support k=1 when limit_to_k = True, but got {k}."
         mask = jax.nn.one_hot(jnp.argmax(logits, axis=-1), logits.shape[-1], axis=-1)
         return jnp.where(mask, logits, NEG_INF)
 
-    return stable_fn if stable else fn
+    return limit_to_k_fn if limit_to_k else fn
 
 
 def _monotonic_int32_to_float32_bit_mask(x: Tensor) -> Tensor:

--- a/axlearn/common/logit_modifiers.py
+++ b/axlearn/common/logit_modifiers.py
@@ -134,7 +134,7 @@ def top_k_logits(k: int, *, break_ties: Literal["all", "smallest_index"] = "all"
 
     Raises:
         ValueError: If break_ties is invalid.
-        NotImplementedError: If braek_ties = lowest-token-id and k > 1.
+        NotImplementedError: If break_ties == "smallest_index" and k != 1.
     """
 
     def fn(logits: Tensor) -> Tensor:

--- a/axlearn/common/logit_modifiers.py
+++ b/axlearn/common/logit_modifiers.py
@@ -125,9 +125,9 @@ def top_k_logits(k: int, *, break_ties: Literal["all", "smallest_index"] = "all"
 
     Args:
         k: The maximum rank of logit to consider for sampling.
-        break_ties: `all`: return all logits with the tied value (in total more than k).
-            `lowest-token-id`: return the k tied values with lowest token id.
-            Currently this only supports for k = 1.
+        break_ties: Configures top-k behavior in the case of ties:
+            * "all": Return all logits with the tied value (in total more than k).
+            * "smallest_index": Return the k tied values with smallest index. Currently this only supports k = 1.
 
     Returns:
         A logits-to-logits function.

--- a/axlearn/common/logit_modifiers.py
+++ b/axlearn/common/logit_modifiers.py
@@ -113,7 +113,7 @@ def top_p_logits(p: float) -> LogitsToLogitsFn:
     return fn
 
 
-def top_k_logits(k: int, break_ties: Literal["all", "lowest-token-id"] = "all") -> LogitsToLogitsFn:
+def top_k_logits(k: int, *, break_ties: Literal["all", "smallest_index"] = "all") -> LogitsToLogitsFn:
     """Build a function that returns logits suitably normalized for top-k sampling.
 
     The returned function does many reductions over the last axis of the input array.

--- a/axlearn/common/logit_modifiers_test.py
+++ b/axlearn/common/logit_modifiers_test.py
@@ -108,7 +108,7 @@ class TestLogitsTransforms(TestCase):
             jnp.full((batch_size, 1), decoding.NEG_INF),
         )
 
-    def test_stable_top_k_modifier_with_ties(self):
+    def test_limit_top_k_modifier_with_ties(self):
         batch_size = 2
         vocab_size = 1024
         logits = jnp.concatenate(
@@ -118,7 +118,7 @@ class TestLogitsTransforms(TestCase):
             ),
             axis=-1,
         )
-        top_k_modified_logits = top_k_logits(1, stable=True)(logits)
+        top_k_modified_logits = top_k_logits(1, limit_to_k=True)(logits)
         # Only the first maximum value is returned.
         self.assertNestedAllClose(top_k_modified_logits[:, 0], logits[:, 0])
         # Check that the rest of the array is neg inf.

--- a/axlearn/common/logit_modifiers_test.py
+++ b/axlearn/common/logit_modifiers_test.py
@@ -111,7 +111,7 @@ class TestLogitsTransforms(TestCase):
     @parameterized.product(
         batch_size=[2, 8],
         vocab_size=[512, 1024],
-        break_ties=["all", "lowest-token-id"],
+        break_ties=["all", "smallest_index"],
     )
     def test_top_k_modifier_break_ties(self, batch_size, vocab_size, break_ties):
         logits = jnp.concatenate(


### PR DESCRIPTION
Add two options to break_ties for top_k_logits:
   * "all": Return all logits with the tied value (in total more than k).
     * This is the current behavior.  
   * "smallest_index": Return the k tied values with smallest index. Currently this only supports k = 1.
     * Allow for generating deterministic response for greedy decoding (k=1).

Tested: unit test
