### PR TITLE
Fix TPU decoding when KV and Q have different dtype

### DIFF
--- a/axlearn/common/flash_attention/tpu_decoding.py
+++ b/axlearn/common/flash_attention/tpu_decoding.py
@@ -185,8 +185,8 @@ def tpu_decoding(
     q = q.squeeze(1)
     # Convert to bnhs which is the native shape of KV in the kv cache. These two transposes should
     # be elided by the compiler. See `BaseQKVLinear.init_states` from attention.py.
-    k = jnp.einsum("bsnh->bnhs", k)
-    v = jnp.einsum("bsnh->bnhs", v)
+    k = jnp.einsum("bsnh->bnhs", k).astype(q.dtype)
+    v = jnp.einsum("bsnh->bnhs", v).astype(q.dtype)
     bs, kv_heads, head_dim, padded_kv_seq_len = k.shape
     if kv_seq_len is not None:
         kv_seq_len = jnp.broadcast_to(jnp.asarray(kv_seq_len), (bs,))


### PR DESCRIPTION
It turns out that when using fp32 inference, the kv cache can still be stored in bfloat16. This causes a compile (lowering) error in the kernel.

This PR fixed this in kernel and added test coverage for fp32 eval.
