### PR TITLE
Implements TPU decoding in Pallas

### DIFF
--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -1,0 +1,88 @@
+# Copyright © 2025 Apple Inc.
+"""Common utilities across backends."""
+
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.experimental import pallas as pl
+
+from axlearn.common.attention_bias import MaskFn
+from axlearn.common.utils import Tensor
+
+
+def build_mask(
+    mask_fn: MaskFn, *, q_seq_len: int, kv_seq_len: int, block_q: int, block_k: int
+) -> np.ndarray:
+    """Builds the block map where True means the block is not fully masked.
+
+    Args:
+        mask_fn: The attention mask function.
+        q_seq_len: Query sequence length.
+        kv_seq_len: Key/Value sequence length.
+        block_q: Query block size.
+        block_k: Key/Value block size.
+
+    Returns:
+        A boolean array of shape (num_q_blocks, num_kv_blocks) where True means the block is not
+        fully masked. num_q_blocks * block_q will be larger than q_seq_len if q_seq_len is not
+        divisible by block_q. The same holds true for kv blocks.
+    """
+    # Initialize the iteration map where True means the block is not empty.
+    num_q_blocks = pl.cdiv(q_seq_len, block_q)
+    num_kv_blocks = pl.cdiv(kv_seq_len, block_k)
+    block_mask_map = np.ones(shape=(num_q_blocks, num_kv_blocks), dtype=np.bool_)
+    # # Initialize the scan begin and end indices.
+    rows = np.arange(q_seq_len, dtype=np.int32)
+    cols = np.arange(kv_seq_len, dtype=np.int32)
+    # Run a compile-time evaluation to get the mask array.
+    # TODO(kelvin-zou): use a block-wise mask function to avoid the compile-time
+    # high memory usage.
+    with jax.ensure_compile_time_eval():
+        mask_array = np.asarray(mask_fn(rows[:, None], cols[None, :]))
+    for i in range(0, q_seq_len, block_q):
+        for j in range(0, kv_seq_len, block_k):
+            # Extract the block
+            block = mask_array[i : i + block_q, j : j + block_k]
+            # All empty means skipping
+            if not block.any():
+                block_mask_map[i // block_q, j // block_k] = False
+    return block_mask_map
+
+
+class KVOffsetInfo(NamedTuple):
+    """Records the block index of non-empty KV blocks.
+
+    Attributes:
+        kv_block_offset: A (num_q_blocks, num_kv_blocks) tensor where `kv_block_offset[i][j]`
+            stores the index of the jth non-empty KV block index for the ith query block.
+            This tensor may be padded at the end.
+        kv_block_offset_size: A (num_q_blocks,) tensor that stores the number of valid entries
+            for each row of `kv_block_offset`, i.e. the number of entries before padding.
+    """
+
+    kv_block_offset: Tensor
+    kv_block_offset_size: Tensor
+
+
+def query_iterator_indices(block_mask_map: np.ndarray, *, padding: int = 0) -> KVOffsetInfo:
+    """Builds `KVOffsetInfo` for block-sparse attention computation in the forward pass.
+
+    Returns:
+        A `KVOffsetInfo`. See the attributes of `KVOffsetInfo` for more info.
+    """
+    num_q_blocks, num_kv_blocks = block_mask_map.shape
+    index_offset = np.full((num_q_blocks, num_kv_blocks), padding, dtype=np.int32)
+    index_offset_size = np.zeros(shape=(num_q_blocks), dtype=np.int32)
+    for i in range(num_q_blocks):
+        k = 0
+        for j in range(num_kv_blocks):
+            if block_mask_map[i, j]:
+                index_offset[i, k] = j
+                k += 1
+        index_offset_size[i] = k
+    return KVOffsetInfo(
+        kv_block_offset=jnp.asarray(index_offset),
+        kv_block_offset_size=jnp.asarray(index_offset_size),
+    )

--- a/axlearn/common/flash_attention/decoding_test.py
+++ b/axlearn/common/flash_attention/decoding_test.py
@@ -1,0 +1,148 @@
+# Copyright © 2025 Apple Inc.
+"""Tests GPU and TPU decoding."""
+from contextlib import nullcontext
+from typing import Literal
+
+import jax
+import jax.numpy as jnp
+import pytest
+from absl.testing import parameterized
+
+from axlearn.common.attention_bias import sliding_window_causal_mask
+from axlearn.common.flash_attention.gpu_decoding import NEG_INF
+from axlearn.common.flash_attention.gpu_decoding import flash_decoding as gpu_decoding
+from axlearn.common.flash_attention.tpu_decoding import tpu_decoding
+from axlearn.common.flash_attention.utils import mha_reference
+from axlearn.common.test_utils import TestCase, Tolerance
+
+if jax.default_backend() == "gpu":
+    decoding_fns = [gpu_decoding]
+    dtypes = [jnp.float32, jnp.float16]
+elif jax.default_backend() == "tpu":
+    decoding_fns = [tpu_decoding]
+    dtypes = [jnp.bfloat16]
+elif jax.default_backend() == "cpu":
+    # CPU emulation of pallas kernels.
+    decoding_fns = [gpu_decoding, tpu_decoding]
+    dtypes = [jnp.float32]
+else:
+    pytest.skip(reason="Incompatible hardware", allow_module_level=True)
+
+
+class DecodingTest(TestCase):
+    """Tests GPU and TPU decoding."""
+
+    @parameterized.product(
+        [
+            dict(zip(["batch_size", "seq_len", "num_heads", "per_head_dim"], args))
+            for args in [
+                (1, 1024, 32, 64),
+                (4, 512, 48, 64),
+                (2, 1024, 16, 128),
+                (1, 4096, 8, 128),
+                (2, 734, 48, 64),
+            ]
+        ],
+        attention_bias_type=[None],
+        input_dtype=dtypes,
+        padding=[0, 111],
+        kv_head_factor=[1, 4, 8],
+        window_len=[-1, 16, 127],
+        decoding_fn=decoding_fns,
+    )
+    def test_decode_against_ref(
+        self,
+        batch_size: int,
+        seq_len: int,
+        num_heads: int,
+        per_head_dim: int,
+        attention_bias_type: Literal["2d", "4d", None],
+        input_dtype: jnp.dtype,
+        padding: int,
+        kv_head_factor: int,
+        window_len: int,
+        decoding_fn,
+    ):
+        if seq_len % 512 != 0 and decoding_fn is tpu_decoding:
+            self.skipTest("TPU decoding doesn't support seq_len % block_size != 0")
+        self.assertEqual(num_heads % kv_head_factor, 0)
+        assert num_heads % kv_head_factor == 0
+        k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(42), 4)
+        q = jax.random.normal(k1, (batch_size, 1, num_heads, per_head_dim), dtype=input_dtype)
+        k = jax.random.normal(
+            k2,
+            (batch_size, seq_len, num_heads // kv_head_factor, per_head_dim),
+            dtype=input_dtype,
+        )
+        v = jax.random.normal(
+            k3,
+            (batch_size, seq_len, num_heads // kv_head_factor, per_head_dim),
+            dtype=input_dtype,
+        )
+
+        if attention_bias_type == "4d":
+            bias = jax.random.normal(k4, (batch_size, num_heads, 1, seq_len), dtype=input_dtype)
+        elif attention_bias_type == "2d":
+            bias = jax.random.normal(k4, (1, 1, 1, seq_len), dtype=input_dtype)
+        else:
+            bias = None
+
+        softmax_scale = per_head_dim**0.5
+        mask_fn = None
+        if window_len > 0:
+            mask_fn = sliding_window_causal_mask(window_len)
+        o = decoding_fn(
+            q,
+            k,
+            v,
+            bias=bias,
+            softmax_scale=softmax_scale,
+            kv_seq_len=seq_len - padding,
+            mask_fn=mask_fn,
+            interpret=(jax.default_backend() == "cpu"),
+        )
+        if bias is not None:
+            bias = bias[:, :, :, : seq_len - padding]
+        if window_len > 0:
+            if bias is None:
+                bias = jnp.zeros((1, 1, 1, seq_len - padding), dtype=input_dtype)
+            bias = bias.at[:, :, :, : -window_len - 1].set(NEG_INF)
+        with jax.default_matmul_precision(
+            "highest"
+        ) if input_dtype is jnp.float32 else nullcontext():
+            o_ref = mha_reference(
+                q,
+                k[:, : seq_len - padding],
+                v[:, : seq_len - padding],
+                bias,
+                None,
+                causal=False,
+                softmax_scale=softmax_scale,
+            )
+        if input_dtype is jnp.float32:
+            self.assertNestedAllClose(o, o_ref, rtol=0.001, atol=0.0005)
+        # bfloat16 and float16 have occasional outliers that require relaxed tolerances.
+        elif input_dtype is jnp.bfloat16:
+            self.assertAllCloseWithOutliers(
+                o,
+                o_ref,
+                tolerance_map={
+                    1.0: Tolerance(rtol=0.05, atol=1.25),
+                    0.99: Tolerance(rtol=0.05, atol=0.4),
+                    0.95: Tolerance(rtol=0.05, atol=0.2),
+                    0.9: Tolerance(rtol=0.05, atol=0.1),
+                    0.8: Tolerance(rtol=0.05, atol=0.05),
+                },
+            )
+        elif input_dtype is jnp.float16:
+            self.assertAllCloseWithOutliers(
+                o,
+                o_ref,
+                tolerance_map={
+                    1.0: Tolerance(rtol=0.01, atol=0.2),
+                    0.98: Tolerance(rtol=0.01, atol=0.05),
+                    0.9: Tolerance(rtol=0.01, atol=0.025),
+                },
+            )
+        else:
+            raise ValueError(f"Unsupported dtype {input_dtype}")

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -17,16 +17,14 @@ import chex
 import jax
 import jax.numpy as jnp
 import pytest
-from absl.testing import parameterized
 
 from axlearn.common.attention_bias import causal_mask, sliding_window_causal_mask
 from axlearn.common.flash_attention.gpu_attention import (
     cudnn_dot_product_attention,
     flash_attention,
 )
-from axlearn.common.flash_attention.gpu_decoding import NEG_INF, flash_decoding
-from axlearn.common.flash_attention.utils import _repeat_kv_heads, mha_reference
-from axlearn.common.test_utils import TestCase
+from axlearn.common.flash_attention.gpu_decoding import NEG_INF
+from axlearn.common.flash_attention.utils import mha_reference
 
 if jax.default_backend() not in ("gpu", "cpu"):
     pytest.skip(reason="Incompatible hardware", allow_module_level=True)
@@ -138,100 +136,6 @@ def test_triton_fwd_only_against_ref(
         chex.assert_trees_all_close(o, o_ref, atol=0.07)
     elif input_dtype == jnp.float32:
         chex.assert_trees_all_close(o, o_ref, atol=0.03)
-
-
-class FlashDecodingTest(TestCase):
-    """Tests FlashDecoding."""
-
-    @parameterized.product(
-        [
-            dict(zip(["batch_size", "seq_len", "num_heads", "per_head_dim"], args))
-            for args in [
-                (1, 1024, 32, 64),
-                (1, 444, 16, 64),
-                (8, 1596, 48, 128),
-                (8, 4044, 64, 128),
-            ]
-        ],
-        softmax_scale=[1.0, 0.83],
-        attention_bias_type=["2d", "4d", None],
-        input_dtype=[jnp.float32, jnp.float16],
-        padding=[0, 111],
-        kv_head_factor=[1, 4, 8],
-        window_len=[-1, 16, 127],
-    )
-    def test_decode_against_ref(
-        self,
-        batch_size: int,
-        seq_len: int,
-        num_heads: int,
-        per_head_dim: int,
-        softmax_scale: float,
-        attention_bias_type: Literal["2d", "4d", None],
-        input_dtype: jnp.dtype,
-        padding: int,
-        kv_head_factor: int,
-        window_len: int,
-    ):
-        if jax.default_backend() == "cpu" and seq_len >= 512:
-            pytest.skip(reason="Too slow on CPU.")
-        self.assertEqual(num_heads % kv_head_factor, 0)
-        assert num_heads % kv_head_factor == 0
-        k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(42), 4)
-        q = jax.random.normal(k1, (batch_size, 1, num_heads, per_head_dim), dtype=input_dtype)
-        k = jax.random.normal(
-            k2,
-            (batch_size, seq_len + padding, num_heads // kv_head_factor, per_head_dim),
-            dtype=input_dtype,
-        )
-        v = jax.random.normal(
-            k3,
-            (batch_size, seq_len + padding, num_heads // kv_head_factor, per_head_dim),
-            dtype=input_dtype,
-        )
-
-        if attention_bias_type == "4d":
-            bias = jax.random.normal(
-                k4, (batch_size, num_heads, 1, seq_len + padding), dtype=input_dtype
-            )
-        elif attention_bias_type == "2d":
-            bias = jax.random.normal(k4, (1, 1, 1, seq_len + padding), dtype=input_dtype)
-        else:
-            bias = None
-
-        mask_fn = None
-        if window_len > 0:
-            mask_fn = sliding_window_causal_mask(window_len)
-        o = flash_decoding(
-            q,
-            k,
-            v,
-            bias=bias,
-            softmax_scale=softmax_scale,
-            kv_seq_len=seq_len,
-            mask_fn=mask_fn,
-            interpret=(jax.default_backend() == "cpu"),
-        )
-        if bias is not None:
-            bias = bias[:, :, :, :seq_len]
-        if window_len > 0:
-            if bias is None:
-                bias = jnp.zeros((1, 1, 1, seq_len), dtype=input_dtype)
-            bias = bias.at[:, :, :, : -window_len - 1].set(NEG_INF)
-        o_ref = mha_reference(
-            q,
-            _repeat_kv_heads(num_heads, k[:, :seq_len]),
-            _repeat_kv_heads(num_heads, v[:, :seq_len]),
-            bias,
-            None,
-            causal=False,
-            softmax_scale=softmax_scale,
-        )
-        self.assertGreaterEqual(jnp.median(jnp.abs(o_ref)).item(), 0.25)
-        if input_dtype is jnp.float32:
-            self.assertNestedAllClose(o, o_ref, rtol=0.01, atol=0.01)
-        else:
-            self.assertNestedAllClose(o, o_ref, rtol=0.05, atol=0.05)
 
 
 @pytest.mark.parametrize(

--- a/axlearn/common/flash_attention/tpu_attention_benchmark.py
+++ b/axlearn/common/flash_attention/tpu_attention_benchmark.py
@@ -39,7 +39,7 @@ from axlearn.common.attention_bias import (
     TensorAttentionBias,
     sliding_window_causal_mask,
 )
-from axlearn.common.flash_attention.utils import flash_attention_implementation, mha_reference
+from axlearn.common.flash_attention.utils import flash_attention_implementation
 
 _BENCHMARK_CONFIGS = {
     "1.2b": dict(
@@ -51,7 +51,8 @@ _BENCHMARK_CONFIGS = {
         per_head_dim=128,
     ),
     "29.6b": dict(
-        num_heads=56,
+        num_heads=8,
+        num_kv_heads=1,
         per_head_dim=128,
     ),
     "65.2b": dict(
@@ -91,75 +92,77 @@ def _benchmark(
     block_size: int,
     num_heads: int,
     per_head_dim: int,
+    num_kv_heads: Optional[int] = None,
+    is_decoding: bool = False,
     causal: bool = True,
     use_bias: bool = False,
-    use_segment_ids: bool = False,
     sliding_window_size: Optional[int] = None,
 ):
     """Benchmarks TPU FlashAttention vs reference impl."""
-    k1, k2, k3, k4, k5 = jax.random.split(jax.random.PRNGKey(0), 5)
-    q = jax.random.normal(k1, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16)
-    k = jax.random.normal(k2, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16)
-    v = jax.random.normal(k3, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16)
-
-    bias = None
-    if use_bias:
-        bias = jax.random.normal(k4, (batch_size, num_heads, seq_len, seq_len), dtype=jnp.bfloat16)
-    segment_ids = None
-    if use_segment_ids:
-        segment_ids = jnp.cumsum(
-            jax.random.bernoulli(k5, shape=(batch_size, seq_len)).astype(jnp.int32), axis=1
-        )
+    k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(0), 4)
+    if num_kv_heads is None:
+        num_kv_heads = num_heads
+    q_seq_len = 1 if is_decoding else seq_len
+    q = jax.random.normal(k1, (batch_size, q_seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16)
+    k = jax.random.normal(k2, (batch_size, seq_len, num_kv_heads, per_head_dim), dtype=jnp.bfloat16)
+    v = jax.random.normal(k3, (batch_size, seq_len, num_kv_heads, per_head_dim), dtype=jnp.bfloat16)
 
     softmax_scale = per_head_dim**-0.5
-    ref_fwd_time = _time_call(
-        lambda: mha_reference(
-            q, k, v, bias, segment_ids, causal=causal, softmax_scale=softmax_scale
-        )
-    )
-
-    grad_fn = jax.jit(
-        jax.grad(
-            lambda q, k, v, b, s: mha_reference(
-                q, k, v, b, s, causal=causal, softmax_scale=softmax_scale
-            ).mean(),
-            argnums=(0, 1, 2),
-        )
-    )
-    ref_bwd_time = _time_call(lambda: grad_fn(q, k, v, bias, segment_ids)[0])
-
-    mask = None
+    mask = []
+    if is_decoding:
+        target_positions = jnp.asarray([seq_len - 1])[None]
+    else:
+        target_positions = jnp.arange(seq_len)[None]
     if causal and sliding_window_size is None:
-        mask = CausalAttentionBias(
-            target_positions=jnp.arange(seq_len)[None],
-            source_positions=jnp.arange(seq_len)[None],
+        mask.append(
+            CausalAttentionBias(
+                target_positions=target_positions,
+                source_positions=jnp.arange(seq_len)[None],
+            )
         )
     elif causal:
-        mask = SlidingWindowAttentionBias(
-            sliding_window_causal_mask(sliding_window_size),
-            sliding_window_size=sliding_window_size,
-            target_positions=jnp.arange(seq_len)[None],
-            source_positions=jnp.arange(seq_len)[None],
+        mask.append(
+            SlidingWindowAttentionBias(
+                sliding_window_causal_mask(sliding_window_size),
+                sliding_window_size=sliding_window_size,
+                target_positions=target_positions,
+                source_positions=jnp.arange(seq_len)[None],
+            )
         )
     if use_bias:
-        bias = CompositeAttentionBias([mask, TensorAttentionBias(bias)])
-    else:
-        bias = CompositeAttentionBias([mask])
+        mask.append(
+            TensorAttentionBias(
+                jax.random.normal(
+                    k4, (batch_size, num_heads, q_seq_len, seq_len), dtype=jnp.bfloat16
+                )
+            )
+        )
+    bias = CompositeAttentionBias(mask)
 
     # Get fwd & bwd timing information when softmax scaling applied before calling the kernel.
+    ref_mha_impl = flash_attention_implementation(
+        "xla", softmax_scale=softmax_scale, block_size=block_size, is_decoding=is_decoding
+    )
     mha_impl = flash_attention_implementation(
-        "tpu", softmax_scale=softmax_scale, block_size=block_size
+        "tpu", softmax_scale=softmax_scale, block_size=block_size, is_decoding=is_decoding
     )
 
+    ref_fwd_time = _time_call(lambda: ref_mha_impl(q, k, v, bias))
     flash_fwd_time = _time_call(lambda: mha_impl(q, k, v, bias))
 
-    flash_grad_fn = jax.jit(
-        jax.grad(lambda q, k, v, b: mha_impl(q, k, v, b).mean(), argnums=(0, 1, 2))
-    )
-    flash_bwd_time = _time_call(lambda: flash_grad_fn(q, k, v, bias)[0])
+    if not is_decoding:
+        flash_grad_fn = jax.jit(
+            jax.grad(lambda q, k, v, b: ref_mha_impl(q, k, v, b).mean(), argnums=(0, 1, 2))
+        )
+        ref_bwd_time = _time_call(lambda: flash_grad_fn(q, k, v, bias)[0])
+        flash_grad_fn = jax.jit(
+            jax.grad(lambda q, k, v, b: mha_impl(q, k, v, b).mean(), argnums=(0, 1, 2))
+        )
+        flash_bwd_time = _time_call(lambda: flash_grad_fn(q, k, v, bias)[0])
 
     print(f"ref_fwd:{ref_fwd_time:.4f}s, flash_fwd:{flash_fwd_time:.4f}s")
-    print(f"ref_bwd:{ref_bwd_time:.4f}s, flash_bwd:{flash_bwd_time:.4f}s\n")
+    if not is_decoding:
+        print(f"ref_bwd:{ref_bwd_time:.4f}s, flash_bwd:{flash_bwd_time:.4f}s\n")
 
 
 if __name__ == "__main__":
@@ -169,8 +172,9 @@ if __name__ == "__main__":
         print(f"Benchmarking attention representative of {name} model layer on {device_kind}.")
         _benchmark(
             batch_size=2,
-            seq_len=1024 * 8,
+            seq_len=1024 * 128,
             block_size=4 * 128,
-            sliding_window_size=1024,
+            sliding_window_size=4096,
+            is_decoding=True,
             **cfg,
         )

--- a/axlearn/common/flash_attention/tpu_decoding.py
+++ b/axlearn/common/flash_attention/tpu_decoding.py
@@ -1,0 +1,283 @@
+# Copyright © 2025 Apple Inc.
+"""Implements TPU decoding.
+
+Unlike GPU, TPU blocks are sequential (except when there're two cores). Therefore, unlike GPU
+decoding, there's no need to parallelize over the KV sequence length. As the result, it works
+very similar to full attention. The grid dimensions are
+(batch_size, num_kv_heads, num_kv_blocks).
+
+The main reason to use the kernel is that it can take advantage of the fact that most KV blocks
+are padding in practical decoding scenarios. Also, it can take advantage of sparsity in
+`mask_fn`.
+
+Performance note:
+1. When kv_seq_len == padded_kv_seq_len:
+    This kernels performs similarly to non-fused (i.e. XLA) attention, or within 10% slower.
+2. When kv_seq_len < padded_kv_seq_len or `mask_fn` has sparsity:
+    This kernel provides speed up roughly equal to padded_kv_seq_len / kv_seq_len or number
+    of masked kv blocks / total kv blocks.
+
+The main reason why non-fused attention is faster when kv are not padded is that the non-fused
+matmuls can flatten the non-head dimensions, thus having larger non-contracting dimensions.
+This leads to have better utilization of the matrix and memory units.
+"""
+from functools import partial
+from typing import Optional
+
+import jax
+import jax.numpy as jnp
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+from axlearn.common.attention_bias import NEG_INF, MaskFn
+from axlearn.common.flash_attention.common import build_mask, query_iterator_indices
+from axlearn.common.utils import Tensor
+
+
+def _tpu_decoding_kernel(
+    # Scalars.
+    kv_seq_len_ref,
+    kv_block_offset,
+    kv_block_offset_size,
+    # Inputs.
+    q_ref,
+    k_ref,
+    v_ref,
+    b_ref,
+    # Outputs.
+    o_ref,
+    # Scatch.
+    m_i,
+    l_i,
+    o_scratch,
+    # Compile time args.
+    softmax_scale: float,
+    mask_fn: Optional[MaskFn],
+):
+    batch_index = pl.program_id(0)
+    non_empty_kv_block_index = pl.program_id(2)
+    _, block_k = k_ref.shape
+    precision = (
+        lax.Precision.HIGHEST if jnp.float32 in (q_ref.dtype, k_ref.dtype, v_ref.dtype) else None
+    )
+
+    # o is the buffer where we accumulate the output on sram.
+    # m_i and l_i (see FlashAttention paper) are updated during the k,v loop.
+    @pl.when(non_empty_kv_block_index == 0)
+    def init():
+        m_i[...] = jnp.full_like(m_i, NEG_INF)
+        l_i[...] = jnp.zeros_like(l_i)
+        o_scratch[...] = jnp.zeros_like(o_scratch)
+
+    # Note: on CPU interpret mode, pl.program_id() cannot appear in functions decorated by
+    # pl.when.
+    kv_offset = kv_block_offset[batch_index, non_empty_kv_block_index] * block_k
+    kv_seq_len = kv_seq_len_ref[batch_index]
+    num_non_empty_kv_blocks = kv_block_offset_size[batch_index]
+
+    # Different batch may have different number of-non empty kv blocks.
+    @pl.when(non_empty_kv_block_index < num_non_empty_kv_blocks)
+    def compute():
+        q = q_ref[...]
+        k = k_ref[...]
+        qk = pl.dot(q, k, precision=precision)
+        if softmax_scale != 1.0:
+            qk *= softmax_scale
+        if b_ref is not None:
+            qk += b_ref[...]
+            qk = jnp.maximum(qk, NEG_INF)
+        # Note: Pallas TPU requires the use of lax.broadcasted_iota instead of jnp.arange as only
+        # 2D range is supported.
+        block_kv_indices = kv_offset + lax.broadcasted_iota(jnp.int32, qk.shape, 1)
+        kv_mask = block_kv_indices < kv_seq_len
+        if mask_fn is not None:
+            kv_mask = kv_mask & mask_fn(kv_seq_len - 1, block_kv_indices)
+        qk = jnp.where(kv_mask, qk, NEG_INF)
+
+        m_prev = m_i[...]
+        l_prev = l_i[...]
+        o_prev = o_scratch[...]
+
+        # We need to make sure each array has two dims, or we get TPU Mosaic lowering errors.
+        m_curr = qk.max(axis=-1, keepdims=True)
+        m_next = jnp.maximum(m_prev, m_curr)
+        correction = jnp.exp(m_prev - m_next)
+        l_prev_corr = correction * l_prev
+        # Use m_next instead of m_curr to avoid a correction on l_curr.
+        s_curr = jnp.exp(qk - m_next)
+        l_curr = s_curr.sum(axis=-1, keepdims=True)
+        l_next = l_prev_corr + l_curr
+        o_prev_corr = correction * o_prev
+        v = v_ref[...]
+        o_curr = pl.dot(s_curr.astype(v.dtype), v.T, precision=precision)
+
+        o_next = o_prev_corr + o_curr
+
+        m_i[...] = m_next
+        l_i[...] = l_next
+        o_scratch[...] = o_next
+
+    @pl.when(non_empty_kv_block_index == num_non_empty_kv_blocks - 1)
+    def final():
+        # We keep an unscaled version of o during the scan over kv_seq_len. Scaling it
+        # by the last l_i gives us the correct final output. See section 3.1.1 in the
+        # FlashAttention-2 paper: https://arxiv.org/pdf/2307.08691.
+        o_ref[...] = (o_scratch[...] / l_i[...]).astype(o_ref.dtype)
+
+
+@partial(
+    jax.jit,
+    static_argnames=[
+        "softmax_scale",
+        "mask_fn",
+        "block_size",
+        "interpret",
+    ],
+)
+def tpu_decoding(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    kv_seq_len: Optional[Tensor],
+    bias: Optional[Tensor] = None,
+    *,
+    softmax_scale: float = 1.0,
+    mask_fn: Optional[MaskFn] = None,
+    block_size: int = 512,
+    interpret: bool = False,
+):
+    """Implements TPU decoding with GQA support.
+
+    The functionality of TPU decoding is similar to GPU FlashDecoding, except that
+    padded_kv_seq_len must be divisible by block_size.
+
+    Args:
+        q: Tensor of shape [batch_size, 1, num_q_heads, head_dim].
+        k: Tensor of shape [batch_size, padded_kv_seq_len, num_kv_heads, head_dim].
+        v: Tensor of shape [batch_size, padded_kv_seq_len, num_kv_heads, head_dim].
+        kv_seq_len: Tensor that can broadcast to [batch_size], indicating the actual kv sequence
+            length for each sequence in the batch. If None, assumes k and v are not padded in the
+            sequence dimension.
+        bias: Tensor that can broadcast to [batch_size, num_q_heads, 1, padded_kv_seq_len].
+            Defaults to None.
+        softmax_scale: Softmax scale.
+        mask_fn: Mask function to use. Preferred over bias.
+        block_size: Block dimension along the sequence dim. Defaults to 512.
+
+    Returns:
+        A tensor with the same shape and dtype as q.
+
+    Raises:
+        ValueError if the shape of qkv doesn't satisfy assumptions.
+    """
+    if q.shape[1] != 1:
+        raise ValueError("Multi-step decoding is not supported yet.")
+    if k.shape[1] % block_size != 0:
+        raise ValueError(f"KV sequence length {k.shape[1]} must be divisible by {block_size=}.")
+    assert q.shape[1] == 1
+    # Pallas TPU doesn't support pl.load(..., mask=xxx), so we kv len must divide block size.
+    block_size = min(block_size, k.shape[1])
+    orig_q_shape = q.shape
+    q_seq_len = q.shape[1]
+    block_kv = block_size
+    q = q.squeeze(1)
+    # Convert to bnhs which is the native shape of KV in the kv cache. These two transposes should
+    # be elided by the compiler. See `BaseQKVLinear.init_states` from attention.py.
+    k = jnp.einsum("bsnh->bnhs", k)
+    v = jnp.einsum("bsnh->bnhs", v)
+    bs, kv_heads, head_dim, padded_kv_seq_len = k.shape
+    if kv_seq_len is not None:
+        kv_seq_len = jnp.broadcast_to(jnp.asarray(kv_seq_len), (bs,))
+    else:
+        kv_seq_len = jnp.full((bs,), padded_kv_seq_len, dtype=jnp.int32)
+
+    # Computes a full block map num_kv_blocks * num_kv_blocks.
+    # Use a padding to ensure padding blocks aren't counted towards `kv_block_offset_size`.
+    padding = -1
+    with jax.ensure_compile_time_eval():
+        if mask_fn is not None:
+            bool_mask = build_mask(
+                mask_fn,
+                q_seq_len=padded_kv_seq_len,
+                kv_seq_len=padded_kv_seq_len,
+                block_q=block_size,
+                block_k=block_size,
+            )
+            offset, _ = query_iterator_indices(bool_mask, padding=padding)
+        else:
+            padded_num_kv_blocks = pl.cdiv(padded_kv_seq_len, block_size)
+            offset = lax.broadcasted_iota(
+                jnp.int32, (padded_num_kv_blocks, padded_num_kv_blocks), 1
+            )
+
+    # Dynamically slice the rows according to the query position (which is kv_seq_len - 1).
+    kv_block_offset = offset[(kv_seq_len - 1) // block_size]
+    # Count the number of blocks with position < kv_seq_len.
+    kv_block_offset_size = jnp.count_nonzero(
+        (kv_block_offset != padding) & (kv_block_offset * block_size < kv_seq_len[:, None]), axis=1
+    )
+    # Replace padding with the last valid kv block's index. See
+    # https://docs.jax.dev/en/latest/pallas/tpu/sparse.html#sparse-access-patterns-on-dense-data
+    kv_block_offset = jnp.where(
+        kv_block_offset == padding, kv_block_offset.max(axis=1, keepdims=True), kv_block_offset
+    )
+
+    q = q.reshape(bs, kv_heads, -1, head_dim)
+    q_seq_head = q.shape[-2]  # = q_seq_len * num_q_heads_per_kv_head
+    assert q_seq_head <= 512
+
+    def kv_index_map(
+        batch_idx, head_idx, kv_block_idx, kv_seq_len, kv_block_offset, kv_block_offset_size
+    ):
+        del kv_seq_len, kv_block_offset_size
+        return (batch_idx, head_idx, 0, kv_block_offset[batch_idx, kv_block_idx])
+
+    q_spec = pl.BlockSpec((None, None, q_seq_head, head_dim), lambda b, h, j, *args: (b, h, 0, 0))
+    kv_spec = pl.BlockSpec((None, None, head_dim, block_kv), kv_index_map)
+    bias_spec = None
+    if bias is not None:
+        if bias.shape[0] == 1 and bias.shape[1] == 1:
+
+            def bias_index_map(
+                batch_idx,
+                head_idx,
+                kv_block_idx,
+                kv_seq_len,
+                kv_block_offset,
+                kv_block_offset_size,
+            ):
+                del head_idx, kv_seq_len, kv_block_offset_size
+                return (0, 0, 0, kv_block_offset[batch_idx, kv_block_idx])
+
+            bias_spec = pl.BlockSpec((None, None, q_seq_len, block_kv), bias_index_map)
+        else:
+            bias = bias.reshape(bs, kv_heads, q_seq_head, padded_kv_seq_len)
+            bias_spec = pl.BlockSpec((None, None, q_seq_head, block_kv), kv_index_map)
+
+    out: Tensor = pl.pallas_call(
+        partial(_tpu_decoding_kernel, softmax_scale=softmax_scale, mask_fn=mask_fn),
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=3,
+            in_specs=[
+                q_spec,
+                kv_spec,
+                kv_spec,
+                bias_spec,
+            ],
+            out_specs=q_spec,
+            scratch_shapes=[
+                # VMEM requires 2D arrays.
+                pltpu.VMEM((q_seq_head, 1), jnp.float32),
+                pltpu.VMEM((q_seq_head, 1), jnp.float32),
+                pltpu.VMEM((q_seq_head, head_dim), jnp.float32),
+            ],
+            grid=(bs, kv_heads, kv_block_offset_size.max()),
+        ),
+        out_shape=jax.ShapeDtypeStruct(q.shape, q.dtype),
+        compiler_params=pltpu.TPUCompilerParams(
+            dimension_semantics=("parallel", "parallel", "arbitrary")
+        ),
+        interpret=interpret,
+    )(kv_seq_len, kv_block_offset, kv_block_offset_size, q, k, v, bias)
+    return out.reshape(orig_q_shape)

--- a/axlearn/common/flash_attention/tpu_decoding.py
+++ b/axlearn/common/flash_attention/tpu_decoding.py
@@ -173,11 +173,12 @@ def tpu_decoding(
     """
     if q.shape[1] != 1:
         raise ValueError("Multi-step decoding is not supported yet.")
+    # Pallas TPU doesn't support pl.load(..., mask=xxx), so we kv len must divide block size.
+    # However, we can reduce the block size to support the case where
+    # padded_kv_seq_len < block_size.
+    block_size = min(block_size, k.shape[1])
     if k.shape[1] % block_size != 0:
         raise ValueError(f"KV sequence length {k.shape[1]} must be divisible by {block_size=}.")
-    assert q.shape[1] == 1
-    # Pallas TPU doesn't support pl.load(..., mask=xxx), so we kv len must divide block size.
-    block_size = min(block_size, k.shape[1])
     orig_q_shape = q.shape
     q_seq_len = q.shape[1]
     block_kv = block_size

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -13,7 +13,7 @@ from collections import OrderedDict, defaultdict
 from collections.abc import Iterator, Sequence
 from functools import partial
 from tempfile import mkdtemp
-from typing import Any, Optional, Protocol, TypeVar, Union
+from typing import Any, NamedTuple, Optional, Protocol, TypeVar, Union
 from unittest.mock import patch
 
 import jax
@@ -135,6 +135,11 @@ class ParameterConversionFn(Protocol):
         """Converts parameters from `src` to parameters for `dst_layer`."""
 
 
+class Tolerance(NamedTuple):
+    rtol: float = 0.001
+    atol: float = 0.001
+
+
 class TestCase(parameterized.TestCase):
     """Base test class."""
 
@@ -248,6 +253,45 @@ class TestCase(parameterized.TestCase):
             np.testing.assert_array_equal(a_value, b_value, err_msg=k)
             if hasattr(a_value, "dtype"):
                 self.assertEqual(a_value.dtype, b_value.dtype)
+
+    def assertAllCloseWithOutliers(self, actual, desired, *, tolerance_map: dict[float, Tolerance]):
+        """Like np.testing.assert_allclose, but allows outlier percentiles to be specified.
+
+        `tolerance_map` is mapping of percentile values (between 0 and 1) to `Tolerance` objects.
+        Each entry defines the acceptable tolerance for a certain percentile of elements in the
+        difference `abs(actual - desired)`. The specified tolerance should be met within the given
+        percentile of total elements in `actual` or `desired`.
+
+        Example:
+        ```python
+        self.assertAllCloseWithOutliers(x, y, tolerance_map={
+            1.0: Tolerance(atol=0.2),
+            0.95: Tolerance(atol=0.05),
+        })
+        ```
+        This example asserts 100% elements of `abs(x - y)` should be within atol=0.2, and 95%
+        elements of `abs(x - y)` should be within atol=0.05.
+        """
+        assert len(tolerance_map) > 0
+        self.assertEqual(actual.shape, desired.shape)
+        self.assertEqual(actual.dtype, desired.dtype)
+        actual = actual.astype(np.float32)
+        desired = desired.astype(np.float32)
+        diff = np.abs(actual - desired)
+        for percentile, tol in tolerance_map.items():
+            percentile = 1 - percentile
+            tolerance = tol.atol + tol.rtol * np.abs(desired)
+            expected_num_ele = round(diff.size * percentile)
+            actual_num_ele = np.count_nonzero(diff > tolerance)
+            actual_percent = actual_num_ele / diff.size
+            self.assertLessEqual(
+                actual_num_ele,
+                expected_num_ele,
+                msg=f"Expected the number of elements over {tol} to be less than {percentile:.3%}"
+                f" of total elements (or {expected_num_ele}), but got {actual_percent:.3%} "
+                f"(or {actual_num_ele}). These differences are {diff[diff > tolerance]}. "
+                f"Max difference = {diff.max()}",
+            )
 
 
 # TODO(markblee): Move this to axlearn/experiments/test_utils.py, where it's used.


### PR DESCRIPTION
See the docstring of `tpu_decoding.py`. This is to improve decoding performance before we have paged KV cache and paged kernel. 

Other changes:
1. The unit test of GPU FlashDecoding is moved and now tests both TPU and GPU decoding.
2. `mha_reference` now adopts GQA optimizations so it's more fair to compare the performance of custom decoding kernel and the reference implementation.
3. Fix `gpu_attention_benchmark.py` being broken for decoding after #962
