### PR TITLE
Refactor Mask in Attention

### DIFF
--- a/axlearn/common/attention_bias_test.py
+++ b/axlearn/common/attention_bias_test.py
@@ -40,30 +40,82 @@ class MaskTest(test_utils.TestCase):
 class AttentionBiasTest(test_utils.TestCase):
     @parameterized.parameters(
         [attention_bias.ZeroAttentionBias(), False],
-        [attention_bias.CausalAttentionBias(shape=(5, 5)), True],
-        [attention_bias.MaskFnAttentionBias(attention_bias.causal_mask, shape=(5, 5)), True],
+        [
+            attention_bias.CausalAttentionBias(
+                target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+            ),
+            True,
+        ],
+        [
+            attention_bias.MaskFnAttentionBias(
+                attention_bias.causal_mask,
+                target_positions=jnp.arange(5)[None],
+                source_positions=jnp.arange(5)[None],
+            ),
+            True,
+        ],
+        [
+            attention_bias.SlidingWindowAttentionBias(
+                attention_bias.sliding_window_causal_mask(sliding_window_size=3),
+                sliding_window_size=3,
+                target_positions=jnp.arange(5)[None],
+                source_positions=jnp.arange(5)[None],
+            ),
+            True,
+        ],
         [attention_bias.TensorAttentionBias.from_tensor(jnp.ones((5, 5))), True],
     )
     def test_has_bias(self, bias, expected):
         self.assertEqual(bias.has_value(), expected)
 
     def test_causal_attention_bias(self):
-        bias = attention_bias.CausalAttentionBias(shape=(5, 5))
+        bias = attention_bias.CausalAttentionBias(
+            target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+        )
         chex.assert_trees_all_close(bias.value(), attention_bias.make_causal_biases(5)[None, None])
         self.assertIsInstance(bias, attention_bias.CausalAttentionBias)
 
-        bias = attention_bias.MaskFnAttentionBias(attention_bias.causal_mask, shape=(5, 5))
+        bias = attention_bias.MaskFnAttentionBias(
+            attention_bias.causal_mask,
+            target_positions=jnp.arange(5)[None],
+            source_positions=jnp.arange(5)[None],
+        )
         self.assertNotIsInstance(bias, attention_bias.CausalAttentionBias)
+
+    def test_sliding_window_attention_bias(self):
+        bias = attention_bias.SlidingWindowAttentionBias(
+            target_positions=jnp.arange(5)[None],
+            source_positions=jnp.arange(5)[None],
+            mask=attention_bias.sliding_window_causal_mask(sliding_window_size=3),
+            sliding_window_size=3,
+        )
+        chex.assert_trees_all_close(
+            bias.value(),
+            attention_bias.make_sliding_window_causal_biases(5, sliding_window_size=3)[None, None],
+        )
+        self.assertIsInstance(bias, attention_bias.SlidingWindowAttentionBias)
+
+        bias = attention_bias.MaskFnAttentionBias(
+            attention_bias.sliding_window_causal_mask(sliding_window_size=3),
+            target_positions=jnp.arange(5)[None],
+            source_positions=jnp.arange(5)[None],
+        )
+        self.assertNotIsInstance(bias, attention_bias.SlidingWindowAttentionBias)
 
     def test_zero_attention_bias(self):
         bias = attention_bias.ZeroAttentionBias()
         self.assertEqual(bias.value(), None)
 
-        bias = attention_bias.MaskFnAttentionBias(None, shape=(5, 5))
+        bias = attention_bias.MaskFnAttentionBias(
+            None, target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+        )
         self.assertNotIsInstance(bias, attention_bias.ZeroAttentionBias)
 
         self.assertNotIsInstance(
-            attention_bias.CausalAttentionBias(shape=(5, 5)), attention_bias.ZeroAttentionBias
+            attention_bias.CausalAttentionBias(
+                target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+            ),
+            attention_bias.ZeroAttentionBias,
         )
 
     def test_base_attention_bias_value(self):
@@ -113,8 +165,12 @@ class AttentionBiasTest(test_utils.TestCase):
         [
             attention_bias.CompositeAttentionBias(
                 [
-                    attention_bias.CausalAttentionBias(shape=(5, 5)),
-                    attention_bias.CausalAttentionBias(shape=(5, 5)),
+                    attention_bias.CausalAttentionBias(
+                        target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+                    ),
+                    attention_bias.CausalAttentionBias(
+                        target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+                    ),
                 ]
             ),
             True,
@@ -122,7 +178,9 @@ class AttentionBiasTest(test_utils.TestCase):
         [
             attention_bias.CompositeAttentionBias(
                 [
-                    attention_bias.CausalAttentionBias(shape=(5, 5)),
+                    attention_bias.CausalAttentionBias(
+                        target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+                    ),
                     attention_bias.ZeroAttentionBias(),
                 ]
             ),
@@ -132,7 +190,9 @@ class AttentionBiasTest(test_utils.TestCase):
             attention_bias.CompositeAttentionBias(
                 [
                     attention_bias.ZeroAttentionBias(),
-                    attention_bias.CausalAttentionBias(shape=(5, 5)),
+                    attention_bias.CausalAttentionBias(
+                        target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+                    ),
                 ]
             ),
             True,
@@ -144,8 +204,14 @@ class AttentionBiasTest(test_utils.TestCase):
     def test_bias_and_residual_has_bias(self):
         bias = attention_bias.CompositeAttentionBias(
             [
-                attention_bias.CausalAttentionBias(shape=(5, 5)),
-                attention_bias.MaskFnAttentionBias(attention_bias.causal_mask, shape=(5, 5)),
+                attention_bias.CausalAttentionBias(
+                    target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+                ),
+                attention_bias.MaskFnAttentionBias(
+                    attention_bias.causal_mask,
+                    target_positions=jnp.arange(5)[None],
+                    source_positions=jnp.arange(5)[None],
+                ),
             ]
         )
         bias_and_residual = bias.bias_and_residual(attention_bias.CausalAttentionBias)
@@ -167,11 +233,18 @@ class AttentionBiasTest(test_utils.TestCase):
 
     def test_composite_attention_bias(self):
         # Test value().
-        b1 = attention_bias.CausalAttentionBias(shape=(5, 5))
+        b1 = attention_bias.CausalAttentionBias(
+            target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+        )
         # Opposite of causal mask.
-        b2 = attention_bias.MaskFnAttentionBias(shape=(5, 5), mask=lambda q, k: q < k)
+        b2 = attention_bias.MaskFnAttentionBias(
+            target_positions=jnp.arange(5)[None],
+            source_positions=jnp.arange(5)[None],
+            mask=lambda q, k: q < k,
+        )
         expected = attention_bias.MaskFnAttentionBias(
-            shape=(5, 5),
+            target_positions=jnp.arange(5)[None],
+            source_positions=jnp.arange(5)[None],
             mask=lambda q, k: jnp.zeros(jnp.broadcast_shapes(q.shape, k.shape), dtype=bool),
         )
         bias = attention_bias.CompositeAttentionBias([b1, b2])
@@ -205,9 +278,15 @@ class AttentionBiasTest(test_utils.TestCase):
 
     def test_bias_and_residual_repeated_call(self):
         """Test repeated calls to `bias_and_residual()`."""
-        b1 = attention_bias.CausalAttentionBias(shape=(5, 5))
+        b1 = attention_bias.CausalAttentionBias(
+            target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+        )
         # Opposite of causal mask.
-        b2 = attention_bias.MaskFnAttentionBias(shape=(5, 5), mask=lambda q, k: q < k)
+        b2 = attention_bias.MaskFnAttentionBias(
+            target_positions=jnp.arange(5)[None],
+            source_positions=jnp.arange(5)[None],
+            mask=lambda q, k: q < k,
+        )
         bias = attention_bias.CompositeAttentionBias([b2, b1])
         causal_bias, residual = bias.bias_and_residual(attention_bias.CausalAttentionBias)
         mask_fn_bias, residual = residual.bias_and_residual(attention_bias.MaskFnAttentionBias)
@@ -223,9 +302,15 @@ class AttentionBiasTest(test_utils.TestCase):
         self.assertIs(bias_and_residual.residual.value(), None)
 
     def test_split(self):
-        b1 = attention_bias.CausalAttentionBias(shape=(5, 5))
+        b1 = attention_bias.CausalAttentionBias(
+            target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+        )
         # Opposite of causal mask.
-        b2 = attention_bias.MaskFnAttentionBias(shape=(5, 5), mask=lambda q, k: q < k)
+        b2 = attention_bias.MaskFnAttentionBias(
+            target_positions=jnp.arange(5)[None],
+            source_positions=jnp.arange(5)[None],
+            mask=lambda q, k: q < k,
+        )
         bias = attention_bias.CompositeAttentionBias([b2, b1])
         causal_bias, mask_fn_bias, residual = attention_bias.split(
             bias, attention_bias.CausalAttentionBias, attention_bias.MaskFnAttentionBias
@@ -247,9 +332,21 @@ class AttentionBiasTest(test_utils.TestCase):
         self.assertIs(residual.value(), None)
 
     @parameterized.product(
-        causal=[None, attention_bias.CausalAttentionBias(shape=(3, 3))],
+        causal=[
+            None,
+            attention_bias.CausalAttentionBias(
+                target_positions=jnp.arange(3)[None], source_positions=jnp.arange(3)[None]
+            ),
+        ],
         segment_ids=[None, attention_bias.SegmentIdAttentionBias(jnp.asarray([1, 2, 3]))],
-        mask=[None, attention_bias.MaskFnAttentionBias(mask=lambda q, k: q < k, shape=(3, 3))],
+        mask=[
+            None,
+            attention_bias.MaskFnAttentionBias(
+                mask=lambda q, k: q < k,
+                target_positions=jnp.arange(3)[None],
+                source_positions=jnp.arange(3)[None],
+            ),
+        ],
     )
     def test_split_subsets(
         self,
@@ -303,9 +400,15 @@ class AttentionBiasTest(test_utils.TestCase):
 
     def test_mask_fn_attention_bias_from_sequence(self):
         """Tests `MaskFnAttentionBias.from_sequence()`."""
-        b1 = attention_bias.CausalAttentionBias(shape=(5, 5))
+        b1 = attention_bias.CausalAttentionBias(
+            target_positions=jnp.arange(5)[None], source_positions=jnp.arange(5)[None]
+        )
         # Opposite of causal mask.
-        b2 = attention_bias.MaskFnAttentionBias(shape=(5, 5), mask=lambda q, k: q < k)
+        b2 = attention_bias.MaskFnAttentionBias(
+            target_positions=jnp.arange(5)[None],
+            source_positions=jnp.arange(5)[None],
+            mask=lambda q, k: q < k,
+        )
 
         self.assertNestedEqual(
             attention_bias.MaskFnAttentionBias.from_sequence([b1, b2]).value(), (b1 + b2).value()
@@ -317,13 +420,21 @@ class AttentionBiasTest(test_utils.TestCase):
         self.assertIs(attention_bias.MaskFnAttentionBias.from_sequence([]), None)
 
     def test_mask_fn_attention_bias(self):
-        bias = attention_bias.MaskFnAttentionBias(mask=lambda q, k: q >= k, shape=(5, 5))
+        bias = attention_bias.MaskFnAttentionBias(
+            mask=lambda q, k: q >= k,
+            target_positions=jnp.arange(5)[None],
+            source_positions=jnp.arange(5)[None],
+        )
         self.assertNestedEqual(
             bias.value(), jnp.asarray(attention_bias.make_causal_biases(5))[None, None]
         )
 
+        target_positions = jnp.arange(4)[None] + jnp.asarray([3, 1])[:, None]
+        source_positions = jnp.arange(7)[None]
         bias = attention_bias.MaskFnAttentionBias(
-            mask=lambda q, k: q >= k, shape=(4, 7), target_positions=jnp.asarray([3, 1])
+            mask=lambda q, k: q >= k,
+            target_positions=target_positions,
+            source_positions=source_positions,
         )
         expected = jnp.asarray(
             [
@@ -349,8 +460,8 @@ class AttentionBiasTest(test_utils.TestCase):
         """Tests mask_fn_attention_bias` when `target_positions.ndim == 2."""
         bias = attention_bias.MaskFnAttentionBias(
             mask=attention_bias.causal_mask,
-            shape=(5, 5),
             target_positions=jnp.asarray([[0, 1, 2, 3, 4], [4, 3, 2, 1, 0]]),
+            source_positions=jnp.arange(5)[None],
         )
         expected = jnp.asarray(
             [
@@ -376,11 +487,15 @@ class AttentionBiasTest(test_utils.TestCase):
             self.assertEqual(source_positions.shape, (1, 1, source_len))
             return attention_bias.causal_mask(target_positions, source_positions)
 
+        target_positions = jnp.arange(target_len)[None] + time_step[:, None]
+        source_positions = jnp.arange(source_len)[None]
         bias = attention_bias.MaskFnAttentionBias(
-            mask=mask_fn, shape=(target_len, source_len), target_positions=time_step
+            mask=mask_fn, target_positions=target_positions, source_positions=source_positions
         )
         ref_bias = attention_bias.MaskFnAttentionBias(
-            attention_bias.causal_mask, shape=(target_len, source_len), target_positions=time_step
+            attention_bias.causal_mask,
+            target_positions=target_positions,
+            source_positions=source_positions,
         )
         chex.assert_trees_all_close(bias.value(), ref_bias.value())
 

--- a/axlearn/common/decoder.py
+++ b/axlearn/common/decoder.py
@@ -617,7 +617,7 @@ class Decoder(BaseLayer):
         cfg: Decoder.Config = self.config
         init_state, _ = self.transformer.init_states(
             time_step=None,
-            data=TensorSpec([batch_size, max_sequence_length, cfg.dim]),
+            data=TensorSpec([batch_size, max_sequence_length, cfg.dim], dtype=jnp.float32),
         )
         return dict(
             transformer_state=init_state,

--- a/axlearn/common/dit_test.py
+++ b/axlearn/common/dit_test.py
@@ -21,8 +21,7 @@ from absl.testing import absltest, parameterized
 from timm.models.vision_transformer import Attention, Mlp, PatchEmbed
 from torch import nn
 
-from axlearn.common.attention_bias import NEG_INF, causal_mask, sliding_window_causal_mask
-from axlearn.common.config import config_for_function
+from axlearn.common.attention_bias import NEG_INF, CausalAttentionBias, SlidingWindowAttentionBias
 from axlearn.common.dit import (
     AdaptiveLayerNormModulation,
     DiTAttentionLayer,
@@ -643,10 +642,8 @@ class TestDiTAttn(parameterized.TestCase):
             )
             assert_allclose(layer_output.shape, inputs.shape)
 
-    @parameterized.parameters(
-        [causal_mask, config_for_function(sliding_window_causal_mask).set(sliding_window_size=10)]
-    )
-    def test_dit_attn_extend_step(self, mask):
+    @parameterized.parameters("causal", "sliding_window")
+    def test_dit_attn_extend_step(self, causal_type):
         batch_size = 2
         seq_len = 12
         dim = 32
@@ -664,7 +661,12 @@ class TestDiTAttn(parameterized.TestCase):
             target_dim=dim,
         )
         layer_cfg.attention.num_heads = num_heads
-        layer_cfg.attention.mask = mask
+        if causal_type == "causal":
+            layer_cfg.attention.mask = CausalAttentionBias.default_config()
+        elif causal_type == "sliding_window":
+            layer_cfg.attention.mask = SlidingWindowAttentionBias.default_config(
+                sliding_window_size=10
+            )
 
         layer = layer_cfg.instantiate(parent=None)
         prng_key, init_key = jax.random.split(prng_key)
@@ -754,13 +756,10 @@ class TestDiTBlock(parameterized.TestCase):
         assert_allclose(layer_output, as_tensor(ref_output))
 
     @parameterized.product(
-        mask=[
-            causal_mask,
-            config_for_function(sliding_window_causal_mask).set(sliding_window_size=10),
-        ],
+        causal_type=["causal", "sliding_window"],
         seq_cond=[False, True],
     )
-    def test_dit_block_extend_step(self, mask, seq_cond):
+    def test_dit_block_extend_step(self, causal_type, seq_cond):
         batch_size = 2
         seq_len = 12
         dim = 32
@@ -775,7 +774,12 @@ class TestDiTBlock(parameterized.TestCase):
 
         layer_cfg = DiTBlock.default_config().set(name="test", input_dim=dim)
         layer_cfg.attention.attention.num_heads = num_heads
-        layer_cfg.attention.attention.mask = mask
+        if causal_type == "causal":
+            layer_cfg.attention.attention.mask = CausalAttentionBias.default_config()
+        elif causal_type == "sliding_window":
+            layer_cfg.attention.attention.mask = SlidingWindowAttentionBias.default_config(
+                sliding_window_size=10
+            )
 
         layer = layer_cfg.instantiate(parent=None)
         prng_key, init_key = jax.random.split(prng_key)

--- a/axlearn/common/encoder.py
+++ b/axlearn/common/encoder.py
@@ -174,7 +174,7 @@ class CausalEncoder(Encoder):
         cfg: CausalEncoder.Config = self.config
         init_state, _ = self.transformer.init_states(
             time_step=None,
-            data=TensorSpec([batch_size, max_sequence_length, cfg.dim]),
+            data=TensorSpec([batch_size, max_sequence_length, cfg.dim], dtype=jnp.float32),
         )
         return dict(
             transformer_state=init_state,

--- a/axlearn/common/flash_attention/gpu_attention.py
+++ b/axlearn/common/flash_attention/gpu_attention.py
@@ -42,7 +42,7 @@ from jax._src.cudnn.fused_attention_stablehlo import MaskType, dot_product_atten
 from jax.ad_checkpoint import checkpoint_name
 from jax.experimental import pallas as pl
 
-from axlearn.common.attention import NEG_INF, MaskFn
+from axlearn.common.attention_bias import NEG_INF, MaskFn
 from axlearn.common.flash_attention.remat import FLASH_ATTN_RESIDUAL_NAME
 from axlearn.common.layers import get_dropout_mask
 from axlearn.common.utils import Tensor

--- a/axlearn/common/flash_attention/gpu_decoding.py
+++ b/axlearn/common/flash_attention/gpu_decoding.py
@@ -49,8 +49,9 @@ from jax import lax
 from jax._src.cudnn.fused_attention_stablehlo import check_compute_capability
 from jax.experimental import pallas as pl
 
-from axlearn.common.attention import NEG_INF, MaskFn, Tensor
+from axlearn.common.attention_bias import NEG_INF, MaskFn
 from axlearn.common.flash_attention.gpu_attention import NoPopDict
+from axlearn.common.utils import Tensor
 
 
 # Note: split_k_seq_len must be a multiple of block_k.

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -36,6 +36,7 @@ from axlearn.common.attention import apply_attention_logit_biases
 from axlearn.common.attention_bias import (
     CausalAttentionBias,
     MaskFnAttentionBias,
+    SlidingWindowAttentionBias,
     ZeroAttentionBias,
     as_attention_bias,
 )
@@ -147,11 +148,12 @@ def tpu_flash_attention(
             # and 1.14x in 539.5b.
             use_fused_bwd_kernel=True,
         )
+        splash_mask = _to_splash_mask(mask, mask_shape=(query.shape[2], key.shape[2]))
         context = _tpu_splash_attention(
             query,
             key,
             value,
-            mask=mask,
+            splash_mask=splash_mask,
             segment_ids=segment_ids,
             block_sizes=block_sizes,
             interpret=interpret,
@@ -172,13 +174,16 @@ def tpu_flash_attention(
             block_k_dq=block_size,
             block_q_dq=block_size,
         )
+        causal = isinstance(mask, CausalAttentionBias)
+        if not causal and mask.has_value():
+            bias = apply_attention_logit_biases(mask.value(), bias)
         context = _legacy_tpu_flash_attention(
             query,
             key,
             value,
             bias,
             segment_ids=segment_ids,
-            mask=mask,
+            causal=causal,
             block_sizes=block_sizes,
             interpret=interpret,
         )
@@ -195,7 +200,7 @@ def tpu_flash_attention(
 @functools.partial(
     jax.jit,
     static_argnames=[
-        "mask",  # Mask objects don't actually contain jax arrays, so they are static.
+        "causal",
         "block_sizes",
         "interpret",
     ],
@@ -207,7 +212,7 @@ def _legacy_tpu_flash_attention(
     bias: Tensor = None,  # [batch_size, num_heads, target_len, source_len]
     segment_ids: Tensor = None,  # [batch_size, target_len]
     *,
-    mask: MaskFnOrZero,
+    causal: bool = False,
     block_sizes: Optional[LegacyBlockSizes] = None,
     interpret: bool = False,
 ) -> Tensor:  # [batch_size, num_heads, target_len, head_dim].
@@ -223,7 +228,7 @@ def _legacy_tpu_flash_attention(
         segment_ids: The id of which segment each token belongs to. Attention is not computed
              between tokens in different segments.
              Shape:  [batch_size, target_len].
-        mask: The mask to apply. This is more compute efficient compared to setting bias = -inf.
+        causal: Whether it's causal attention.
         block_sizes: An object containing values that can be used to tune the performance
             such as the block size to chunk things into.
         interpret: If True, interpret the kernel using the pallas interpreter. CPU needs it.
@@ -234,10 +239,6 @@ def _legacy_tpu_flash_attention(
     Raises:
         NotImplementedError: If a custom (non-causal, non-full) mask is specified.
     """
-    causal = isinstance(mask, CausalAttentionBias)
-    if not causal and mask.has_value():
-        bias = apply_attention_logit_biases(mask.value(), bias)
-
     context = pallas_tpu_flash_attention(
         q=query,
         k=key,
@@ -251,7 +252,6 @@ def _legacy_tpu_flash_attention(
         debug=False,
         interpret=interpret,
     )
-
     return context
 
 
@@ -301,11 +301,12 @@ def check_tpu_splash_attention(
         )
     if mask.has_value():
         assert isinstance(mask, MaskFnAttentionBias)
+        if not isinstance(mask, (CausalAttentionBias, SlidingWindowAttentionBias)):
+            raise SplashAttentionUnsupportedError(f"{mask=} is not supported.")
         if is_decoding:
             # TODO(dhwang2): support splash decoding via splash NumPy mask.
             raise SplashAttentionUnsupportedError(
-                "Currently, we don't support Splash Attention in extend_step because the query and "
-                "key lengths are different, making it impossible to use the lazy mask."
+                "Query and key/value must have same length when mask is used."
             )
         else:
             if target_len != source_len:
@@ -324,10 +325,8 @@ def _to_splash_mask(
     assert isinstance(mask, MaskFnAttentionBias)
     if isinstance(mask, CausalAttentionBias):
         return splash_attention_mask.CausalMask(shape=mask_shape, shard_count=q_seq_shards)
-    if hasattr(mask.mask, "_sliding_window_size"):
-        # TODO(dhwang2): introduce SlidingWindowAttentionBias instead of "_sliding_window_size".
-        # This is set in sliding_window_causal_mask().
-        left_size = getattr(mask.mask, "_sliding_window_size")
+    elif isinstance(mask, SlidingWindowAttentionBias):
+        left_size = mask.sliding_window_size
         return splash_attention_mask.LocalMask(
             shape=mask_shape, window_size=(left_size, 0), offset=0, shard_count=q_seq_shards
         )
@@ -345,14 +344,14 @@ def _to_splash_mask(
 
 @functools.partial(
     jax.jit,
-    static_argnames=["block_sizes", "interpret"],
+    static_argnames=["splash_mask", "block_sizes", "interpret"],
 )
 def _tpu_splash_attention(
     query: Tensor,  # [batch_size, num_heads, target_len, head_dim]
     key: Tensor,  # [batch_size, num_heads, source_len, head_dim]
     value: Tensor,  # [batch_size, num_heads, source_len, head_dim]
     *,
-    mask: MaskFnOrZero,
+    splash_mask: splash_attention_mask.Mask,
     segment_ids: Optional[Tensor] = None,  # [batch_size, target_len]
     block_sizes: Optional[splash_attention_kernel.BlockSizes] = None,
     interpret: bool = False,
@@ -386,9 +385,6 @@ def _tpu_splash_attention(
     # TODO(dhwang2): splash attention can support segment_ids. Support it when needed.
     del segment_ids
     num_heads = query.shape[1]
-    mask_shape = (query.shape[2], key.shape[2])
-    splash_mask = _to_splash_mask(mask, mask_shape=mask_shape)
-
     kernel = splash_attention_kernel.make_splash_mha(
         mask=splash_attention_mask.MultiHeadMask(masks=[splash_mask] * num_heads),
         block_sizes=block_sizes,

--- a/axlearn/common/flash_attention/utils.py
+++ b/axlearn/common/flash_attention/utils.py
@@ -189,7 +189,8 @@ def flash_attention_implementation(
                 if mask is None or mask.target_positions is None:
                     raise RuntimeError("Cannot retrive MaskFnAttentionBias or target_positions.")
                 mask_fn = mask.mask
-                kv_seq_len = mask.target_positions + 1
+                query_time_step = mask.target_positions[:, -1]
+                kv_seq_len = query_time_step + 1
                 logging.info("Using mask_fn=%s for FlashDecoding.", mask_fn)
 
                 bias = explicit_bias.value()

--- a/axlearn/common/lora_test.py
+++ b/axlearn/common/lora_test.py
@@ -263,7 +263,7 @@ class LoraFusedQKVLinearTest(TestCase):
 
         initial_cache_state, init_output = layer.init_states(
             time_step=None,
-            query=TensorSpec([batch_size, seq_len]),
+            query=TensorSpec([batch_size, seq_len], dtype=q_proj.dtype),
         )
         self.assertIsNone(init_output)
 

--- a/axlearn/common/multiway_transformer_test.py
+++ b/axlearn/common/multiway_transformer_test.py
@@ -139,7 +139,7 @@ class ModelTest(parameterized.TestCase):
             prng_key=jax.random.PRNGKey(0),
         )
         initial_state, initial_output = layer.init_states(
-            time_step=None, data=TensorSpec([batch_size, tgt_len])
+            time_step=None, data=TensorSpec([batch_size, tgt_len], dtype=jnp.float32)
         )
         self.assertIsNone(initial_output)
         inputs = dict(

--- a/axlearn/common/ssm_test.py
+++ b/axlearn/common/ssm_test.py
@@ -424,7 +424,7 @@ class MambaMixerLayerTest(TestCase):
         )
         initial_state, initial_output = layer.init_states(
             time_step=None,
-            query=TensorSpec([batch_size, tgt_len]),
+            query=TensorSpec([batch_size, tgt_len], dtype=dtype),
         )
         self.assertIsNone(initial_output)
         for k in ["conv_input", "state"]:
@@ -552,9 +552,9 @@ def _test_extend_step(layer_cfg: InstantiableConfig, *, model_dim: int, dtype: j
         inputs=inputs,
     )
     if isinstance(layer, MambaMixerLayer):
-        init_kwargs = dict(query=TensorSpec([batch_size, tgt_len]))
+        init_kwargs = dict(query=TensorSpec([batch_size, tgt_len], dtype=dtype))
     else:
-        init_kwargs = dict(data=TensorSpec([batch_size, tgt_len]))
+        init_kwargs = dict(data=TensorSpec([batch_size, tgt_len], dtype=dtype))
     initial_state, initial_output = layer.init_states(time_step=None, **init_kwargs)
     assert initial_output is None
     inputs = dict(cached_states=initial_state)

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -52,7 +52,7 @@ Nested = Union[_NestedT, dict[str, "Nested[_NestedT]"]]
 
 Tensor = jax.Array
 NestedTree = Union[Any, dict[str, Any]]
-NestedTensor = Union[Tensor, dict[str, Any]]
+NestedTensor = Union[Tensor, dict[str, Any]]  # DEPRECATED, use Nested[Tensor].
 NestedPartitionSpec = Optional[Union[PartitionSpec, dict[str, Any]]]
 
 # The device mesh shape in the form of a tuple of ints.

--- a/axlearn/vision/coca.py
+++ b/axlearn/vision/coca.py
@@ -663,7 +663,7 @@ class CoCaCaptioningFusionNetwork(FusionNetwork):
         cfg = self.config
         init_state, _ = self.transformer.init_states(
             time_step=None,
-            data=TensorSpec([batch_size, max_sequence_length, cfg.dim]),
+            data=TensorSpec([batch_size, max_sequence_length, cfg.dim], dtype=jnp.float32),
         )
         return dict(transformer_state=init_state)
 


### PR DESCRIPTION
Currently, the attention code is **hardcoded** to handle either `causal_mask` or an arbitrary `mask_fn`.

To support **sliding window masks**, we previously used a **hack** by injecting the `_sliding_window_size` attribute into functions.

This refactor **makes the masking logic more flexible** by allowing arbitrary `MaskFnAttentionBias`.
If downstream requires a **new mask pattern**, they can simply:
  1. Implement a **subclass of `MaskFnAttentionBias`**.
  2. Set `attention.mask` accordingly.