### PR TITLE
Minor changes to Checkpointer

### DIFF
--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -459,7 +459,7 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
         return fut.result()
 
 
-class BoundedDataShardedAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
+class BoundedDataShardedAsyncCheckpointManager(GlobalAsyncCheckpointManager):
     """Similar to GlobalAsyncCheckpointManager but with few improvements:
 
     1. Writing to tensorstore requires no host-to-host copy most of the time. This reduces host


### PR DESCRIPTION
Some minor changes to Checkpointer
1. `_all_checkpoint_paths` now return full checkpoint paths to ensure similar semantic to `checkpoint_paths`. 
2. `_restore_tensorstore_state` now takes an optional sync argument to allow skipping a sync after restore.
3. Following https://github.com/apple/axlearn/pull/1012, allow `BoundedDataShardedAsyncCheckpointManager` to be called in async functions.