### PR TITLE
Trainer: the model analysis on the AOT compiled JAX program.

### DIFF
--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -50,7 +50,7 @@ from axlearn.common.learner import UpdateType, should_update_with_optimizers
 from axlearn.common.module import Module
 from axlearn.common.monitoring.device_monitor import DeviceMonitor
 from axlearn.common.state_builder import Builder as TrainerStateBuilder
-from axlearn.common.trainer import SpmdTrainer, TrainerState, select_mesh_config
+from axlearn.common.trainer import SpmdTrainer, TrainerState, aot_model_analysis, select_mesh_config
 from axlearn.common.trainer_config_modifier import (
     ChainConfigModifier,
     GradientAccumulationModifier,
@@ -586,6 +586,10 @@ class TrainerTest(test_utils.TestCase):
         compiled_with_input_batch = trainer.compile_train_step(input_batch=input_batch)
         # In a single-host environment, both compiled functions should match.
         self.assertEqual(compiled_without_args.as_text(), compiled_with_input_batch.as_text())
+        self.assertEqual(
+            aot_model_analysis(compiled_without_args),
+            aot_model_analysis(compiled_with_input_batch),
+        )
 
         # A version compiled with non-default compiled args should be different.
         compiled_with_compiler_options = trainer.compile_train_step(
@@ -599,6 +603,10 @@ class TrainerTest(test_utils.TestCase):
         )
         self.assertEqual(
             compiled_without_args.as_text(), compiled_with_trainer_state_and_input_batch.as_text()
+        )
+        self.assertEqual(
+            aot_model_analysis(compiled_without_args),
+            aot_model_analysis(compiled_with_trainer_state_and_input_batch),
         )
 
     @parameterized.parameters(

--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -20,13 +20,12 @@ Reference: https://jax.readthedocs.io/en/latest/aot.html
 import pickle
 from typing import Optional
 
-import prefixed
 from absl import app, flags, logging
 from jax.experimental.serialize_executable import serialize
 
 from axlearn.common import compiler_options
 from axlearn.common.aot_compilation import compile_trainer_programs
-from axlearn.common.trainer import SpmdTrainer, select_mesh_config
+from axlearn.common.trainer import SpmdTrainer, aot_model_analysis, select_mesh_config
 from axlearn.common.utils import set_data_dir
 from axlearn.common.utils_spmd import setup
 from axlearn.experiments import TrainerConfigFn, get_named_trainer_config
@@ -67,18 +66,7 @@ def _compile_and_dump_programs(
         print(f"== Text: {program_name} ==")
         print(program.as_text())
         print()
-        print(f"== Cost analysis {program_name} ==")
-        print(program.cost_analysis())
-        print()
-        print(f"== Memory analysis {program_name} ==")
-        memory_analysis = program.memory_analysis()
-        for k in dir(memory_analysis):
-            v = getattr(memory_analysis, k)
-            if k.startswith("_"):
-                continue
-            if "bytes" in k:
-                v = f"{prefixed.Float(v):!.3K}B"
-            print(f"\t{k}: {v}")
+        print(aot_model_analysis(program))
         print()
 
         # Serialization does not work for CPU devices:


### PR DESCRIPTION
Trainer: the model analysis on the AOT compiled JAX program.

This will help researchers estimate HBM usage and computation costs before
launching a job, allowing them to determine whether a model is compute-bound or
memory-bound.

Introduced aot_model_analysis(), which returns analysis results as a string,
making it reusable (e.g., in Jupyter notebooks).

`run_aot_compilation` tool prints fuji-1B-v3 model analysis as follows.
```
======= Memory Analysis ==================================
Input memory: 4.4GB
Output memory: 4.4GB
Temp memory: 170.9GB
Code memory: 0.0MB
Total HBM memory: 179.6GB
======= Cost Analysis ====================================
FLOPS: 70052.0G
The number of exp/log/sin/cos ops: 20.9G
The total memory traffic: 1750.7GB
  HBM access: 733.9GB
  L2 cache access: 321.0GB
  Register usage: 59.8GB
  Output data transferred: 661.4GB
Hardware utilization scores
  Tensor Cores / MatMul units: 630.0
  ALU (Arithmetic Logic Unit): 416.0
  Memory Load/Store Units: 143.0
  L1 Cache Operations: 92.0
  L2 Cache Operations: 60.0
  Special Function Units (exp/log/sin/cos): 41.0
  Integer Units (for indexing, loop counters): 16.0
  Branch Divergence (Control Flow Processing): 12.0
  Load Balancing / Dispatch): 10.0
  Texture Units (or Rarely Used Compute Units): 8.0
```
