### PR TITLE
Set megascale_grpc_enable_xor_tracer to false by default

### DIFF
--- a/axlearn/common/compiler_options.py
+++ b/axlearn/common/compiler_options.py
@@ -148,6 +148,8 @@ def default_xla_options(
             # Similar to megascale_graph_hang_threshold but specific to within a launch_id.
             # Default is 1m.
             megascale_graph_within_launch_hang_threshold="10m",
+            # TODO(ethanli): temporary workaround to avoid memory leak in megascale.
+            megascale_grpc_enable_xor_tracer="false",
         )
 
     # Validate options. Will never fail if this function is implemented correctly.


### PR DESCRIPTION
megascale_grpc_enable_xor_tracer has caused two problems

* memory link on megascale coordinator (a bug before jax-0.5.0)
* extensive logs but doesn't seem to provide extra value to us


so disable it for now.