### PR TITLE
Refactor and optimize FlashAttention dispatch

### DIFF
--- a/axlearn/common/attention_bias.py
+++ b/axlearn/common/attention_bias.py
@@ -668,7 +668,9 @@ class SlidingWindowAttentionBias(MaskFnAttentionBias):  # pylint: disable=final-
 
     @classmethod
     # pylint: disable-next=arguments-renamed
-    def default_config(cls, sliding_window_size: int) -> ClassConfigBase[MaskFnAttentionBias]:
+    def default_config(
+        cls, sliding_window_size: int
+    ) -> ClassConfigBase["SlidingWindowAttentionBias"]:
         return config_for_class(SlidingWindowAttentionBias).set(
             mask=sliding_window_causal_mask(sliding_window_size=sliding_window_size),
             sliding_window_size=sliding_window_size,

--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -184,12 +184,14 @@ class BaseFlashAttention(Configurable):
     ) -> Tensor:
         """Computes attention context.
 
+        Warning: The dtype of key and value may differ from the dtype of query.
+
         Args:
             query: Query of shape [batch_size, target_length, num_heads, per_head_dim].
             key: Key of shape [batch_size, source_length, num_kv_heads, per_head_dim].
             value: Value of shape [batch_size, source_length, num_kv_heads, per_head_dim].
             bias: Attention bias to apply.
-            prng_key: PRNG key for dropout.
+            prng_key: PRNG key for dropout. Only needed when dropout_rate > 0.0.
 
         Returns:
             The context tensor of shape [batch_size, target_length, num_heads, per_head_dim].

--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -205,6 +205,12 @@ class BaseFlashAttention(Configurable):
 class BaseSingleStepDecoding(BaseFlashAttention):
     """Wraps the common checks for single step decoding kernels."""
 
+    @classmethod
+    def default_config(cls) -> BaseFlashAttention.Config:
+        cfg: BaseFlashAttention.Config = super().default_config()
+        cfg.is_decoding = True
+        return cfg
+
     def is_supported(
         self, *, query: Tensor, key: Tensor, value: Tensor, bias: BaseAttentionBias
     ) -> bool:

--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -2,7 +2,7 @@
 """Common utilities across backends."""
 
 from functools import partial
-from typing import NamedTuple, Optional
+from typing import Literal, NamedTuple, Optional
 
 import jax
 import jax.numpy as jnp
@@ -125,7 +125,17 @@ class BaseFlashAttention(Configurable):
         """Returns the class name."""
         return self.__class__.__name__
 
-    def _log_unsupported(self, reason: str):
+    def _log_unsupported(self, reason: str) -> Literal[False]:
+        """Logs this class is unsupported with `reason`.
+
+        The log message will be formatted as `Not using {self.name()} because {reason}`.
+
+        This method also conveniently returns False so it could be used like this in `is_supported`
+        ```
+        if ...:
+            return self._log_unsupported(...)
+        ```
+        """
         logging.warning("Not using %s because %s", self.name(), reason)
         return False
 

--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -138,7 +138,7 @@ class BaseFlashAttention(Configurable):
         return True
 
     def is_supported(
-        self, query: Tensor, key: Tensor, value: Tensor, bias: BaseAttentionBias
+        self, *, query: Tensor, key: Tensor, value: Tensor, bias: BaseAttentionBias
     ) -> bool:
         """Returns whether the attention kernel supports the given configuration.
 
@@ -175,6 +175,8 @@ class BaseFlashAttention(Configurable):
             )
         return True
 
+    # Note: Positional arguments are used since some use cases require positional-only args,
+    # such as functional transformations.
     def __call__(
         self,
         query: Tensor,
@@ -203,8 +205,11 @@ class BaseFlashAttention(Configurable):
 class BaseSingleStepDecoding(BaseFlashAttention):
     """Wraps the common checks for single step decoding kernels."""
 
-    def is_supported(self, query, key, value, bias):
-        if not super().is_supported(query, key, value, bias):
+    def is_supported(
+        self, *, query: Tensor, key: Tensor, value: Tensor, bias: BaseAttentionBias
+    ) -> bool:
+        """See `BaseFlashAttention.is_supported`."""
+        if not super().is_supported(query=query, key=key, value=value, bias=bias):
             return False
         if not self.cfg.is_decoding:
             return self._log_unsupported("is_decoding=False.")

--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -127,6 +127,7 @@ class BaseFlashAttention(Configurable):
 
     def _log_unsupported(self, reason: str):
         logging.warning("Not using %s because %s", self.name(), reason)
+        return False
 
     def _check_block_size(self, *, query: Tensor, key: Tensor, block_size: int) -> bool:
         q_seq_len = query.shape[1]
@@ -206,11 +207,9 @@ class BaseSingleStepDecoding(BaseFlashAttention):
         if not super().is_supported(query, key, value, bias):
             return False
         if not self.cfg.is_decoding:
-            self._log_unsupported("is_decoding=False.")
-            return False
+            return self._log_unsupported("is_decoding=False.")
         if query.shape[1] != 1:
-            self._log_unsupported(f"{query.shape[1]=} != 1")
-            return False
+            return self._log_unsupported(f"{query.shape[1]=} != 1")
         if self.cfg.dropout_rate != 0.0:
             raise ValueError("Dropout rate cannot be set for decoding!")
         return True

--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -1,14 +1,16 @@
 # Copyright © 2025 Apple Inc.
 """Common utilities across backends."""
 
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+from absl import logging
 from jax.experimental import pallas as pl
 
-from axlearn.common.attention_bias import MaskFn
+from axlearn.common.attention_bias import BaseAttentionBias, MaskFn, SegmentIdAttentionBias
+from axlearn.common.config import Configurable, config_class
 from axlearn.common.utils import Tensor
 
 
@@ -86,3 +88,154 @@ def query_iterator_indices(block_mask_map: np.ndarray, *, padding: int = 0) -> K
         kv_block_offset=jnp.asarray(index_offset),
         kv_block_offset_size=jnp.asarray(index_offset_size),
     )
+
+
+class BaseFlashAttention(Configurable):
+    """Common interface for FlashAttention for all backends."""
+
+    @config_class
+    class Config(Configurable.Config):
+        """Configures BaseFlashAttention.
+
+        Attributes:
+            is_decoding: Whether we're in decoding/inference mode.
+            softmax_scale: Scale factor to apply to QK.
+            dropout_rate: Dropout rate for attention probs.
+            interpret: Whether to use interpret mode for Pallas kernels.
+            tpu_block_size: Block size for TPU pallas kernels.
+            gpu_block_size: Block size for GPU pallas kernels.
+        """
+
+        is_decoding: bool = False
+        softmax_scale: float = 1.0
+        dropout_rate: float = 0.0
+        interpret: bool = False
+        tpu_block_size: int = 512
+        gpu_block_size: int = 128
+
+    def name(self) -> str:
+        """Returns the class name."""
+        return self.__class__.__name__
+
+    def _log_unsupported(self, reason: str):
+        logging.warning("Not using %s because %s", self.name(), reason)
+
+    def _check_block_size(self, *, query: Tensor, key: Tensor, block_size: int) -> bool:
+        q_seq_len = query.shape[1]
+        k_seq_len = key.shape[1]
+        if q_seq_len % block_size != 0 or k_seq_len % block_size != 0:
+            self._log_unsupported(f"{q_seq_len=} or {k_seq_len=} is not divisible by {block_size=}")
+            return False
+        return True
+
+    def is_supported(
+        self, query: Tensor, key: Tensor, value: Tensor, bias: BaseAttentionBias
+    ) -> bool:
+        """Returns whether the attention kernel supports the given configuration.
+
+        Args:
+            query: Query of shape [batch_size, target_length, num_heads, per_head_dim].
+            key: Key of shape [batch_size, source_length, num_kv_heads, per_head_dim].
+            value: Value of shape [batch_size, source_length, num_kv_heads, per_head_dim].
+            bias: Attention bias to apply.
+
+        Returns:
+            True if the current configuration is supported. False otherwise.
+
+        Raises:
+            ValueError: If the given configuration doesn't logically make sense, e.g. if the
+                shapes of q/k/v do not satisfy the requirement of a standard attention.
+        """
+        del bias
+        if key.shape != value.shape:
+            raise ValueError(f"Expects {query.shape=} to be equal to {key.shape=}")
+        if query.shape[0] != key.shape[0]:
+            raise ValueError(
+                f"Expects query batch size {query.shape[0]} to be equal to key batch size "
+                f"{key.shape[0]}"
+            )
+        if query.shape[-1] != key.shape[-1]:
+            raise ValueError(
+                f"Expects query head dim {query.shape[-1]} to be equal to key head dim "
+                f"{key.shape[-1]}"
+            )
+        if query.shape[2] % key.shape[2] != 0:
+            raise ValueError(
+                f"Expects query num heads {query.shape[2]} to be divisible by num key heads "
+                f"{key.shape[2]}"
+            )
+        return True
+
+    @property
+    def cfg(self) -> Config:
+        """Returns a typed self.config."""
+        return self.config
+
+    def __call__(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        bias: BaseAttentionBias,
+        prng_key: Optional[Tensor] = None,
+    ) -> Tensor:
+        """Computes attention context.
+
+        Args:
+            query: Query of shape [batch_size, target_length, num_heads, per_head_dim].
+            key: Key of shape [batch_size, source_length, num_kv_heads, per_head_dim].
+            value: Value of shape [batch_size, source_length, num_kv_heads, per_head_dim].
+            bias: Attention bias to apply.
+            prng_key: PRNG key for dropout.
+
+        Returns:
+            The context tensor of shape [batch_size, target_length, num_heads, per_head_dim].
+        """
+        raise NotImplementedError()
+
+
+class BaseSingleStepDecoding(BaseFlashAttention):
+    """Wraps the common checks for single step decoding kernels."""
+
+    def is_supported(self, query, key, value, bias):
+        if not super().is_supported(query, key, value, bias):
+            return False
+        if not self.cfg.is_decoding:
+            self._log_unsupported("is_decoding=False.")
+            return False
+        if query.shape[1] != 1:
+            self._log_unsupported(f"{query.shape[1]=} != 1")
+            return False
+        if self.cfg.dropout_rate != 0.0:
+            raise ValueError("Dropout rate cannot be set for decoding!")
+        return True
+
+
+def get_segment_ids(
+    *, query: Tensor, key: Tensor, segment_ids: SegmentIdAttentionBias
+) -> Optional[Tensor]:
+    """Return the segment ids Tensor from the sequence of segment ids attention
+    biases or None if there are no segment ids.
+    """
+    if not segment_ids.has_value():
+        return None
+    if query.shape[1] != key.shape[1]:
+        raise ValueError("segment_ids is only supported for query and key with identical lengths.")
+    if segment_ids.eval_shape()[0] != query.shape[0]:
+        raise ValueError(
+            "segment_ids must have matching batch dim: "
+            f"{segment_ids.eval_shape()} vs. {query.shape[0]}"
+        )
+    return segment_ids.segment_ids
+
+
+def repeat_kv_heads(num_q_heads: int, key_or_value: Tensor) -> Tensor:
+    """Repeats key or value heads dim to match the query.
+
+    TODO(dhwang2): optimize computation like GroupedQueryAttention.
+    """
+    num_head_repeats = num_q_heads // key_or_value.shape[-2]
+    if num_head_repeats == 1:
+        return key_or_value
+    # Repeat along the num_heads dim: [batch, source_length, num_heads, per_head_dim].
+    return jnp.repeat(key_or_value, num_head_repeats, axis=-2)

--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -157,7 +157,7 @@ class BaseFlashAttention(Configurable):
         """
         del bias
         if key.shape != value.shape:
-            raise ValueError(f"Expects {query.shape=} to be equal to {key.shape=}")
+            raise ValueError(f"Expects {key.shape=} to be equal to {key.shape=}")
         if query.shape[0] != key.shape[0]:
             raise ValueError(
                 f"Expects query batch size {query.shape[0]} to be equal to key batch size "

--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -116,6 +116,11 @@ class BaseFlashAttention(Configurable):
         tpu_block_size: int = 512
         gpu_block_size: int = 128
 
+    def __init__(self, cfg):
+        super().__init__(cfg)
+        # Keep a typed copy of self.config.
+        self.cfg: BaseFlashAttention.Config = self.config
+
     def name(self) -> str:
         """Returns the class name."""
         return self.__class__.__name__
@@ -168,11 +173,6 @@ class BaseFlashAttention(Configurable):
                 f"{key.shape[2]}"
             )
         return True
-
-    @property
-    def cfg(self) -> Config:
-        """Returns a typed self.config."""
-        return self.config
 
     def __call__(
         self,

--- a/axlearn/common/flash_attention/decoding_test.py
+++ b/axlearn/common/flash_attention/decoding_test.py
@@ -8,22 +8,22 @@ import jax.numpy as jnp
 import pytest
 from absl.testing import parameterized
 
-from axlearn.common.attention_bias import sliding_window_causal_mask
-from axlearn.common.flash_attention.gpu_decoding import NEG_INF
-from axlearn.common.flash_attention.gpu_decoding import flash_decoding as gpu_decoding
-from axlearn.common.flash_attention.tpu_decoding import tpu_decoding
-from axlearn.common.flash_attention.utils import mha_reference
+from axlearn.common.attention_bias import causal_mask, sliding_window_causal_mask
+from axlearn.common.flash_attention.gpu_decoding import GPUDecoding
+from axlearn.common.flash_attention.test_utils import generate_attention_data
+from axlearn.common.flash_attention.tpu_decoding import TPUDecoding
+from axlearn.common.flash_attention.utils import BaseFlashAttention, ReferenceMHA
 from axlearn.common.test_utils import TestCase, Tolerance
 
 if jax.default_backend() == "gpu":
-    decoding_fns = [gpu_decoding]
+    decoding_fns = [GPUDecoding]
     dtypes = [jnp.float32, jnp.float16]
 elif jax.default_backend() == "tpu":
-    decoding_fns = [tpu_decoding]
+    decoding_fns = [TPUDecoding]
     dtypes = [jnp.bfloat16]
 elif jax.default_backend() == "cpu":
     # CPU emulation of pallas kernels.
-    decoding_fns = [gpu_decoding, tpu_decoding]
+    decoding_fns = [GPUDecoding, TPUDecoding]
     dtypes = [jnp.float32]
 else:
     pytest.skip(reason="Incompatible hardware", allow_module_level=True)
@@ -61,64 +61,44 @@ class DecodingTest(TestCase):
         padding: int,
         kv_head_factor: int,
         window_len: int,
-        decoding_fn,
+        decoding_fn: BaseFlashAttention,
     ):
-        if seq_len % 512 != 0 and decoding_fn is tpu_decoding:
-            self.skipTest("TPU decoding doesn't support seq_len % block_size != 0")
         self.assertEqual(num_heads % kv_head_factor, 0)
         assert num_heads % kv_head_factor == 0
-        k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(42), 4)
-        q = jax.random.normal(k1, (batch_size, 1, num_heads, per_head_dim), dtype=input_dtype)
-        k = jax.random.normal(
-            k2,
-            (batch_size, seq_len, num_heads // kv_head_factor, per_head_dim),
-            dtype=input_dtype,
-        )
-        v = jax.random.normal(
-            k3,
-            (batch_size, seq_len, num_heads // kv_head_factor, per_head_dim),
-            dtype=input_dtype,
-        )
-
-        if attention_bias_type == "4d":
-            bias = jax.random.normal(k4, (batch_size, num_heads, 1, seq_len), dtype=input_dtype)
-        elif attention_bias_type == "2d":
-            bias = jax.random.normal(k4, (1, 1, 1, seq_len), dtype=input_dtype)
-        else:
-            bias = None
-
         softmax_scale = per_head_dim**0.5
-        mask_fn = None
+        mask_fn = causal_mask
         if window_len > 0:
             mask_fn = sliding_window_causal_mask(window_len)
-        o = decoding_fn(
-            q,
-            k,
-            v,
-            bias=bias,
+        cfg = dict(
             softmax_scale=softmax_scale,
-            kv_seq_len=seq_len - padding,
-            mask_fn=mask_fn,
             interpret=(jax.default_backend() == "cpu"),
+            is_decoding=True,
         )
-        if bias is not None:
-            bias = bias[:, :, :, : seq_len - padding]
-        if window_len > 0:
-            if bias is None:
-                bias = jnp.zeros((1, 1, 1, seq_len - padding), dtype=input_dtype)
-            bias = bias.at[:, :, :, : -window_len - 1].set(NEG_INF)
+        q, k, v, bias = generate_attention_data(
+            batch_size,
+            1,
+            seq_len,
+            num_heads,
+            per_head_dim,
+            num_kv_heads=num_heads // kv_head_factor,
+            mask_fn=mask_fn,
+            attention_bias_type=attention_bias_type,
+            dtype=input_dtype,
+            query_offset=seq_len - padding - 1,
+        )
+
+        fn = decoding_fn.default_config().set(**cfg).instantiate()
+        is_supported = fn.is_supported(q, k, v, bias)
+        if seq_len % 512 != 0 and decoding_fn is TPUDecoding:
+            self.assertFalse(is_supported)
+            return
+        self.assertTrue(is_supported)
+
+        o = fn(q, k, v, bias)
         with jax.default_matmul_precision(
             "highest"
         ) if input_dtype is jnp.float32 else nullcontext():
-            o_ref = mha_reference(
-                q,
-                k[:, : seq_len - padding],
-                v[:, : seq_len - padding],
-                bias,
-                None,
-                causal=False,
-                softmax_scale=softmax_scale,
-            )
+            o_ref = ReferenceMHA.default_config().set(**cfg).instantiate()(q, k, v, bias)
         if input_dtype is jnp.float32:
             self.assertNestedAllClose(o, o_ref, rtol=0.001, atol=0.0005)
         # bfloat16 and float16 have occasional outliers that require relaxed tolerances.

--- a/axlearn/common/flash_attention/decoding_test.py
+++ b/axlearn/common/flash_attention/decoding_test.py
@@ -89,7 +89,7 @@ class DecodingTest(TestCase):
         )
 
         fn = decoding_fn.default_config().set(**cfg).instantiate()
-        is_supported = fn.is_supported(q, k, v, bias)
+        is_supported = fn.is_supported(query=q, key=k, value=v, bias=bias)
         if seq_len % 512 != 0 and decoding_fn is TPUDecoding:
             self.assertFalse(is_supported)
             return

--- a/axlearn/common/flash_attention/decoding_test.py
+++ b/axlearn/common/flash_attention/decoding_test.py
@@ -73,7 +73,6 @@ class DecodingTest(TestCase):
         cfg = dict(
             softmax_scale=softmax_scale,
             interpret=(jax.default_backend() == "cpu"),
-            is_decoding=True,
         )
         q, k, v, bias = generate_attention_data(
             batch_size,

--- a/axlearn/common/flash_attention/gpu_attention.py
+++ b/axlearn/common/flash_attention/gpu_attention.py
@@ -816,6 +816,7 @@ class PallasGPUFlashAttention(BaseFlashAttention):
         logging.info("Using %s.", self.name())
         return True
 
+    @functools.partial(jax.jit, static_argnames=["self"])
     def __call__(self, query, key, value, bias, prng_key=None):
         mask, segment_ids, explicit_bias = split(bias, MaskFnAttentionBias, SegmentIdAttentionBias)
         key = repeat_kv_heads(query.shape[2], key)
@@ -868,6 +869,7 @@ class CuDNNGPUFlashAttention(BaseFlashAttention):
         logging.info("Using %s.", self.name())
         return True
 
+    @functools.partial(jax.jit, static_argnames=["self"])
     def __call__(self, query, key, value, bias, prng_key=None):
         del prng_key
         causal, explicit_bias = split(

--- a/axlearn/common/flash_attention/gpu_attention_benchmark.py
+++ b/axlearn/common/flash_attention/gpu_attention_benchmark.py
@@ -160,13 +160,12 @@ def measure(f: BenchFn, *args: Tensor) -> tuple[Tensor, float]:
     launch overhead to cuda event.
 
     Args:
-      f: The function to measure. It must accept at least one argument and return
-        at least one output to be measurable.
-      *args: The arguments to pass to ``f``.
-      **kwargs: The keyword arguments to pass to ``f``.
+        f: The function to measure. It must accept at least one argument and return
+            at least one output to be measurable.
+        *args: The arguments to pass to ``f``.
 
     Returns:
-      The return value of ``f`` and the elapsed time in milliseconds.
+        The return value of ``f`` and the elapsed time in milliseconds.
     """
     if not has_registrations:
         raise RuntimeError("This function requires jaxlib >=0.4.36 with CUDA support.")
@@ -242,7 +241,7 @@ def bench_flash_attention(
     else:
         base_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
 
-    assert base_fn.is_supported(q, k, v, bias)
+    assert base_fn.is_supported(query=q, key=k, value=v, bias=bias)
     if use_bwd:
         fn = lambda *args: base_fn(*args).mean()
     else:

--- a/axlearn/common/flash_attention/gpu_attention_benchmark.py
+++ b/axlearn/common/flash_attention/gpu_attention_benchmark.py
@@ -10,114 +10,111 @@
 """FlashAttention kernel benchmarks.
 
 Tor run: python3 gpu_attention_benchmark.py > out.txt
-Requires Jax >= 0.4.36. Sample numbers on H100 SXM5 with Jax == 0.4.36:
+Sample numbers on H100 SXM5 with Jax == 0.4.38:
 is_decode=True, use_bwd=False, num_heads=8, num_kv_heads=8, per_head_dim=128, sw_sz=-1
-                                        jax           axlearn       jax-cudnn
-bs=1,seq_len=1024                       0.020832      0.017536      0.024128
-bs=1,seq_len=4096                       0.037472      0.021248      0.058656
-bs=1,seq_len=8192                       0.034016      0.032576      0.108576
-bs=1,seq_len=131072                     0.229856      0.198944      1.558464
-bs=4,seq_len=1024                       0.021632      0.023296      0.024352
-bs=4,seq_len=4096                       0.068064      0.055168      0.061312
-bs=4,seq_len=8192                       0.080352      0.075968      0.109696
-bs=4,seq_len=131072                     0.824576      0.703360      1.560768
-bs=8,seq_len=1024                       0.033536      0.030304      0.024448
-bs=8,seq_len=4096                       0.089056      0.071712      0.062944
-bs=8,seq_len=8192                       0.128960      0.114848      0.112736
-bs=8,seq_len=131072                     1.620032      1.373088      1.566208
-bs=16,seq_len=1024                      0.050368      0.048064      0.036608
-bs=16,seq_len=4096                      0.134816      0.116320      0.104320
-bs=16,seq_len=8192                      0.234880      0.200384      0.191936
-bs=16,seq_len=131072                    3.219008      2.726912      2.784768
-bs=32,seq_len=1024                      0.078112      0.070816      0.061568
-bs=32,seq_len=4096                      0.235648      0.203296      0.191936
-bs=32,seq_len=8192                      0.442080      0.371936      0.365152
-bs=32,seq_len=131072                    6.404832      5.448480      5.541504
+                                                  jax           axlearn       jax-cudnn
+bs=1,seq_len=1024                                 0.022144      0.020960      0.043520
+bs=1,seq_len=4096                                 0.038880      0.026912      0.119872
+bs=1,seq_len=8192                                 0.034336      0.037056      0.222784
+bs=1,seq_len=131072                               0.233728      0.199520      3.113216
+bs=4,seq_len=1024                                 0.025760      0.023392      0.043200
+bs=4,seq_len=4096                                 0.066336      0.055488      0.119680
+bs=4,seq_len=8192                                 0.078976      0.077792      0.221600
+bs=4,seq_len=131072                               0.830560      0.702752      3.263360
+bs=8,seq_len=1024                                 0.043392      0.033632      0.043872
+bs=8,seq_len=4096                                 0.090624      0.074976      0.121024
+bs=8,seq_len=8192                                 0.132480      0.116960      0.223904
+bs=8,seq_len=131072                               1.628800      1.372448      3.149344
+bs=16,seq_len=1024                                0.058080      0.051520      0.047520
+bs=16,seq_len=4096                                0.134080      0.118848      0.124288
+bs=16,seq_len=8192                                0.236288      0.202720      0.217920
+bs=16,seq_len=131072                              3.194208      2.721792      3.102272
+bs=32,seq_len=1024                                0.083200      0.074112      0.077760
+bs=32,seq_len=4096                                0.282784      0.203488      0.219808
+bs=32,seq_len=8192                                0.443488      0.371360      0.411392
+bs=32,seq_len=131072                              6.384032      5.438784      6.138784
 is_decode=True, use_bwd=False, num_heads=8, seq_len=32768, per_head_dim=128, sw_sz=-1
-                                        jax           axlearn       jax-cudnn
-bs=1,num_kv_heads=1                     0.027648      0.058464      0.398816
-bs=1,num_kv_heads=8                     0.076096      0.070368      0.398912
-bs=8,num_kv_heads=1                     0.101696      0.078560      0.399040
-bs=8,num_kv_heads=8                     0.426656      0.367616      0.403360
+                                                  jax           axlearn       jax-cudnn
+bs=1,num_kv_heads=1                               0.033344      0.061408      0.863968
+bs=1,num_kv_heads=8                               0.078976      0.076832      0.800064
+bs=8,num_kv_heads=1                               0.110240      0.082464      1.464544
+bs=8,num_kv_heads=8                               0.431200      0.372608      0.814688
 is_decode=True, use_bwd=False, num_heads=8, num_kv_heads=8, per_head_dim=128
-                                        jax           axlearn       jax-cudnn
-bs=1,seq_len=131072,sw_sz=-1            0.230336      0.199968      1.559168
-bs=1,seq_len=131072,sw_sz=4096          0.235296      0.051296      4.414048
-bs=1,seq_len=131072,sw_sz=16384         0.235904      0.062976      4.385216
-bs=8,seq_len=131072,sw_sz=-1            1.619008      1.372768      1.570272
-bs=8,seq_len=131072,sw_sz=4096          1.635424      0.194720      4.390976
-bs=8,seq_len=131072,sw_sz=16384         1.632832      0.321280      4.361984
+                                                  jax           axlearn       jax-cudnn
+bs=1,seq_len=131072,sw_sz=-1                      0.236064      0.202016      3.098304
+bs=1,seq_len=131072,sw_sz=4096                    0.235904      0.058176      3.091552
+bs=1,seq_len=131072,sw_sz=16384                   0.236960      0.066272      3.093632
+bs=8,seq_len=131072,sw_sz=-1                      1.633824      1.374656      3.183424
+bs=8,seq_len=131072,sw_sz=4096                    1.632896      0.196224      3.124256
+bs=8,seq_len=131072,sw_sz=16384                   1.622656      0.318752      3.104640
 is_decode=False, use_bwd=False, num_heads=32, num_kv_heads=None, seq_len=4096, per_head_dim=128, sw_sz=-1
-                                        jax           axlearn       jax-cudnn     jax-pallas
-bs=2                                    3.573152      0.899136      0.458144      0.839488
-bs=4                                    7.099072      1.721024      0.870624      1.608000
-bs=8                                    14.183424     3.369152      1.705248      3.126688
+                                                  jax           axlearn       jax-cudnn
+bs=2                                              6.151616      0.903744      0.453472
+bs=4                                              11.448928     1.728224      0.868096
+bs=8                                              23.125055     3.385728      1.692704
 is_decode=False, use_bwd=False, bs=2, num_kv_heads=None, seq_len=4096, per_head_dim=128, sw_sz=-1
-                                        jax           axlearn       jax-cudnn     jax-pallas
-num_heads=12                            1.277984      0.387104      0.198784      0.360832
-num_heads=16                            1.812416      0.488224      0.251104      0.455040
-num_heads=32                            3.580384      0.900160      0.453920      2.424960
-num_heads=48                            5.318784      1.315072      0.662368      1.220640
-num_heads=72                            7.986816      1.925024      0.973344      1.792544
+                                                  jax           axlearn       jax-cudnn
+num_heads=12                                      2.344864      0.388864      0.200256
+num_heads=16                                      3.104704      0.493696      0.250944
+num_heads=32                                      6.151008      0.902208      0.452736
+num_heads=48                                      9.222688      1.319168      0.661536
+num_heads=72                                      12.914016     1.946592      0.968800
 is_decode=False, use_bwd=False, bs=2, num_heads=32, num_kv_heads=None, per_head_dim=128, sw_sz=-1
-                                        jax           axlearn       jax-cudnn     jax-pallas
-seq_len=256                             0.048288      0.015136      0.015520      0.014944
-seq_len=512                             0.108736      0.038464      0.027296      0.037024
-seq_len=1024                            0.299776      0.095840      0.052128      0.089120
-seq_len=2048                            0.933824      0.274720      0.144736      0.254912
-seq_len=4096                            3.570368      0.899776      0.452832      2.431424
-seq_len=8192                            14.231360     3.270272      1.649280      3.052800
+                                                  jax           axlearn       jax-cudnn
+seq_len=256                                       0.052096      0.016224      0.015360
+seq_len=512                                       0.133024      0.038944      0.027648
+seq_len=1024                                      0.428480      0.095648      0.052288
+seq_len=2048                                      1.448448      0.273632      0.141568
+seq_len=4096                                      6.142496      0.905152      0.453632
+seq_len=8192                                      19.964993     3.300000      1.638720
 is_decode=False, use_bwd=False, bs=2, num_heads=32, num_kv_heads=None, seq_len=4096, sw_sz=-1
-                                        jax           axlearn       jax-cudnn     jax-pallas
-per_head_dim=16                         3.263456      0.523584      0.304416      0.468032
-per_head_dim=32                         3.316736      0.547872      0.306144      0.514304
-per_head_dim=64                         3.415104      0.691200      0.308704      0.616896
-per_head_dim=128                        3.571488      0.898720      0.455296      2.428064
+                                                  jax           axlearn       jax-cudnn
+per_head_dim=16                                   5.845152      0.527168      0.309536
+per_head_dim=32                                   5.905984      0.560672      0.310912
+per_head_dim=64                                   5.972000      0.684672      0.313184
+per_head_dim=128                                  6.147936      0.902272      0.453280
+is_decode=False, use_bwd=False, num_kv_heads=None, per_head_dim=128
+                                                  jax           axlearn       jax-cudnn
+bs=1,num_heads=4,seq_len=8192,sw_sz=1024          1.528320      0.080000      0.052032
+bs=1,num_heads=4,seq_len=8192,sw_sz=4096          1.528800      0.249504      0.138400
+bs=1,num_heads=4,seq_len=16384,sw_sz=1024         5.917536      0.150784      0.094304
+bs=1,num_heads=4,seq_len=16384,sw_sz=4096         5.918464      0.477888      0.263616
+bs=1,num_heads=4,seq_len=32768,sw_sz=1024         24.009888     0.287040      0.174208
+bs=1,num_heads=4,seq_len=32768,sw_sz=4096         23.968737     0.920320      0.498016
 is_decode=False, use_bwd=True, num_heads=32, num_kv_heads=None, seq_len=4096, per_head_dim=128, sw_sz=-1
-                                        jax           axlearn       jax-cudnn     jax-pallas
-bs=2                                    10.707744     3.956448      1.958240      4.454080
-bs=4                                    21.305376     8.083104      3.799424      9.148736
-bs=8                                    42.545246     16.388351     7.600864      18.032385
+                                                  jax           axlearn       jax-cudnn
+bs=2                                              6.134624      0.940480      0.488192
+bs=4                                              11.365568     1.791296      0.922528
+bs=8                                              22.983904     3.470272      1.795264
 is_decode=False, use_bwd=True, bs=2, num_kv_heads=None, seq_len=4096, per_head_dim=128, sw_sz=-1
-                                        jax           axlearn       jax-cudnn     jax-pallas
-num_heads=12                            4.081632      1.524320      0.834816      1.692224
-num_heads=16                            5.411136      2.013376      1.061248      2.227840
-num_heads=32                            10.724896     3.964064      1.959168      4.461600
-num_heads=48                            15.999936     6.114784      2.883072      6.932064
-num_heads=72                            23.977665     9.295424      4.333504      10.293408
+                                                  jax           axlearn       jax-cudnn
+num_heads=12                                      2.335136      0.406336      0.215584
+num_heads=16                                      3.088672      0.513216      0.272192
+num_heads=32                                      6.135712      0.941312      0.488288
+num_heads=48                                      9.171968      1.371936      0.705792
+num_heads=72                                      12.810016     2.001088      1.032000
 is_decode=False, use_bwd=True, bs=2, num_heads=32, num_kv_heads=None, per_head_dim=128, sw_sz=-1
-                                        jax           axlearn       jax-cudnn     jax-pallas
-seq_len=256                             0.092320      0.057280      0.052928      0.064896
-seq_len=512                             0.294752      0.137600      0.108864      0.156992
-seq_len=1024                            0.883040      0.361856      0.237632      0.415168
-seq_len=2048                            2.855808      1.125152      0.625536      1.285472
-seq_len=4096                            10.700160     3.963456      1.955680      4.454624
-seq_len=8192                            42.416161     15.214400     6.937056      16.611712
+                                                  jax           axlearn       jax-cudnn
+seq_len=256                                       0.054560      0.026080      0.025824
+seq_len=512                                       0.137696      0.052096      0.039616
+seq_len=1024                                      0.424864      0.109216      0.067808
+seq_len=2048                                      1.447232      0.297248      0.164768
+seq_len=4096                                      6.145216      0.939520      0.486816
+seq_len=8192                                      19.973057     3.357696      1.695168
 is_decode=False, use_bwd=True, bs=2, num_heads=32, num_kv_heads=None, seq_len=4096, sw_sz=-1
-                                        jax           axlearn       jax-cudnn     jax-pallas
-per_head_dim=16                         10.013792     1.822496      1.190880      1.670848
-per_head_dim=32                         10.118080     1.984032      1.224000      2.017568
-per_head_dim=64                         10.279040     2.543008      1.270880      2.492608
-per_head_dim=128                        10.704416     3.942368      1.963296      4.455680
-
-is_decode=False, use_bwd=False, bs=1, num_heads=4, num_kv_heads=None, per_head_dim=128
-                                        jax           axlearn       jax-cudnn     jax-pallas
-seq_len=8192,sw_sz=1024                 0.882752      0.079968      0.325088      0.319456
-seq_len=8192,sw_sz=4096                 0.882272      0.250880      0.325152      0.914560
-seq_len=16384,sw_sz=1024                4.639008      0.150720      0.971968      0.948480
-seq_len=16384,sw_sz=4096                4.635008      0.471840      0.977888      2.816384
-seq_len=32768,sw_sz=1024                25.747295     0.286272      3.327232      3.198048
-seq_len=32768,sw_sz=4096                25.761728     0.916800      3.305376      9.667904
-
-is_decode=False, use_bwd=True, bs=1, num_heads=4, num_kv_heads=None, per_head_dim=128
-                                        jax           axlearn       jax-cudnn     jax-pallas
-seq_len=8192,sw_sz=1024                 2.481056      0.313504      1.625088      1.154720
-seq_len=8192,sw_sz=4096                 2.475456      0.955936      1.610944      1.152000
-seq_len=16384,sw_sz=1024                14.337056     0.592704      4.390048      4.075360
-seq_len=16384,sw_sz=4096                14.300768     1.845344      4.402304      4.078464
-seq_len=32768,sw_sz=1024                44.028992     1.149792      16.766592     15.573600
-seq_len=32768,sw_sz=4096                43.984417     3.662720      16.771521     15.582080
-
+                                                  jax           axlearn       jax-cudnn
+per_head_dim=16                                   5.843936      0.541312      0.319744
+per_head_dim=32                                   5.892192      0.563232      0.324736
+per_head_dim=64                                   5.955232      0.700224      0.333440
+per_head_dim=128                                  6.132384      0.941472      0.489696
+is_decode=False, use_bwd=True, num_kv_heads=None, per_head_dim=128
+                                                  jax           axlearn       jax-cudnn
+bs=1,num_heads=4,seq_len=8192,sw_sz=1024          1.528192      0.091232      0.064576
+bs=1,num_heads=4,seq_len=8192,sw_sz=4096          1.530336      0.262080      0.148960
+bs=1,num_heads=4,seq_len=16384,sw_sz=1024         5.922656      0.164960      0.107584
+bs=1,num_heads=4,seq_len=16384,sw_sz=4096         5.914208      0.493888      0.277248
+bs=1,num_heads=4,seq_len=32768,sw_sz=1024         23.976608     0.308416      0.195104
+bs=1,num_heads=4,seq_len=32768,sw_sz=4096         24.004320     0.942208      0.517792
 """
 # pylint: enable=line-too-long
 import itertools

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -113,8 +113,6 @@ def test_triton_against_xla_ref(
     kv_seq_len = kv_seq_len or seq_len
     if kv_seq_len != seq_len and use_segment_ids:
         pytest.skip(reason="segment ids require kv_seq_len == q_seq_len")
-    if jax.default_backend() == "cpu" and kv_seq_len >= 512:
-        pytest.skip(reason="Too slow on CPU.")
     q, k, v, bias = generate_attention_data(
         batch_size,
         seq_len,
@@ -166,6 +164,8 @@ def test_sliding_window_mask(
     use_segment_ids,
     test_cls,
 ):
+    if jax.default_backend() != "gpu" and test_cls is CuDNNGPUFlashAttention:
+        pytest.skip("cuDNN requires GPU.")
     q, k, v, bias = generate_attention_data(
         batch_size,
         seq_len,

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -319,13 +319,13 @@ def test_cudnn_dropout_against_xla_dropout(
 @pytest.mark.parametrize(
     "batch_size,num_heads,seq_len,kv_seq_len,per_head_dim",
     [
-        (1, 1, 378, 676, 128),
-        (2, 4, 582, 582, 128),
+        (1, 1, 378, 676, 72),
+        (2, 4, 582, 582, 56),
     ],
 )
 @pytest.mark.parametrize("causal", [True, False])
 @pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16])
-def test_cudnn_arbitrary_seq_len(
+def test_cudnn_seqlen_head_support(
     batch_size: int,
     num_heads: int,
     seq_len: int,
@@ -334,7 +334,7 @@ def test_cudnn_arbitrary_seq_len(
     causal: bool,
     dtype: jnp.dtype,
 ):
-    """Tests that cudnn supports any even sequence length."""
+    """Tests that cudnn supports any even sequence length and head dim % 8 == 0."""
     if jax.default_backend() == "cpu":
         pytest.skip(reason="cudnn function needs GPU.")
     q, k, v, bias = generate_attention_data(

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -147,7 +147,7 @@ def test_triton_fwd_only_against_ref(
     # Compare outputs.
     test_fn = PallasGPUFlashAttention.default_config().set(**cfg).instantiate()
     ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
-    chex.assert_equal(test_fn.is_supported(q, k, v, bias), True)
+    chex.assert_equal(test_fn.is_supported(query=q, key=k, value=v, bias=bias), True)
     prng_key = jax.random.PRNGKey(43)
     o = test_fn(q, k, v, bias, prng_key)
     o_ref = ref_fn(q, k, v, bias, prng_key)
@@ -193,7 +193,7 @@ def test_triton_against_xla_ref(
     # Compare outputs.
     test_fn = PallasGPUFlashAttention.default_config().set(**cfg).instantiate()
     ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
-    chex.assert_equal(test_fn.is_supported(q, k, v, bias), True)
+    chex.assert_equal(test_fn.is_supported(query=q, key=k, value=v, bias=bias), True)
 
     def forward_tol_fn(backend, dtype):
         del dtype
@@ -241,9 +241,9 @@ def test_sliding_window_mask(
     )
     test_fn = test_cls.default_config().set(**cfg).instantiate()
     if test_cls is CuDNNGPUFlashAttention and use_segment_ids:
-        chex.assert_equal(test_fn.is_supported(q, k, v, bias), False)
+        chex.assert_equal(test_fn.is_supported(query=q, key=k, value=v, bias=bias), False)
         test_fn = CuDNNGPUFlashAttentionWithExplicitBias.default_config().set(**cfg).instantiate()
-    chex.assert_equal(test_fn.is_supported(q, k, v, bias), True)
+    chex.assert_equal(test_fn.is_supported(query=q, key=k, value=v, bias=bias), True)
     ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
     _test_forward_and_backward(q, k, v, bias, ref_fn=ref_fn, test_fn=test_fn)
 
@@ -288,7 +288,7 @@ def test_cudnn_against_triton_ref(
 
     # Compare outputs.
     test_fn = CuDNNGPUFlashAttention.default_config().set(**cfg).instantiate()
-    chex.assert_equal(test_fn.is_supported(q, k, v, bias), True)
+    chex.assert_equal(test_fn.is_supported(query=q, key=k, value=v, bias=bias), True)
     ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
 
     def forward_tol_fn(backend, dtype):
@@ -372,7 +372,7 @@ def test_cudnn_dropout_against_xla_dropout(
     q = jax.random.normal(k1, qkv_shape, dtype=dtype)
     k = jax.random.normal(k2, qkv_shape, dtype=dtype)
     v = jax.random.normal(k3, qkv_shape, dtype=dtype)
-    chex.assert_equal(test_fn.is_supported(q, k, v, bias), True)
+    chex.assert_equal(test_fn.is_supported(query=q, key=k, value=v, bias=bias), True)
 
     ref_fn = functools.partial(
         ref_fn,
@@ -422,7 +422,7 @@ def test_cudnn_seqlen_head_support(
     # Compare outputs.
     test_fn = CuDNNGPUFlashAttention.default_config().set(**cfg).instantiate()
     ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
-    chex.assert_equal(test_fn.is_supported(q, k, v, bias), True)
+    chex.assert_equal(test_fn.is_supported(query=q, key=k, value=v, bias=bias), True)
 
     _test_forward_and_backward(
         q, k, v, bias, ref_fn=ref_fn, test_fn=test_fn, forward_tol_fn=_cudnn_xla_forward_tol_fn

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -27,12 +27,12 @@ from axlearn.common.attention_bias import (
     causal_mask,
     sliding_window_causal_mask,
 )
+from axlearn.common.flash_attention.common import ReferenceMHA
 from axlearn.common.flash_attention.gpu_attention import (
     CuDNNGPUFlashAttention,
     PallasGPUFlashAttention,
 )
 from axlearn.common.flash_attention.test_utils import generate_attention_data
-from axlearn.common.flash_attention.utils import ReferenceMHA
 from axlearn.common.utils import Tensor
 
 if jax.default_backend() not in ("gpu", "cpu"):

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -8,7 +8,10 @@
 
 """Tests GPU FlashAttention kernels.
 
-Currently tested on A100/H100.
+Currently tested on A100/H100. To run tests in parallel on multi-GPU machines, use somethine like
+```
+PARALLEL_GPU_TEST=1 pytest -n 8 axlearn/common/flash_attention/gpu_attention_test.py
+```
 """
 import functools
 from typing import Any, Callable, Literal

--- a/axlearn/common/flash_attention/gpu_decoding.py
+++ b/axlearn/common/flash_attention/gpu_decoding.py
@@ -45,13 +45,14 @@ from typing import Optional
 
 import jax
 import jax.numpy as jnp
+from absl import logging
 from jax import lax
 from jax._src.cudnn.fused_attention_stablehlo import check_compute_capability
 from jax.experimental import pallas as pl
 
-from axlearn.common.attention_bias import NEG_INF, MaskFn
+from axlearn.common.attention_bias import NEG_INF, MaskFn, MaskFnAttentionBias, split
+from axlearn.common.flash_attention.common import BaseSingleStepDecoding
 from axlearn.common.flash_attention.gpu_attention import NoPopDict
-from axlearn.common.utils import Tensor
 
 
 # Note: split_k_seq_len must be a multiple of block_k.
@@ -270,94 +271,48 @@ def _decode_attn_unbatched(
     return o.astype(q.dtype)
 
 
-@functools.partial(
-    jax.jit,
-    static_argnames=[
-        "softmax_scale",
-        "block_h",
-        "block_k",
-        "num_warps",
-        "num_stages",
-        "interpret",
-        "debug",
-        "mask_fn",
-    ],
-)
-def flash_decoding(
-    q: Tensor,
-    k: Tensor,
-    v: Tensor,
-    kv_seq_len: Optional[Tensor],
-    *,
-    bias: Optional[Tensor] = None,
-    softmax_scale: float = 1.0,
-    mask_fn: Optional[MaskFn] = None,
-    block_h: int = 16,
-    block_k: int = 128,
-    num_warps: int = 4,
-    num_stages: int = 2,
-    interpret: bool = False,
-    debug: bool = False,
-):
-    """Runs flash decoding with GQA support.
+class GPUDecoding(BaseSingleStepDecoding):
+    """Implements GPU FlashDecoding with GQA support."""
 
-    Args:
-        q: Tensor of shape [batch_size, 1, num_q_heads, head_dim].
-        k: Tensor of shape [batch_size, padded_kv_seq_len, num_kv_heads, head_dim].
-        v: Tensor of shape [batch_size, padded_kv_seq_len, num_kv_heads, head_dim].
-        kv_seq_len: Tensor that can broadcast to [batch_size], indicating the actual kv sequence
-            length for each sequence in the batch. If None, assumes k and v are not padded in the
-            sequence dimension.
-        bias: Tensor that can broadcast to [batch_size, q_heads, 1, padded_kv_seq_len].
-            Defaults to None.
-        softmax_scale: Softmax scale.
-        mask_fn: Mask function to use. Preferred over bias.
-        block_h: Block dimension for num_q_heads // num_kv_heads. Defaults to 16, which is the
-            minimal size required for pl.dot. Increase the block size for better performance if
-            num_q_heads // num_kv_heads > 16.
-        block_k: Block dimension along the sequence dim. Defaults to 128. Decrease if SMEM usage
-            exceeds limit.
-        num_warps: See the compiler options of `pl.pallas_call`. Default to 4 wraps which have the
-            best performance in most settings.
-        num_stages: See the compiler options of `pl.pallas_call`. Default to 2 which is faster than
-            no software pipelining. Higher values may cause SMEM OOM.
-        interpret: See `pl.pallas_call`.
-        debug: See `pl.pallas_call`.
+    def __call__(self, query, key, value, bias, prng_key=None):
+        del prng_key
+        mask, explicit_bias = split(bias, MaskFnAttentionBias)
+        if mask is None or mask.target_positions is None:
+            raise ValueError("Cannot retrieve MaskFnAttentionBias or target_positions.")
+        mask_fn = mask.mask
+        kv_seq_len = mask.target_positions[:, -1] + 1
+        logging.info("Using mask_fn=%s for FlashDecoding.", mask_fn)
 
-    Returns:
-        A tensor with the same shape and dtype as q.
-    """
-    q = q.squeeze(1)
-    batch_size, q_heads, head_dim = q.shape
-    padded_kv_seq_len, kv_heads = k.shape[1], k.shape[2]
-    if k.shape != v.shape:
-        raise RuntimeError(f"Expect k and v to have the same shape. Got {k.shape=}, {v.shape=}!")
-    if q_heads % kv_heads != 0:
-        raise RuntimeError(
-            f"Expect number of kv heads divides number of q heads. Got {kv_heads=}, {q_heads=}!"
-        )
-    if kv_seq_len is not None:
+        query = query.squeeze(1)
+        batch_size, q_heads, head_dim = query.shape
+        padded_kv_seq_len, kv_heads = key.shape[1], key.shape[2]
         kv_seq_len = jnp.broadcast_to(jnp.asarray(kv_seq_len), (batch_size,))
-    else:
-        kv_seq_len = jnp.full((batch_size,), padded_kv_seq_len, dtype=jnp.int32)
-    q_heads_per_kv_head = q_heads // kv_heads
-    q = q.reshape(batch_size, kv_heads, q_heads_per_kv_head, head_dim)
+        q_heads_per_kv_head = q_heads // kv_heads
+        query = query.reshape(batch_size, kv_heads, q_heads_per_kv_head, head_dim)
 
-    if bias is not None:
-        bias = jnp.broadcast_to(bias, (batch_size, q_heads, 1, padded_kv_seq_len))
-        bias = bias.reshape(batch_size, kv_heads, q_heads_per_kv_head, padded_kv_seq_len)
+        bias = explicit_bias.value()
+        if bias is not None:
+            logging.info(
+                "Using explicit_bias=%s for FlashDecoding. "
+                "This is not expected unless an explicit Tensor bias is used.",
+                bias,
+            )
+            bias = jnp.broadcast_to(bias, (batch_size, q_heads, 1, padded_kv_seq_len))
+            bias = bias.reshape(batch_size, kv_heads, q_heads_per_kv_head, padded_kv_seq_len)
 
-    inner = functools.partial(
-        _decode_attn_unbatched,
-        softmax_scale=softmax_scale,
-        block_h=block_h,
-        block_k=block_k,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        interpret=interpret,
-        debug=debug,
-        mask_fn=mask_fn,
-        batch_size=batch_size,
-    )
-    o = jax.vmap(inner)(q, k, v, bias, kv_seq_len)
-    return o.reshape(batch_size, 1, q_heads, head_dim)
+        inner = functools.partial(
+            _decode_attn_unbatched,
+            softmax_scale=self.cfg.softmax_scale,
+            # Minimum block size is 16 to allow pl.dot to lower successfully.
+            block_h=max(16, pl.next_power_of_2(q_heads_per_kv_head)),
+            block_k=self.cfg.gpu_block_size,
+            num_warps=4,
+            num_stages=2,
+            interpret=self.cfg.interpret,
+            debug=False,
+            mask_fn=mask_fn,
+            batch_size=batch_size,
+        )
+        return jax.vmap(inner)(query, key, value, bias, kv_seq_len).reshape(
+            batch_size, 1, q_heads, head_dim
+        )

--- a/axlearn/common/flash_attention/gpu_decoding.py
+++ b/axlearn/common/flash_attention/gpu_decoding.py
@@ -274,6 +274,7 @@ def _decode_attn_unbatched(
 class GPUDecoding(BaseSingleStepDecoding):
     """Implements GPU FlashDecoding with GQA support."""
 
+    @functools.partial(jax.jit, static_argnames=["self"])
     def __call__(self, query, key, value, bias, prng_key=None):
         del prng_key
         mask, explicit_bias = split(bias, MaskFnAttentionBias)

--- a/axlearn/common/flash_attention/gpu_decoding.py
+++ b/axlearn/common/flash_attention/gpu_decoding.py
@@ -50,9 +50,16 @@ from jax import lax
 from jax._src.cudnn.fused_attention_stablehlo import check_compute_capability
 from jax.experimental import pallas as pl
 
-from axlearn.common.attention_bias import NEG_INF, MaskFn, MaskFnAttentionBias, split
+from axlearn.common.attention_bias import (
+    NEG_INF,
+    BaseAttentionBias,
+    MaskFn,
+    MaskFnAttentionBias,
+    split,
+)
 from axlearn.common.flash_attention.common import BaseSingleStepDecoding
 from axlearn.common.flash_attention.gpu_attention import NoPopDict
+from axlearn.common.utils import Tensor
 
 
 # Note: split_k_seq_len must be a multiple of block_k.
@@ -275,7 +282,15 @@ class GPUDecoding(BaseSingleStepDecoding):
     """Implements GPU FlashDecoding with GQA support."""
 
     @functools.partial(jax.jit, static_argnames=["self"])
-    def __call__(self, query, key, value, bias, prng_key=None):
+    def __call__(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        bias: BaseAttentionBias,
+        prng_key: Optional[Tensor] = None,
+    ) -> Tensor:
+        """See `BaseFlashAttention.__call__`."""
         del prng_key
         mask, explicit_bias = split(bias, MaskFnAttentionBias)
         if mask is None or mask.target_positions is None:

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -177,6 +177,7 @@ class FlashAttention(GroupedQueryAttention):
             backend=backend,
             softmax_scale=1.0,
             is_decoding=is_decoding,
+            # TODO(hanzhi-zhou): Refactor backend specific config passing.
             tpu_block_size=cfg.tpu_block_size,
             dropout_rate=cfg.dropout.rate,
         )

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -177,7 +177,7 @@ class FlashAttention(GroupedQueryAttention):
             backend=backend,
             softmax_scale=1.0,
             is_decoding=is_decoding,
-            block_size=cfg.tpu_block_size,
+            tpu_block_size=cfg.tpu_block_size,
             dropout_rate=cfg.dropout.rate,
         )
 

--- a/axlearn/common/flash_attention/neuron_attention.py
+++ b/axlearn/common/flash_attention/neuron_attention.py
@@ -234,6 +234,7 @@ class NeuronFlashAttention(BaseFlashAttention):
         logging.info("Using %s.", self.name())
         return True
 
+    @partial(jax.jit, static_argnames=["self"])
     def __call__(self, query, key, value, bias, prng_key=None):
         del prng_key
 

--- a/axlearn/common/flash_attention/neuron_attention.py
+++ b/axlearn/common/flash_attention/neuron_attention.py
@@ -229,8 +229,7 @@ class NeuronFlashAttention(BaseFlashAttention):
         if not super().is_supported(query, key, value, bias):
             return False
         if self.cfg.dropout_rate != 0.0:
-            self._log_unsupported("dropout is not supported.")
-            return False
+            return self._log_unsupported("dropout is not supported.")
         logging.info("Using %s.", self.name())
         return True
 

--- a/axlearn/common/flash_attention/neuron_attention_test.py
+++ b/axlearn/common/flash_attention/neuron_attention_test.py
@@ -1,6 +1,8 @@
 # Copyright © 2024 Amazon Inc.
 """Tests for Flash attention on Neuron. Tested on trn1 & trn2."""
 
+from typing import Literal
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -90,7 +92,7 @@ def test_bwd_against_ref(
     per_head_dim: int,
     causal: bool,
     input_dtype: jnp.dtype,
-    attention_bias_type: str,
+    attention_bias_type: Literal[None, "2d"],
 ):
     # On demand import only if test is needed.
     # pylint: disable=import-outside-toplevel

--- a/axlearn/common/flash_attention/neuron_attention_test.py
+++ b/axlearn/common/flash_attention/neuron_attention_test.py
@@ -39,7 +39,7 @@ def test_fwd_against_ref(
     per_head_dim: int,
     causal: bool,
     input_dtype: jnp.dtype,
-    attention_bias_type: str,
+    attention_bias_type: Literal[None, "2d"],
 ):
     # On demand import only if test is needed.
     # pylint: disable=import-outside-toplevel

--- a/axlearn/common/flash_attention/neuron_attention_test.py
+++ b/axlearn/common/flash_attention/neuron_attention_test.py
@@ -6,7 +6,9 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from axlearn.common.flash_attention.utils import mha_reference
+from axlearn.common.attention_bias import causal_mask
+from axlearn.common.flash_attention.test_utils import generate_attention_data
+from axlearn.common.flash_attention.utils import ReferenceMHA
 
 if jax.default_backend() != "neuron":
     pytestmark = pytest.skip(
@@ -39,37 +41,28 @@ def test_fwd_against_ref(
 ):
     # On demand import only if test is needed.
     # pylint: disable=import-outside-toplevel
-    from axlearn.common.flash_attention.neuron_attention import flash_attention
+    from axlearn.common.flash_attention.neuron_attention import NeuronFlashAttention
 
-    softmax_scale = per_head_dim**-0.5
-    k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(0), 4)
-    q = jax.random.normal(k1, (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype)
-    k = jax.random.normal(k2, (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype)
-    v = jax.random.normal(k3, (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype)
-
-    if attention_bias_type == "2d":
-        bias = jax.random.normal(k4, (1, 1, seq_len, seq_len), dtype=input_dtype)
-    else:
-        bias = None
-
-    o = flash_attention(
-        q,
-        k,
-        v,
-        bias,
-        causal=causal,
-        softmax_scale=softmax_scale,
-        dropout_rate=0.0,
+    q, k, v, bias = generate_attention_data(
+        batch_size,
+        seq_len,
+        seq_len,
+        num_heads,
+        per_head_dim,
+        mask_fn=causal_mask if causal else None,
+        attention_bias_type=attention_bias_type,
+        dtype=input_dtype,
     )
-    o_ref = mha_reference(
-        q,
-        k,
-        v,
-        bias,
-        causal=causal,
-        softmax_scale=softmax_scale,
-        dropout_rate=0.0,
+
+    cfg = dict(
+        softmax_scale=q.shape[-1] ** -0.5,
     )
+    # Compare outputs.
+    test_fn = NeuronFlashAttention.default_config().set(**cfg).instantiate()
+    ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
+
+    o = test_fn(q, k, v, bias)
+    o_ref = ref_fn(q, k, v, bias)
     if input_dtype == jnp.float16:
         chex.assert_trees_all_close(o, o_ref, atol=0.07)
     elif input_dtype == jnp.float32:
@@ -101,41 +94,26 @@ def test_bwd_against_ref(
 ):
     # On demand import only if test is needed.
     # pylint: disable=import-outside-toplevel
-    from axlearn.common.flash_attention.neuron_attention import flash_attention
+    from axlearn.common.flash_attention.neuron_attention import NeuronFlashAttention
 
-    softmax_scale = per_head_dim**-0.5
-    k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(0), 4)
-    q = jax.random.normal(k1, (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype)
-    k = jax.random.normal(k2, (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype)
-    v = jax.random.normal(k3, (batch_size, seq_len, num_heads, per_head_dim), dtype=input_dtype)
+    q, k, v, bias = generate_attention_data(
+        batch_size,
+        seq_len,
+        seq_len,
+        num_heads,
+        per_head_dim,
+        mask_fn=causal_mask if causal else None,
+        attention_bias_type=attention_bias_type,
+        dtype=input_dtype,
+    )
 
-    if attention_bias_type == "2d":
-        bias = jax.random.normal(k4, (1, 1, seq_len, seq_len), dtype=input_dtype)
-    else:
-        bias = None
+    cfg = dict(
+        softmax_scale=q.shape[-1] ** -0.5,
+    )
+    # Compare outputs.
+    test_fn = NeuronFlashAttention.default_config().set(**cfg).instantiate()
+    ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
 
-    def fn(q, k, v, bias):
-        return flash_attention(
-            q,
-            k,
-            v,
-            bias,
-            causal=causal,
-            softmax_scale=softmax_scale,
-            dropout_rate=0.0,
-        ).sum()
-
-    def ref_fn(q, k, v, bias):
-        return mha_reference(
-            q,
-            k,
-            v,
-            bias,
-            causal=causal,
-            softmax_scale=softmax_scale,
-            dropout_rate=0.0,
-        ).sum()
-
-    jax_grads = jax.grad(fn, argnums=(0, 1, 2))(q, k, v, bias)
+    jax_grads = jax.grad(test_fn, argnums=(0, 1, 2))(q, k, v, bias)
     jax_ref_grads = jax.grad(ref_fn, argnums=(0, 1, 2))(q, k, v, bias)
     chex.assert_trees_all_close(jax_grads, jax_ref_grads, atol=0.07)

--- a/axlearn/common/flash_attention/neuron_attention_test.py
+++ b/axlearn/common/flash_attention/neuron_attention_test.py
@@ -114,6 +114,6 @@ def test_bwd_against_ref(
     test_fn = NeuronFlashAttention.default_config().set(**cfg).instantiate()
     ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
 
-    jax_grads = jax.grad(test_fn, argnums=(0, 1, 2))(q, k, v, bias)
-    jax_ref_grads = jax.grad(ref_fn, argnums=(0, 1, 2))(q, k, v, bias)
+    jax_grads = jax.grad(lambda *args: test_fn(*args).mean(), argnums=(0, 1, 2))(q, k, v, bias)
+    jax_ref_grads = jax.grad(lambda *args: ref_fn(*args).mean(), argnums=(0, 1, 2))(q, k, v, bias)
     chex.assert_trees_all_close(jax_grads, jax_ref_grads, atol=0.07)

--- a/axlearn/common/flash_attention/neuron_attention_test.py
+++ b/axlearn/common/flash_attention/neuron_attention_test.py
@@ -7,8 +7,8 @@ import jax.numpy as jnp
 import pytest
 
 from axlearn.common.attention_bias import causal_mask
+from axlearn.common.flash_attention.common import ReferenceMHA
 from axlearn.common.flash_attention.test_utils import generate_attention_data
-from axlearn.common.flash_attention.utils import ReferenceMHA
 
 if jax.default_backend() != "neuron":
     pytestmark = pytest.skip(

--- a/axlearn/common/flash_attention/test_utils.py
+++ b/axlearn/common/flash_attention/test_utils.py
@@ -5,6 +5,7 @@ from typing import Literal, Optional
 
 import jax
 import jax.numpy as jnp
+import pytest
 
 from axlearn.common.attention_bias import (
     CausalAttentionBias,
@@ -41,6 +42,9 @@ def generate_attention_data(
     k1, k2, k3, k4, k5 = jax.random.split(jax.random.PRNGKey(0), 5)
     q = jax.random.normal(k1, (batch_size, query_len, num_heads, per_head_dim), dtype=dtype)
     num_kv_heads = num_kv_heads or num_heads
+    kv_len = kv_len or query_len
+    if kv_len != query_len and with_segment_ids:
+        pytest.skip(reason="segment ids require kv_seq_len == q_seq_len")
     k = jax.random.normal(k2, (batch_size, kv_len, num_kv_heads, per_head_dim), dtype=dtype)
     v = jax.random.normal(k3, (batch_size, kv_len, num_kv_heads, per_head_dim), dtype=dtype)
     attention_bias = None

--- a/axlearn/common/flash_attention/test_utils.py
+++ b/axlearn/common/flash_attention/test_utils.py
@@ -12,8 +12,10 @@ from axlearn.common.attention_bias import (
     MaskFn,
     MaskFnAttentionBias,
     SegmentIdAttentionBias,
+    SlidingWindowAttentionBias,
     TensorAttentionBias,
     causal_mask,
+    sliding_window_causal_mask,
 )
 from axlearn.common.utils import Tensor
 
@@ -26,12 +28,16 @@ def generate_attention_data(
     per_head_dim: int,
     num_kv_heads: Optional[int] = None,
     mask_fn: Optional[MaskFn] = None,
+    sliding_window_sz: Optional[int] = None,
     attention_bias_type: Literal[None, "2d", "4d"] = None,
     with_segment_ids: bool = False,
     dtype=jnp.bfloat16,
     query_offset: int = 0,
 ) -> tuple[Tensor, Tensor, Tensor, CompositeAttentionBias]:
     """Generates QKV and Bias for unit test purposes."""
+    if sliding_window_sz is not None and sliding_window_sz != -1:
+        # Sliding window size conflicts with the following mask fns.
+        assert mask_fn is not causal_mask and mask_fn is not sliding_window_causal_mask
     k1, k2, k3, k4, k5 = jax.random.split(jax.random.PRNGKey(0), 5)
     q = jax.random.normal(k1, (batch_size, query_len, num_heads, per_head_dim), dtype=dtype)
     num_kv_heads = num_kv_heads or num_heads
@@ -50,15 +56,23 @@ def generate_attention_data(
         segment_ids = jnp.cumsum(segment_ids, axis=1)
 
     bias_list = []
+    pos = dict(
+        target_positions=jnp.arange(query_len)[None] + query_offset,
+        source_positions=jnp.arange(kv_len)[None],
+    )
     if mask_fn is not None:
-        pos = dict(
-            target_positions=jnp.arange(query_len)[None] + query_offset,
-            source_positions=jnp.arange(kv_len)[None],
-        )
         if mask_fn is causal_mask:
             bias_list.append(CausalAttentionBias(**pos))
         else:
             bias_list.append(MaskFnAttentionBias(mask_fn, **pos))
+    if sliding_window_sz is not None and sliding_window_sz != -1:
+        bias_list.append(
+            SlidingWindowAttentionBias(
+                sliding_window_causal_mask(sliding_window_sz),
+                **pos,
+                sliding_window_size=sliding_window_sz,
+            )
+        )
     if with_segment_ids:
         bias_list.append(SegmentIdAttentionBias(segment_ids))
     if attention_bias is not None:

--- a/axlearn/common/flash_attention/test_utils.py
+++ b/axlearn/common/flash_attention/test_utils.py
@@ -1,0 +1,64 @@
+# Copyright © 2023 Apple Inc.
+"""Common test utils for FlashAttention tests."""
+
+from typing import Literal, Optional
+
+import jax
+import jax.numpy as jnp
+
+from axlearn.common.attention_bias import (
+    CompositeAttentionBias,
+    MaskFn,
+    MaskFnAttentionBias,
+    SegmentIdAttentionBias,
+    TensorAttentionBias,
+)
+from axlearn.common.utils import Tensor
+
+
+def generate_attention_data(
+    batch_size,
+    query_len,
+    kv_len,
+    num_heads,
+    per_head_dim,
+    num_kv_heads: Optional[int] = None,
+    mask_fn: Optional[MaskFn] = None,
+    attention_bias_type: Literal[None, "2d", "4d"] = None,
+    with_segment_ids: bool = False,
+    dtype=jnp.bfloat16,
+    query_offset: int = 0,
+) -> tuple[Tensor, Tensor, Tensor, CompositeAttentionBias]:
+    k1, k2, k3, k4, k5 = jax.random.split(jax.random.PRNGKey(0), 5)
+    q = jax.random.normal(k1, (batch_size, query_len, num_heads, per_head_dim), dtype=dtype)
+    num_kv_heads = num_kv_heads or num_heads
+    k = jax.random.normal(k2, (batch_size, kv_len, num_kv_heads, per_head_dim), dtype=dtype)
+    v = jax.random.normal(k3, (batch_size, kv_len, num_kv_heads, per_head_dim), dtype=dtype)
+    attention_bias = None
+    if attention_bias_type == "2d":
+        attention_bias = jax.random.normal(k4, (1, 1, query_len, kv_len), dtype=dtype)
+    elif attention_bias_type == "4d":
+        attention_bias = jax.random.normal(
+            k4, (batch_size, num_heads, query_len, kv_len), dtype=dtype
+        )
+    segment_ids = None
+    if with_segment_ids:
+        segment_ids = jax.random.bernoulli(k5, shape=(batch_size, kv_len)).astype(jnp.int32)
+        segment_ids = jnp.cumsum(segment_ids, axis=1)
+
+    bias_list = []
+    if mask_fn is not None:
+        bias_list.append(
+            MaskFnAttentionBias(
+                mask_fn,
+                target_positions=jnp.arange(query_len)[None] + query_offset,
+                source_positions=jnp.arange(kv_len)[None],
+            )
+        )
+    if with_segment_ids:
+        bias_list.append(SegmentIdAttentionBias(segment_ids))
+    if attention_bias is not None:
+        bias_list.append(TensorAttentionBias(attention_bias))
+    bias = CompositeAttentionBias(bias_list)
+
+    return q, k, v, bias

--- a/axlearn/common/flash_attention/test_utils.py
+++ b/axlearn/common/flash_attention/test_utils.py
@@ -7,21 +7,23 @@ import jax
 import jax.numpy as jnp
 
 from axlearn.common.attention_bias import (
+    CausalAttentionBias,
     CompositeAttentionBias,
     MaskFn,
     MaskFnAttentionBias,
     SegmentIdAttentionBias,
     TensorAttentionBias,
+    causal_mask,
 )
 from axlearn.common.utils import Tensor
 
 
 def generate_attention_data(
-    batch_size,
-    query_len,
-    kv_len,
-    num_heads,
-    per_head_dim,
+    batch_size: int,
+    query_len: int,
+    kv_len: int,
+    num_heads: int,
+    per_head_dim: int,
     num_kv_heads: Optional[int] = None,
     mask_fn: Optional[MaskFn] = None,
     attention_bias_type: Literal[None, "2d", "4d"] = None,
@@ -29,6 +31,7 @@ def generate_attention_data(
     dtype=jnp.bfloat16,
     query_offset: int = 0,
 ) -> tuple[Tensor, Tensor, Tensor, CompositeAttentionBias]:
+    """Generates QKV and Bias for unit test purposes."""
     k1, k2, k3, k4, k5 = jax.random.split(jax.random.PRNGKey(0), 5)
     q = jax.random.normal(k1, (batch_size, query_len, num_heads, per_head_dim), dtype=dtype)
     num_kv_heads = num_kv_heads or num_heads
@@ -48,13 +51,14 @@ def generate_attention_data(
 
     bias_list = []
     if mask_fn is not None:
-        bias_list.append(
-            MaskFnAttentionBias(
-                mask_fn,
-                target_positions=jnp.arange(query_len)[None] + query_offset,
-                source_positions=jnp.arange(kv_len)[None],
-            )
+        pos = dict(
+            target_positions=jnp.arange(query_len)[None] + query_offset,
+            source_positions=jnp.arange(kv_len)[None],
         )
+        if mask_fn is causal_mask:
+            bias_list.append(CausalAttentionBias(**pos))
+        else:
+            bias_list.append(MaskFnAttentionBias(mask_fn, **pos))
     if with_segment_ids:
         bias_list.append(SegmentIdAttentionBias(segment_ids))
     if attention_bias is not None:

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -19,298 +19,36 @@ from jax.experimental.pallas.ops.tpu.flash_attention import (
     NUM_SUBLANES,
 )
 from jax.experimental.pallas.ops.tpu.flash_attention import BlockSizes as LegacyBlockSizes
+from jax.experimental.pallas.ops.tpu.flash_attention import SegmentIds as LegacySegmentIds
 from jax.experimental.pallas.ops.tpu.flash_attention import (
-    SegmentIds,
     _flash_attention_dkv_kernel,
     _flash_attention_dq_kernel,
     _flash_attention_kernel,
     _verify_block,
     below_or_on_diag,
 )
+from jax.experimental.pallas.ops.tpu.splash_attention import SegmentIds as SplashSegmentIds
 from jax.experimental.pallas.ops.tpu.splash_attention import (
     splash_attention_kernel,
     splash_attention_mask,
 )
 
-from axlearn.common.attention import apply_attention_logit_biases
 from axlearn.common.attention_bias import (
     CausalAttentionBias,
     MaskFnAttentionBias,
+    SegmentIdAttentionBias,
     SlidingWindowAttentionBias,
     ZeroAttentionBias,
-    as_attention_bias,
+    split,
+)
+from axlearn.common.flash_attention.common import (
+    BaseFlashAttention,
+    get_segment_ids,
+    repeat_kv_heads,
 )
 from axlearn.common.flash_attention.remat import FLASH_ATTN_RESIDUAL_NAME
-from axlearn.common.utils import Tensor
 
 MaskFnOrZero = MaskFnAttentionBias | ZeroAttentionBias
-
-
-def tpu_flash_attention(
-    query: Tensor,  # [batch_size, target_len, num_heads, head_dim]
-    key: Tensor,  # [batch_size, source_len, num_heads, head_dim]
-    value: Tensor,  # [batch_size, source_len, num_heads, head_dim]
-    bias: Tensor = None,  # [batch_size, num_heads, target_len, source_len]
-    segment_ids: Tensor = None,  # [batch_size, target_len]
-    *,
-    mask: MaskFnOrZero,
-    softmax_scale: float = 1.0,
-    is_decoding: bool = False,
-    block_size: int = 128,
-    interpret: bool = False,
-):
-    """Wraps JAX's TPU flash-attention, with reshapes and softmax-scaling outside kernel.
-
-    An implementation is automatically selected based on the arguments.
-
-    N.B. we apply the softmax scale factor outside of the kernel because:
-        1. within-kernel ordering of attention-bias addition and softmax scaling differ to axlearn,
-        2. it's more efficient to scale outside the kernel vs. fix order of ops in kernel.
-
-    If provided, bias, segment_ids, and mask are applied on top of one another.
-
-    Args:
-        query: The query tensor, of shape [batch_size, target_len, num_heads, head_dim].
-        key: The key tensor, of shape [batch_size, source_len, num_heads, head_dim].
-        value: The value tensor, of shape [batch_size, source_len, num_heads, head_dim].
-        bias: The attention biases, can broadcast to shape
-            [batch_size, num_heads, target_len, source_len].
-        segment_ids: The id of which segment each token belongs to. Attention is not computed
-             between tokens in different segments.
-             Shape:  [batch_size, target_len].
-        mask: The mask to apply. This is more compute efficient compared to setting bias = -inf.
-        softmax_scale: A scaling factor applied to the query.
-        is_decoding: Whether it is in decoding.
-        block_size: The block size to use for chunking data in the kernel.
-        interpret: If True, interpret the kernel using the pallas interpreter. CPU needs it.
-
-    Returns:
-        The context tensor, of shape [batch_size, target_len, num_heads, head_dim].
-
-    Raises:
-        NotImplementedError: If no implementation with support for the arguments is found.
-        ValueError: If the head_dim of the query, key, and value are not all equal.
-        ValueError: if the target or source sequence length is not divisible by block_size.`
-    """
-    if segment_ids is not None:
-        assert query.shape[1] == key.shape[1] and query.shape[1] == value.shape[1]
-    # Apply the softmax scale outside the kernel (see docstring for why).
-    if softmax_scale != 1.0:
-        query *= softmax_scale
-
-    head_dim = query.shape[3]
-
-    if head_dim != key.shape[3]:
-        raise ValueError(
-            f"Per-head dimension of query doesn't equal that of key: "
-            f"{head_dim} != {key.shape[3]}"
-        )
-    if head_dim != value.shape[3]:
-        raise ValueError(
-            f"Per-head dimension of query doesn't equal that of value: "
-            f"{head_dim} != {value.shape[3]}"
-        )
-
-    if query.shape[1] % block_size != 0:
-        raise ValueError(
-            f"Target seq len {query.shape[1]} must be divisible by block size {block_size}."
-        )
-    if key.shape[1] % block_size != 0:
-        raise ValueError(
-            f"Source seq len {key.shape[1]} must be divisible by block size {block_size}."
-        )
-
-    mask: MaskFnOrZero = as_attention_bias(mask)
-
-    # Switch num_heads and seq_len axes.
-    query = jnp.einsum("btnh->bnth", query)
-    key = jnp.einsum("bsnh->bnsh", key)
-    value = jnp.einsum("bsnh->bnsh", value)
-    try:
-        check_tpu_splash_attention(
-            target_len=query.shape[2],
-            source_len=key.shape[2],
-            head_dim=query.shape[3],
-            mask=mask,
-            is_decoding=is_decoding,
-            has_segment_ids=(segment_ids is not None),
-            has_bias=(bias is not None),
-        )
-        block_sizes = splash_attention_kernel.BlockSizes(
-            block_q=block_size,
-            block_kv=block_size,
-            block_kv_compute=block_size,
-            block_q_dkv=block_size,
-            block_kv_dkv=block_size,
-            block_kv_dkv_compute=block_size,
-            # The fused kernel is neutral in small models and a ~5%-15% improvement in larger ones.
-            # E.g., 1.03x speedup in a 12.6b simulated model, 1.06x speedup in 29.6b ,
-            # and 1.14x in 539.5b.
-            use_fused_bwd_kernel=True,
-        )
-        splash_mask = _to_splash_mask(mask, mask_shape=(query.shape[2], key.shape[2]))
-        context = _tpu_splash_attention(
-            query,
-            key,
-            value,
-            splash_mask=splash_mask,
-            segment_ids=segment_ids,
-            block_sizes=block_sizes,
-            interpret=interpret,
-        )
-        logging.info("Using SplashAttention.")
-    except SplashAttentionUnsupportedError as e:
-        # TODO(tom_gunter): See if we can do better block-size tuning.
-        block_sizes = LegacyBlockSizes(
-            block_q=block_size,
-            block_k_major=block_size,
-            block_k=block_size,
-            block_b=1,
-            block_q_major_dkv=block_size,
-            block_k_major_dkv=block_size,
-            block_k_dkv=block_size,
-            block_q_dkv=block_size,
-            block_k_major_dq=block_size,
-            block_k_dq=block_size,
-            block_q_dq=block_size,
-        )
-        causal = isinstance(mask, CausalAttentionBias)
-        if not causal and mask.has_value():
-            bias = apply_attention_logit_biases(mask.value(), bias)
-        context = _legacy_tpu_flash_attention(
-            query,
-            key,
-            value,
-            bias,
-            segment_ids=segment_ids,
-            causal=causal,
-            block_sizes=block_sizes,
-            interpret=interpret,
-        )
-        logging.warning(
-            "Falling back to legacy flash attention because SplashAttention is not supported.\n"
-            "Reason: %s",
-            e,
-        )
-
-    # Restore num_heads and seq_len axes.
-    return jnp.einsum("bnth->btnh", context)
-
-
-@functools.partial(
-    jax.jit,
-    static_argnames=[
-        "causal",
-        "block_sizes",
-        "interpret",
-    ],
-)
-def _legacy_tpu_flash_attention(
-    query: Tensor,  # [batch_size, num_heads, target_len, head_dim]
-    key: Tensor,  # [batch_size, num_heads, source_len, head_dim]
-    value: Tensor,  # [batch_size, num_heads, source_len, head_dim]
-    bias: Tensor = None,  # [batch_size, num_heads, target_len, source_len]
-    segment_ids: Tensor = None,  # [batch_size, target_len]
-    *,
-    causal: bool = False,
-    block_sizes: Optional[LegacyBlockSizes] = None,
-    interpret: bool = False,
-) -> Tensor:  # [batch_size, num_heads, target_len, head_dim].
-    """Wraps JAX's legacy TPU flash-attention.
-
-    If provided, bias, segment_ids, and mask are applied on top of one another.
-
-    Args:
-        query: The query tensor, of shape [batch_size, num_heads, target_len, head_dim].
-        key: The key tensor, of shape [batch_size, num_heads, source_len, head_dim].
-        value: The value tensor, of shape [batch_size, num_heads, source_len, head_dim].
-        bias: The attention biases, of shape [batch_size, num_heads, target_len, source_len].
-        segment_ids: The id of which segment each token belongs to. Attention is not computed
-             between tokens in different segments.
-             Shape:  [batch_size, target_len].
-        causal: Whether it's causal attention.
-        block_sizes: An object containing values that can be used to tune the performance
-            such as the block size to chunk things into.
-        interpret: If True, interpret the kernel using the pallas interpreter. CPU needs it.
-
-    Returns:
-        The context tensor, of shape [batch_size, num_heads, target_len, head_dim].
-
-    Raises:
-        NotImplementedError: If a custom (non-causal, non-full) mask is specified.
-    """
-    context = pallas_tpu_flash_attention(
-        q=query,
-        k=key,
-        v=value,
-        ab=bias,
-        segment_ids=SegmentIds(q=segment_ids, kv=segment_ids) if segment_ids is not None else None,
-        causal=causal,
-        # If softmax_scale==1.0, the kernel skips applying it.
-        softmax_scale=1.0,
-        block_sizes=block_sizes,
-        debug=False,
-        interpret=interpret,
-    )
-    return context
-
-
-class SplashAttentionUnsupportedError(NotImplementedError):
-    """An error indicating splash attention is not supported."""
-
-
-def check_tpu_splash_attention(
-    *,
-    target_len: int,
-    source_len: int,
-    head_dim: int,
-    mask: MaskFnOrZero,
-    is_decoding: bool = False,
-    has_segment_ids: bool = False,
-    has_bias: bool = False,
-):
-    """Checks if splash attention is supported on TPU for the given arguments.
-
-    Args:
-        target_len: The length of the target sequence.
-        source_len: The length of the source sequence.
-        head_dim: The dimension of each head.
-        mask: The mask to apply. This is more compute efficient compared to setting bias = -inf.
-        is_decoding: Whether it is in decoding.
-        has_segment_ids: Whether segment_ids is None or not.
-        has_bias: Whether attention involves a bias.
-
-    Raises:
-        SplashAttentionUnsupportedError: If splash attention is not supported for the given
-            arguments.
-    """
-    if has_bias:
-        raise SplashAttentionUnsupportedError("SplashAttention does not support specifying a bias.")
-    with jax.ensure_compile_time_eval():
-        if jnp.any(
-            jnp.asarray([target_len, source_len, head_dim]) % splash_attention_kernel.NUM_LANES != 0
-        ):
-            raise SplashAttentionUnsupportedError(
-                "SplashAttention requires target_len, source_len, head_dim are divisible by"
-                f" {splash_attention_kernel.NUM_LANES}, got {target_len, source_len, head_dim}."
-            )
-    if has_segment_ids:
-        raise SplashAttentionUnsupportedError(
-            "The public API for SplashAttention that we "
-            "currently use does not support segment ids."
-        )
-    if mask.has_value():
-        assert isinstance(mask, MaskFnAttentionBias)
-        if not isinstance(mask, (CausalAttentionBias, SlidingWindowAttentionBias)):
-            raise SplashAttentionUnsupportedError(f"{mask=} is not supported.")
-        if is_decoding:
-            # TODO(dhwang2): support splash decoding via splash NumPy mask.
-            raise SplashAttentionUnsupportedError(
-                "Query and key/value must have same length when mask is used."
-            )
-        else:
-            if target_len != source_len:
-                raise ValueError(f"{target_len=} and {source_len=} must be same in forward().")
 
 
 def _to_splash_mask(
@@ -342,63 +80,6 @@ def _to_splash_mask(
     return splash_attention_mask.NumpyMask(array=mask_array)
 
 
-@functools.partial(
-    jax.jit,
-    static_argnames=["splash_mask", "block_sizes", "interpret"],
-)
-def _tpu_splash_attention(
-    query: Tensor,  # [batch_size, num_heads, target_len, head_dim]
-    key: Tensor,  # [batch_size, num_heads, source_len, head_dim]
-    value: Tensor,  # [batch_size, num_heads, source_len, head_dim]
-    *,
-    splash_mask: splash_attention_mask.Mask,
-    segment_ids: Optional[Tensor] = None,  # [batch_size, target_len]
-    block_sizes: Optional[splash_attention_kernel.BlockSizes] = None,
-    interpret: bool = False,
-) -> Tensor:  # [batch_size, num_heads, target_len, head_dim].
-    """Wraps JAX's sparse TPU flash-attention.
-
-    Args:
-        query: The query tensor, of shape [batch_size, num_heads, target_len, head_dim].
-        key: The key tensor, of shape [batch_size, num_heads, source_len, head_dim].
-        value: The value tensor, of shape [batch_size, num_heads, source_len, head_dim].
-        mask: The mask to apply. This is more compute efficient compared to setting bias = -inf.
-        segment_ids: The id of which segment each token belongs to. Attention is not computed
-            between tokens in different segments, [batch_size, target_len].
-        block_sizes: An object containing values that can be used to tune the performance
-            such as the block size to chunk things into.
-        interpret: If True, interpret the kernel using the pallas interpreter. CPU needs it.
-
-    Returns:
-        The context tensor, of shape [batch_size, num_heads, target_len, head_dim].
-
-    Raises:
-        SplashAttentionUnsupportedError: If splash attention does not support the given arguments.
-            This happens if any of the following is true:
-            - bias is not None.
-            - The per_head_dim is not divisible by 128.
-            - segment_ids is not None.
-            - The source and target lengths are different and a nonzero mask is used.
-        TypeError: If mask is not an instance of `MaskFnAttentionBias.
-    """
-
-    # TODO(dhwang2): splash attention can support segment_ids. Support it when needed.
-    del segment_ids
-    num_heads = query.shape[1]
-    kernel = splash_attention_kernel.make_splash_mha(
-        mask=splash_attention_mask.MultiHeadMask(masks=[splash_mask] * num_heads),
-        block_sizes=block_sizes,
-        # TODO(dhwang2): support "seq" and "model" shard.
-        head_shards=1,
-        q_seq_shards=1,
-        interpret=interpret,
-        residual_checkpoint_name=f"tpu_attention.{FLASH_ATTN_RESIDUAL_NAME}",
-    )
-    kernel = jax.vmap(kernel)
-    context = kernel(q=query, k=key, v=value)
-    return context
-
-
 # The following code is adapted from jax-ml/jax:
 # Copyright 2023 The JAX Authors.
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -428,26 +109,7 @@ def pallas_tpu_flash_attention(
     interpret: bool = False,
 ):
     batch_size, num_heads, q_seq_len, d_model = q.shape
-    batch_size_k, num_heads_k, kv_seq_len, d_model_k = k.shape
-    batch_size_v, num_heads_v, kv_seq_len_v, d_model_v = v.shape
-    if batch_size != batch_size_k or batch_size != batch_size_v:
-        raise ValueError(
-            f"Batch size mismatch: got {batch_size}, {batch_size_k} and"
-            f" {batch_size_v} (for q, k, v respectively)"
-        )
-    if num_heads != num_heads_k or num_heads != num_heads_v:
-        raise ValueError(
-            f"Head count mismatch: got {num_heads}, {num_heads_k},"
-            f" {num_heads_v} (for q, k, v respectively)"
-        )
-    if d_model != d_model_k:
-        raise ValueError(
-            f"Model dimension mismatch: got {d_model} and {d_model_k} (for q and k" " respectively)"
-        )
-    if d_model != d_model_v:
-        raise NotImplementedError("V model dimension unequal to KV model dimension unsupported")
-    if kv_seq_len != kv_seq_len_v:
-        raise ValueError(f"KV sequence length mismatch: got {kv_seq_len} and {kv_seq_len_v}")
+    _, _, kv_seq_len, _ = k.shape
     if ab is not None:
         if ab.shape not in [
             (batch_size, num_heads, q_seq_len, kv_seq_len),
@@ -1200,3 +862,141 @@ def _flash_attention_bwd_dq(
 
     # dab is just ds
     return dq, ds
+
+
+class TPUFlashAttention(BaseFlashAttention):
+    """Wraps the common checks for TPU attention implementations."""
+
+    def is_supported(self, query, key, value, bias):
+        if not super().is_supported(query, key, value, bias):
+            return False
+        block_size = self.cfg.tpu_block_size
+        if not self._check_block_size(query=query, key=key, block_size=block_size):
+            return False
+        if self.cfg.dropout_rate != 0.0:
+            self._log_unsupported("dropout is not supported.")
+            return False
+        return True
+
+
+class TPUSplashAttention(TPUFlashAttention):
+    """Wraps SplashAttention.
+
+    This kernel should be used for majority of the cases, except when
+    1. explicit bias is used.
+    2. head_dim is not a multiple of 128.
+
+    In these two cases, we fallback to the legacy implementation.
+    """
+
+    def is_supported(self, query, key, value, bias):
+        if not super().is_supported(query, key, value, bias):
+            return False
+        _, _, explicit_bias = split(bias, MaskFnAttentionBias, SegmentIdAttentionBias)
+        head_dim = query.shape[-1]
+
+        if explicit_bias.has_value():
+            self._log_unsupported("explicit bias is not supported.")
+            return False
+
+        if head_dim % splash_attention_kernel.NUM_LANES != 0:
+            self._log_unsupported(
+                f"{head_dim=} is not divisible by {splash_attention_kernel.NUM_LANES=}"
+            )
+            return False
+        logging.info("Using %s.", self.name())
+        return True
+
+    def __call__(self, query, key, value, bias, prng_key=None):
+        del prng_key
+        mask, segment_ids, _ = split(bias, MaskFnAttentionBias, SegmentIdAttentionBias)
+        segment_id_tensor = get_segment_ids(query=query, key=key, segment_ids=segment_ids)
+        seg_ids = None
+        if segment_id_tensor is not None:
+            seg_ids = SplashSegmentIds(q=segment_id_tensor, kv=segment_id_tensor)
+
+        # Switch num_heads and seq_len axes.
+        query = jnp.einsum("btnh->bnth", query) * self.cfg.softmax_scale
+        key = jnp.einsum("bsnh->bnsh", key)
+        value = jnp.einsum("bsnh->bnsh", value)
+
+        block_size = self.cfg.tpu_block_size
+        block_sizes = splash_attention_kernel.BlockSizes(
+            block_q=block_size,
+            block_kv=block_size,
+            block_kv_compute=block_size,
+            block_q_dkv=block_size,
+            block_kv_dkv=block_size,
+            block_kv_dkv_compute=block_size,
+            # The fused kernel is neutral in small models and a ~5%-15% improvement in larger ones.
+            # E.g., 1.03x speedup in a 12.6b simulated model, 1.06x speedup in 29.6b ,
+            # and 1.14x in 539.5b.
+            use_fused_bwd_kernel=True,
+        )
+        splash_mask = _to_splash_mask(mask, mask_shape=(query.shape[2], key.shape[2]))
+        num_heads = query.shape[1]
+        kernel = splash_attention_kernel.make_splash_mha(
+            mask=splash_attention_mask.MultiHeadMask(masks=[splash_mask] * num_heads),
+            block_sizes=block_sizes,
+            # TODO(dhwang2): support "seq" and "model" shard.
+            head_shards=1,
+            q_seq_shards=1,
+            interpret=self.cfg.interpret,
+            residual_checkpoint_name=f"tpu_attention.{FLASH_ATTN_RESIDUAL_NAME}",
+        )
+        kernel = jax.vmap(kernel)
+        context = kernel(q=query, k=key, v=value, segment_ids=seg_ids)
+        return jnp.einsum("bnth->btnh", context)
+
+
+class LegacyTPUFlashAttention(TPUFlashAttention):
+    """Wraps the legacy (deprecated) implementation of TPU attention."""
+
+    def is_supported(self, query, key, value, bias):
+        if not super().is_supported(query, key, value, bias):
+            return False
+        logging.info("Using %s.", self.name())
+        return True
+
+    def __call__(self, query, key, value, bias, prng_key=None):
+        del prng_key
+        causal_mask, segment_ids, explicit_bias = split(
+            bias, CausalAttentionBias, SegmentIdAttentionBias
+        )
+        segment_id_tensor = get_segment_ids(query=query, key=key, segment_ids=segment_ids)
+        seg_ids = None
+        if segment_id_tensor is not None:
+            seg_ids = LegacySegmentIds(q=segment_id_tensor, kv=segment_id_tensor)
+        key = repeat_kv_heads(query.shape[2], key)
+        value = repeat_kv_heads(query.shape[2], value)
+        # Switch num_heads and seq_len axes.
+        query = jnp.einsum("btnh->bnth", query) * self.cfg.softmax_scale
+        key = jnp.einsum("bsnh->bnsh", key)
+        value = jnp.einsum("bsnh->bnsh", value)
+
+        block_size = self.cfg.tpu_block_size
+        # TODO(tom_gunter): See if we can do better block-size tuning.
+        block_sizes = LegacyBlockSizes(
+            block_q=block_size,
+            block_k_major=block_size,
+            block_k=block_size,
+            block_b=1,
+            block_q_major_dkv=block_size,
+            block_k_major_dkv=block_size,
+            block_k_dkv=block_size,
+            block_q_dkv=block_size,
+            block_k_major_dq=block_size,
+            block_k_dq=block_size,
+            block_q_dq=block_size,
+        )
+        context = pallas_tpu_flash_attention(
+            query,
+            key,
+            value,
+            ab=explicit_bias.value(),
+            segment_ids=seg_ids,
+            causal=causal_mask.has_value(),
+            block_sizes=block_sizes,
+            interpret=self.cfg.interpret,
+        )
+        return jnp.einsum("bnth->btnh", context)

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -862,8 +862,7 @@ class TPUFlashAttention(BaseFlashAttention):
         if not self._check_block_size(query=query, key=key, block_size=block_size):
             return False
         if self.cfg.dropout_rate != 0.0:
-            self._log_unsupported("dropout is not supported.")
-            return False
+            return self._log_unsupported("dropout is not supported.")
         return True
 
 
@@ -884,14 +883,12 @@ class TPUSplashAttention(TPUFlashAttention):
         head_dim = query.shape[-1]
 
         if explicit_bias.has_value():
-            self._log_unsupported("explicit bias is not supported.")
-            return False
+            return self._log_unsupported("explicit bias is not supported.")
 
         if head_dim % splash_attention_kernel.NUM_LANES != 0:
-            self._log_unsupported(
+            return self._log_unsupported(
                 f"{head_dim=} is not divisible by {splash_attention_kernel.NUM_LANES=}"
             )
-            return False
         logging.info("Using %s.", self.name())
         return True
 

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -143,11 +143,11 @@ class TestFlashAttention(TestCase):
         )
         ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
         fn = tpu_attention.TPUSplashAttention.default_config().set(**cfg).instantiate()
-        if not fn.is_supported(q, k, v, bias):
+        if not fn.is_supported(query=q, key=k, value=v, bias=bias):
             # Check splash attention is used when it should be.
             self.assertEqual(fallback_to_legacy, True)
             fn = tpu_attention.LegacyTPUFlashAttention.default_config().set(**cfg).instantiate()
-            self.assertEqual(fn.is_supported(q, k, v, bias), True)
+            self.assertEqual(fn.is_supported(query=q, key=k, value=v, bias=bias), True)
 
         # Compare outputs.
         out = fn(q, k, v, bias)

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -125,8 +125,6 @@ class TestFlashAttention(TestCase):
             pytest.skip("Custom mask is broken.")
         if fallback_to_legacy and mask is jax_fn_mask:
             pytest.skip("Custom masks are not supported by legacy attention.")
-        if with_segment_ids and query_length_multiplier != 1:
-            pytest.skip("Segment IDs are not supported for Q and K with different lengths.")
 
         q, k, v, bias = generate_attention_data(
             batch_size,

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -3,30 +3,24 @@
 """Tests TPU FlashAttention kernels."""
 from __future__ import annotations
 
-import unittest
-
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 from absl.testing import absltest, parameterized
-from jax.experimental import mesh_utils
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask
-from jax.experimental.shard_map import shard_map
-from jax.interpreters.pxla import thread_resources
-from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 from axlearn.common.attention_bias import (
     CausalAttentionBias,
-    MaskFnAttentionBias,
     SlidingWindowAttentionBias,
     ZeroAttentionBias,
     causal_mask,
     sliding_window_causal_mask,
 )
 from axlearn.common.flash_attention import tpu_attention
-from axlearn.common.flash_attention.utils import mha_reference
-from axlearn.common.test_utils import TestCase, is_supported_mesh_shape
+from axlearn.common.flash_attention.test_utils import generate_attention_data
+from axlearn.common.flash_attention.utils import ReferenceMHA
+from axlearn.common.test_utils import TestCase
 from axlearn.common.utils import Tensor
 
 
@@ -102,100 +96,6 @@ class TestFlashAttention(TestCase):
         self.assertEqual(splash_mask, expected)
 
     @parameterized.product(
-        batch_size=[4],
-        seq_len=[1024, 32768],
-        mask_fn=["zero", "causal", "sliding"],
-        sliding_window_size=[1024],
-        num_heads=[4],
-        per_head_dim=[256],
-        mesh_axis_names=[("data", "model")],
-    )
-    def test_forward(
-        self,
-        batch_size,
-        seq_len,
-        num_heads,
-        per_head_dim,
-        mask_fn,
-        sliding_window_size,
-        mesh_axis_names,
-    ):
-        if jax.default_backend() == "cpu" and seq_len > 1024:
-            pytest.skip(reason="Too slow on CPU.")
-        mesh = (1, 1) if jax.default_backend() == "cpu" else (4, 1)
-        self.assertTrue(is_supported_mesh_shape(mesh))
-
-        k1, k2, k3 = jax.random.split(jax.random.PRNGKey(0), 3)
-        q = jax.random.normal(
-            k1, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16
-        )
-        k = jax.random.normal(
-            k2, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16
-        )
-        v = jax.random.normal(
-            k3, (batch_size, seq_len, num_heads, per_head_dim), dtype=jnp.bfloat16
-        )
-
-        with Mesh(mesh_utils.create_device_mesh(mesh), mesh_axis_names):
-            mesh = thread_resources.env.physical_mesh
-
-            def fn(q, k, v):
-                q = jax.lax.with_sharding_constraint(
-                    q, NamedSharding(mesh, PartitionSpec("data", None, "model", None))
-                )
-                k = jax.lax.with_sharding_constraint(
-                    k, NamedSharding(mesh, PartitionSpec("data", None, "model", None))
-                )
-                v = jax.lax.with_sharding_constraint(
-                    v, NamedSharding(mesh, PartitionSpec("data", None, "model", None))
-                )
-
-                softmax_scale = q.shape[-1] ** -0.5
-                if mask_fn == "zero":
-                    mask = ZeroAttentionBias()
-                elif mask_fn == "causal":
-                    mask = CausalAttentionBias(
-                        target_positions=jnp.arange(seq_len)[None],
-                        source_positions=jnp.arange(seq_len)[None],
-                    )
-                elif mask_fn.startswith("sliding"):
-                    mask = SlidingWindowAttentionBias(
-                        sliding_window_causal_mask(sliding_window_size),
-                        sliding_window_size=sliding_window_size,
-                        target_positions=jnp.arange(seq_len)[None],
-                        source_positions=jnp.arange(seq_len)[None],
-                    )
-
-                attn = lambda q, k, v: tpu_attention.tpu_flash_attention(
-                    q,
-                    k,
-                    v,
-                    mask=mask,
-                    softmax_scale=softmax_scale,
-                    interpret=(jax.default_backend() == "cpu"),
-                )
-
-                partitioned_mha = shard_map(
-                    attn,
-                    mesh=mesh,
-                    in_specs=(
-                        PartitionSpec("data", None, "model", None),
-                        PartitionSpec("data", None, "model", None),
-                        PartitionSpec("data", None, "model", None),
-                    ),
-                    out_specs=PartitionSpec("data", None, "model", None),
-                    check_rep=False,
-                )
-
-                return partitioned_mha(q, k, v)
-
-            fn = jax.jit(fn)
-
-        # Trigger compilation.
-        fn(q, k, v)
-        jax.grad(lambda q, k, v: fn(q, k, v).mean(), argnums=(0, 1, 2))(q, k, v)
-
-    @parameterized.product(
         _TEST_CONFIGS,
         query_length_multiplier=[0.5, 1, 2],
         mask=[None, causal_mask, jax_fn_mask],
@@ -218,96 +118,51 @@ class TestFlashAttention(TestCase):
             # TODO(dhwang2): this has been broken for a while on CPU.
             pytest.skip(reason="Backward path is broken on CPU")
         # pylint: disable=protected-access
-        causal = mask in [causal_mask, jax_fn_mask]
-
-        fallback_to_legacy = (
-            per_head_dim % 128 != 0
-            or (attention_bias_type is not None)
-            or with_segment_ids
-            or (query_length_multiplier != 1 and mask is not None)
-        )
-        print(
-            f"{batch_size=}, {kv_len=}, {num_heads=}, \n"
-            f"{per_head_dim=}, {query_length_multiplier=}, {mask=}, \n"
-            f"{attention_bias_type=}, {with_segment_ids=} \n"
-            f"{causal=}, {fallback_to_legacy=}"
-        )
+        fallback_to_legacy = per_head_dim % 128 != 0 or (attention_bias_type is not None)
 
         if fallback_to_legacy and mask is jax_fn_mask:
             pytest.skip("Custom masks are not supported by legacy attention.")
         if with_segment_ids and query_length_multiplier != 1:
             pytest.skip("Segment IDs are not supported for Q and K with different lengths.")
 
-        k1, k2, k3, k4, k5 = jax.random.split(jax.random.PRNGKey(0), 5)
-        query_len = int(kv_len * query_length_multiplier)
-        q = jax.random.normal(
-            k1, (batch_size, query_len, num_heads, per_head_dim), dtype=jnp.bfloat16
+        q, k, v, bias = generate_attention_data(
+            batch_size,
+            kv_len * query_length_multiplier,
+            kv_len,
+            num_heads,
+            per_head_dim,
+            mask,
+            attention_bias_type,
+            with_segment_ids,
         )
-        k = jax.random.normal(k2, (batch_size, kv_len, num_heads, per_head_dim), dtype=jnp.bfloat16)
-        v = jax.random.normal(k3, (batch_size, kv_len, num_heads, per_head_dim), dtype=jnp.bfloat16)
-        attention_bias = None
-        if attention_bias_type == "2d":
-            attention_bias = jax.random.normal(k4, (1, 1, query_len, kv_len), dtype=jnp.bfloat16)
-        elif attention_bias_type == "4d":
-            attention_bias = jax.random.normal(
-                k4, (batch_size, num_heads, query_len, kv_len), dtype=jnp.bfloat16
-            )
-        segment_ids = None
-        if with_segment_ids:
-            segment_ids = jax.random.bernoulli(k5, shape=(batch_size, kv_len)).astype(jnp.int32)
-            segment_ids = jnp.cumsum(segment_ids, axis=1)
+        softmax_scale = per_head_dim**-0.5
+        ref_fn = ReferenceMHA.default_config().set(softmax_scale=softmax_scale).instantiate()
 
-        softmax_scale = q.shape[-1] ** -0.5
-
-        def ref_fn(q, k, v, bias, ids):
-            return mha_reference(q, k, v, bias, ids, causal=causal, softmax_scale=softmax_scale)
-
-        legacy_flash_wrapper = unittest.mock.Mock(wraps=tpu_attention._legacy_tpu_flash_attention)
-
-        if mask is not None:
-            mask = MaskFnAttentionBias(
-                mask,
-                target_positions=jnp.arange(query_len)[None],
-                source_positions=jnp.arange(kv_len)[None],
-            )
-        else:
-            mask = ZeroAttentionBias()
-
-        def fn(q, k, v, bias, ids):
-            record_legacy_call = unittest.mock.patch.object(
-                tpu_attention, "_legacy_tpu_flash_attention", legacy_flash_wrapper
-            )
-            with record_legacy_call:
-                return tpu_attention.tpu_flash_attention(
-                    q,
-                    k,
-                    v,
-                    bias,
-                    ids,
-                    mask=mask,
-                    softmax_scale=softmax_scale,
-                    interpret=(jax.default_backend() == "cpu"),
-                )
+        cfg = dict(
+            interpret=jax.default_backend() == "cpu",
+            softmax_scale=softmax_scale,
+            tpu_block_size=128,
+        )
+        fn = tpu_attention.TPUSplashAttention.default_config().set(**cfg).instantiate()
+        if not fn.is_supported(q, k, v, bias):
+            # Check splash attention is used when it should be.
+            self.assertEqual(fallback_to_legacy, True)
+            fn = tpu_attention.LegacyTPUFlashAttention.default_config().set(**cfg).instantiate()
+            self.assertEqual(fn.is_supported(q, k, v, bias), True)
 
         # Compare outputs.
-        out = fn(q, k, v, attention_bias, segment_ids)
-        ref_out = ref_fn(q, k, v, attention_bias, segment_ids)
+        out = fn(q, k, v, bias)
+        ref_out = ref_fn(q, k, v, bias)
         self.assertNestedAllClose(out, ref_out, atol=0.05)
 
         # Compare grads.
-        grad_out = jax.grad(lambda q, k, v, b, s: fn(q, k, v, b, s).mean(), argnums=(0, 1, 2))(
-            q, k, v, attention_bias, segment_ids
+        grad_out = jax.grad(lambda q, k, v, b: fn(q, k, v, b).mean(), argnums=(0, 1, 2))(
+            q, k, v, bias
         )
-        ref_grad_out = jax.grad(
-            lambda q, k, v, b, s: ref_fn(q, k, v, b, s).mean(), argnums=(0, 1, 2)
-        )(q, k, v, attention_bias, segment_ids)
+        ref_grad_out = jax.grad(lambda q, k, v, b: ref_fn(q, k, v, b).mean(), argnums=(0, 1, 2))(
+            q, k, v, bias
+        )
         self.assertNestedAllClose(grad_out, ref_grad_out, atol=0.05)
-
-        # Check splash attention is used when it should be.
-        if fallback_to_legacy:
-            legacy_flash_wrapper.assert_called()
-        else:
-            legacy_flash_wrapper.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -120,6 +120,9 @@ class TestFlashAttention(TestCase):
         # pylint: disable=protected-access
         fallback_to_legacy = per_head_dim % 128 != 0 or (attention_bias_type is not None)
 
+        if mask is jax_fn_mask:
+            # TODO(dhwang2,hanzhi-zhou): Fix this.
+            pytest.skip("Custom mask is broken.")
         if fallback_to_legacy and mask is jax_fn_mask:
             pytest.skip("Custom masks are not supported by legacy attention.")
         if with_segment_ids and query_length_multiplier != 1:

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -18,8 +18,8 @@ from axlearn.common.attention_bias import (
     sliding_window_causal_mask,
 )
 from axlearn.common.flash_attention import tpu_attention
+from axlearn.common.flash_attention.common import ReferenceMHA
 from axlearn.common.flash_attention.test_utils import generate_attention_data
-from axlearn.common.flash_attention.utils import ReferenceMHA
 from axlearn.common.test_utils import TestCase
 from axlearn.common.utils import Tensor
 

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -154,10 +154,8 @@ class TestFlashAttention(TestCase):
         self.assertNestedAllClose(out, ref_out, atol=0.05)
 
         # Compare grads.
-        grad_out = jax.grad(lambda q, k, v, b: fn(q, k, v, b).mean(), argnums=(0, 1, 2))(
-            q, k, v, bias
-        )
-        ref_grad_out = jax.grad(lambda q, k, v, b: ref_fn(q, k, v, b).mean(), argnums=(0, 1, 2))(
+        grad_out = jax.grad(lambda *args: fn(*args).mean(), argnums=(0, 1, 2))(q, k, v, bias)
+        ref_grad_out = jax.grad(lambda *args: ref_fn(*args).mean(), argnums=(0, 1, 2))(
             q, k, v, bias
         )
         self.assertNestedAllClose(grad_out, ref_grad_out, atol=0.05)

--- a/axlearn/common/flash_attention/tpu_decoding.py
+++ b/axlearn/common/flash_attention/tpu_decoding.py
@@ -26,12 +26,17 @@ from typing import Optional
 
 import jax
 import jax.numpy as jnp
+from absl import logging
 from jax import lax
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
-from axlearn.common.attention_bias import NEG_INF, MaskFn
-from axlearn.common.flash_attention.common import build_mask, query_iterator_indices
+from axlearn.common.attention_bias import NEG_INF, MaskFn, MaskFnAttentionBias, split
+from axlearn.common.flash_attention.common import (
+    BaseSingleStepDecoding,
+    build_mask,
+    query_iterator_indices,
+)
 from axlearn.common.utils import Tensor
 
 
@@ -126,159 +131,141 @@ def _tpu_decoding_kernel(
         o_ref[...] = (o_scratch[...] / l_i[...]).astype(o_ref.dtype)
 
 
-@partial(
-    jax.jit,
-    static_argnames=[
-        "softmax_scale",
-        "mask_fn",
-        "block_size",
-        "interpret",
-    ],
-)
-def tpu_decoding(
-    q: Tensor,
-    k: Tensor,
-    v: Tensor,
-    kv_seq_len: Optional[Tensor],
-    bias: Optional[Tensor] = None,
-    *,
-    softmax_scale: float = 1.0,
-    mask_fn: Optional[MaskFn] = None,
-    block_size: int = 512,
-    interpret: bool = False,
-):
-    """Implements TPU decoding with GQA support.
+class TPUDecoding(BaseSingleStepDecoding):
+    "Wraps the TPU decoding kernel."
 
-    The functionality of TPU decoding is similar to GPU FlashDecoding, except that
-    padded_kv_seq_len must be divisible by block_size.
+    def is_supported(self, query, key, value, bias):
+        if not super().is_supported(query, key, value, bias):
+            return False
 
-    Args:
-        q: Tensor of shape [batch_size, 1, num_q_heads, head_dim].
-        k: Tensor of shape [batch_size, padded_kv_seq_len, num_kv_heads, head_dim].
-        v: Tensor of shape [batch_size, padded_kv_seq_len, num_kv_heads, head_dim].
-        kv_seq_len: Tensor that can broadcast to [batch_size], indicating the actual kv sequence
-            length for each sequence in the batch. If None, assumes k and v are not padded in the
-            sequence dimension.
-        bias: Tensor that can broadcast to [batch_size, num_q_heads, 1, padded_kv_seq_len].
-            Defaults to None.
-        softmax_scale: Softmax scale.
-        mask_fn: Mask function to use. Preferred over bias.
-        block_size: Block dimension along the sequence dim. Defaults to 512.
+        block_size = self.cfg.tpu_block_size
+        k_seq_len = key.shape[1]
+        if k_seq_len % block_size != 0 and k_seq_len > block_size:
+            self._log_unsupported(f"{k_seq_len=} is not divisible by {block_size=}")
+            return False
+        return True
 
-    Returns:
-        A tensor with the same shape and dtype as q.
+    def __call__(self, query, key, value, bias, prng_key=None):
+        del prng_key
+        mask, explicit_bias = split(bias, MaskFnAttentionBias)
+        if mask is None or mask.target_positions is None:
+            raise ValueError("Cannot retrieve MaskFnAttentionBias or target_positions.")
+        mask_fn = mask.mask
+        kv_seq_len = mask.target_positions[:, -1] + 1
+        logging.info("Using mask_fn=%s for Decoding.", mask_fn)
 
-    Raises:
-        ValueError if the shape of qkv doesn't satisfy assumptions.
-    """
-    if q.shape[1] != 1:
-        raise ValueError("Multi-step decoding is not supported yet.")
-    # Pallas TPU doesn't support pl.load(..., mask=xxx), so we kv len must divide block size.
-    # However, we can reduce the block size to support the case where
-    # padded_kv_seq_len < block_size.
-    block_size = min(block_size, k.shape[1])
-    if k.shape[1] % block_size != 0:
-        raise ValueError(f"KV sequence length {k.shape[1]} must be divisible by {block_size=}.")
-    orig_q_shape = q.shape
-    q_seq_len = q.shape[1]
-    block_kv = block_size
-    q = q.squeeze(1)
-    # Convert to bnhs which is the native shape of KV in the kv cache. These two transposes should
-    # be elided by the compiler. See `BaseQKVLinear.init_states` from attention.py.
-    k = jnp.einsum("bsnh->bnhs", k)
-    v = jnp.einsum("bsnh->bnhs", v)
-    bs, kv_heads, head_dim, padded_kv_seq_len = k.shape
-    if kv_seq_len is not None:
+        bias = explicit_bias.value()
+        if bias is not None:
+            logging.info(
+                "Using explicit_bias=%s for Decoding. "
+                "This is not expected unless an explicit Tensor bias is used.",
+                bias,
+            )
+
+        # Pallas TPU doesn't support pl.load(..., mask=xxx), so we kv len must divide block size.
+        # However, we can reduce the block size to support the case where
+        # padded_kv_seq_len < block_size.
+        block_size = min(self.cfg.tpu_block_size, key.shape[1])
+        orig_q_shape = query.shape
+        q_seq_len = query.shape[1]
+        block_kv = block_size
+
+        q = query.squeeze(1)
+        # Convert to bnhs which is the native shape of KV in the kv cache. These two transposes
+        # should be elided by the compiler. See `BaseQKVLinear.init_states` from attention.py.
+        k = jnp.einsum("bsnh->bnhs", key)
+        v = jnp.einsum("bsnh->bnhs", value)
+        bs, kv_heads, head_dim, padded_kv_seq_len = k.shape
         kv_seq_len = jnp.broadcast_to(jnp.asarray(kv_seq_len), (bs,))
-    else:
-        kv_seq_len = jnp.full((bs,), padded_kv_seq_len, dtype=jnp.int32)
+        # Computes a full block map num_kv_blocks * num_kv_blocks.
+        # Use a padding to ensure padding blocks aren't counted towards `kv_block_offset_size`.
+        padding = -1
+        with jax.ensure_compile_time_eval():
+            if mask_fn is not None:
+                bool_mask = build_mask(
+                    mask_fn,
+                    q_seq_len=padded_kv_seq_len,
+                    kv_seq_len=padded_kv_seq_len,
+                    block_q=block_size,
+                    block_k=block_size,
+                )
+                offset, _ = query_iterator_indices(bool_mask, padding=padding)
+            else:
+                padded_num_kv_blocks = pl.cdiv(padded_kv_seq_len, block_size)
+                offset = lax.broadcasted_iota(
+                    jnp.int32, (padded_num_kv_blocks, padded_num_kv_blocks), 1
+                )
 
-    # Computes a full block map num_kv_blocks * num_kv_blocks.
-    # Use a padding to ensure padding blocks aren't counted towards `kv_block_offset_size`.
-    padding = -1
-    with jax.ensure_compile_time_eval():
-        if mask_fn is not None:
-            bool_mask = build_mask(
-                mask_fn,
-                q_seq_len=padded_kv_seq_len,
-                kv_seq_len=padded_kv_seq_len,
-                block_q=block_size,
-                block_k=block_size,
-            )
-            offset, _ = query_iterator_indices(bool_mask, padding=padding)
-        else:
-            padded_num_kv_blocks = pl.cdiv(padded_kv_seq_len, block_size)
-            offset = lax.broadcasted_iota(
-                jnp.int32, (padded_num_kv_blocks, padded_num_kv_blocks), 1
-            )
+        # Dynamically slice the rows according to the query position (which is kv_seq_len - 1).
+        kv_block_offset = offset[(kv_seq_len - 1) // block_size]
+        # Count the number of blocks with position < kv_seq_len.
+        kv_block_offset_size = jnp.count_nonzero(
+            (kv_block_offset != padding) & (kv_block_offset * block_size < kv_seq_len[:, None]),
+            axis=1,
+        )
+        # Replace padding with the last valid kv block's index. See
+        # https://docs.jax.dev/en/latest/pallas/tpu/sparse.html#sparse-access-patterns-on-dense-data
+        kv_block_offset = jnp.where(
+            kv_block_offset == padding, kv_block_offset.max(axis=1, keepdims=True), kv_block_offset
+        )
 
-    # Dynamically slice the rows according to the query position (which is kv_seq_len - 1).
-    kv_block_offset = offset[(kv_seq_len - 1) // block_size]
-    # Count the number of blocks with position < kv_seq_len.
-    kv_block_offset_size = jnp.count_nonzero(
-        (kv_block_offset != padding) & (kv_block_offset * block_size < kv_seq_len[:, None]), axis=1
-    )
-    # Replace padding with the last valid kv block's index. See
-    # https://docs.jax.dev/en/latest/pallas/tpu/sparse.html#sparse-access-patterns-on-dense-data
-    kv_block_offset = jnp.where(
-        kv_block_offset == padding, kv_block_offset.max(axis=1, keepdims=True), kv_block_offset
-    )
+        q = q.reshape(bs, kv_heads, -1, head_dim)
+        q_seq_head = q.shape[-2]  # = q_seq_len * num_q_heads_per_kv_head
+        assert q_seq_head <= 512
 
-    q = q.reshape(bs, kv_heads, -1, head_dim)
-    q_seq_head = q.shape[-2]  # = q_seq_len * num_q_heads_per_kv_head
-    assert q_seq_head <= 512
+        def kv_index_map(
+            batch_idx, head_idx, kv_block_idx, kv_seq_len, kv_block_offset, kv_block_offset_size
+        ):
+            del kv_seq_len, kv_block_offset_size
+            return (batch_idx, head_idx, 0, kv_block_offset[batch_idx, kv_block_idx])
 
-    def kv_index_map(
-        batch_idx, head_idx, kv_block_idx, kv_seq_len, kv_block_offset, kv_block_offset_size
-    ):
-        del kv_seq_len, kv_block_offset_size
-        return (batch_idx, head_idx, 0, kv_block_offset[batch_idx, kv_block_idx])
+        q_spec = pl.BlockSpec(
+            (None, None, q_seq_head, head_dim), lambda b, h, j, *args: (b, h, 0, 0)
+        )
+        kv_spec = pl.BlockSpec((None, None, head_dim, block_kv), kv_index_map)
+        bias_spec = None
+        if bias is not None:
+            if bias.shape[0] == 1 and bias.shape[1] == 1:
 
-    q_spec = pl.BlockSpec((None, None, q_seq_head, head_dim), lambda b, h, j, *args: (b, h, 0, 0))
-    kv_spec = pl.BlockSpec((None, None, head_dim, block_kv), kv_index_map)
-    bias_spec = None
-    if bias is not None:
-        if bias.shape[0] == 1 and bias.shape[1] == 1:
+                def bias_index_map(
+                    batch_idx,
+                    head_idx,
+                    kv_block_idx,
+                    kv_seq_len,
+                    kv_block_offset,
+                    kv_block_offset_size,
+                ):
+                    del head_idx, kv_seq_len, kv_block_offset_size
+                    return (0, 0, 0, kv_block_offset[batch_idx, kv_block_idx])
 
-            def bias_index_map(
-                batch_idx,
-                head_idx,
-                kv_block_idx,
-                kv_seq_len,
-                kv_block_offset,
-                kv_block_offset_size,
-            ):
-                del head_idx, kv_seq_len, kv_block_offset_size
-                return (0, 0, 0, kv_block_offset[batch_idx, kv_block_idx])
+                bias_spec = pl.BlockSpec((None, None, q_seq_len, block_kv), bias_index_map)
+            else:
+                bias = bias.reshape(bs, kv_heads, q_seq_head, padded_kv_seq_len)
+                bias_spec = pl.BlockSpec((None, None, q_seq_head, block_kv), kv_index_map)
 
-            bias_spec = pl.BlockSpec((None, None, q_seq_len, block_kv), bias_index_map)
-        else:
-            bias = bias.reshape(bs, kv_heads, q_seq_head, padded_kv_seq_len)
-            bias_spec = pl.BlockSpec((None, None, q_seq_head, block_kv), kv_index_map)
-
-    out: Tensor = pl.pallas_call(
-        partial(_tpu_decoding_kernel, softmax_scale=softmax_scale, mask_fn=mask_fn),
-        grid_spec=pltpu.PrefetchScalarGridSpec(
-            num_scalar_prefetch=3,
-            in_specs=[
-                q_spec,
-                kv_spec,
-                kv_spec,
-                bias_spec,
-            ],
-            out_specs=q_spec,
-            scratch_shapes=[
-                # VMEM requires 2D arrays.
-                pltpu.VMEM((q_seq_head, 1), jnp.float32),
-                pltpu.VMEM((q_seq_head, 1), jnp.float32),
-                pltpu.VMEM((q_seq_head, head_dim), jnp.float32),
-            ],
-            grid=(bs, kv_heads, kv_block_offset_size.max()),
-        ),
-        out_shape=jax.ShapeDtypeStruct(q.shape, q.dtype),
-        compiler_params=pltpu.TPUCompilerParams(
-            dimension_semantics=("parallel", "parallel", "arbitrary")
-        ),
-        interpret=interpret,
-    )(kv_seq_len, kv_block_offset, kv_block_offset_size, q, k, v, bias)
-    return out.reshape(orig_q_shape)
+        out: Tensor = pl.pallas_call(
+            partial(_tpu_decoding_kernel, softmax_scale=self.cfg.softmax_scale, mask_fn=mask_fn),
+            grid_spec=pltpu.PrefetchScalarGridSpec(
+                num_scalar_prefetch=3,
+                in_specs=[
+                    q_spec,
+                    kv_spec,
+                    kv_spec,
+                    bias_spec,
+                ],
+                out_specs=q_spec,
+                scratch_shapes=[
+                    # VMEM requires 2D arrays.
+                    pltpu.VMEM((q_seq_head, 1), jnp.float32),
+                    pltpu.VMEM((q_seq_head, 1), jnp.float32),
+                    pltpu.VMEM((q_seq_head, head_dim), jnp.float32),
+                ],
+                grid=(bs, kv_heads, kv_block_offset_size.max()),
+            ),
+            out_shape=jax.ShapeDtypeStruct(q.shape, q.dtype),
+            compiler_params=pltpu.TPUCompilerParams(
+                dimension_semantics=("parallel", "parallel", "arbitrary")
+            ),
+            interpret=self.cfg.interpret,
+        )(kv_seq_len, kv_block_offset, kv_block_offset_size, q, k, v, bias)
+        return out.reshape(orig_q_shape)

--- a/axlearn/common/flash_attention/tpu_decoding.py
+++ b/axlearn/common/flash_attention/tpu_decoding.py
@@ -141,8 +141,7 @@ class TPUDecoding(BaseSingleStepDecoding):
         block_size = self.cfg.tpu_block_size
         k_seq_len = key.shape[1]
         if k_seq_len % block_size != 0 and k_seq_len > block_size:
-            self._log_unsupported(f"{k_seq_len=} is not divisible by {block_size=}")
-            return False
+            return self._log_unsupported(f"{k_seq_len=} is not divisible by {block_size=}")
         return True
 
     @partial(jax.jit, static_argnames=["self"])

--- a/axlearn/common/flash_attention/tpu_decoding.py
+++ b/axlearn/common/flash_attention/tpu_decoding.py
@@ -145,6 +145,7 @@ class TPUDecoding(BaseSingleStepDecoding):
             return False
         return True
 
+    @partial(jax.jit, static_argnames=["self"])
     def __call__(self, query, key, value, bias, prng_key=None):
         del prng_key
         mask, explicit_bias = split(bias, MaskFnAttentionBias)

--- a/axlearn/common/flash_attention/utils.py
+++ b/axlearn/common/flash_attention/utils.py
@@ -1,103 +1,59 @@
 # Copyright © 2023 Apple Inc.
 
 """FlashAttention utilities shared amongst CPU/GPU/TPU backends."""
-import functools
 from typing import Callable, Literal, Optional
 
 import jax
-import jax.numpy as jnp
 from absl import logging
 
 from axlearn.common.attention import compute_gqa_context, compute_gqa_logits, softmax_with_biases
-from axlearn.common.attention_bias import (
-    NEG_INF,
-    BaseAttentionBias,
-    CausalAttentionBias,
-    CompositeAttentionBias,
-    MaskFnAttentionBias,
-    SegmentIdAttentionBias,
-    split,
+from axlearn.common.attention_bias import BaseAttentionBias
+from axlearn.common.flash_attention.common import BaseFlashAttention
+from axlearn.common.flash_attention.gpu_attention import (
+    CuDNNGPUFlashAttention,
+    CuDNNGPUFlashAttentionWithExplicitBias,
+    PallasGPUFlashAttention,
 )
-from axlearn.common.flash_attention.gpu_attention import cudnn_dot_product_attention
-from axlearn.common.flash_attention.gpu_attention import flash_attention as gpu_flash_attention
-from axlearn.common.flash_attention.gpu_decoding import flash_decoding
-from axlearn.common.flash_attention.tpu_attention import tpu_flash_attention
-from axlearn.common.flash_attention.tpu_decoding import tpu_decoding
+from axlearn.common.flash_attention.gpu_decoding import GPUDecoding
+from axlearn.common.flash_attention.tpu_attention import LegacyTPUFlashAttention, TPUSplashAttention
+from axlearn.common.flash_attention.tpu_decoding import TPUDecoding
 from axlearn.common.layers import dropout
 from axlearn.common.utils import Tensor
 
 
-@functools.partial(jax.jit, static_argnames=["causal", "softmax_scale", "dropout_rate"])
-def mha_reference(
-    q: Tensor,
-    k: Tensor,
-    v: Tensor,
-    bias: Optional[Tensor] = None,
-    segment_ids: Optional[Tensor] = None,
-    prng_key: Optional[Tensor] = None,
-    *,
-    causal: bool = False,
-    softmax_scale: float = 1.0,
-    dropout_rate: float = 0.0,
-    dropout_mask: Optional[Tensor] = None,
-) -> Tensor:
-    """Reference multi-headed attention implementation with GQA optimization.
+class ReferenceMHA(BaseFlashAttention):
+    """The reference implementation of attention in XLA."""
 
-    Args:
-        q: query tensor with shape [batch_size, seq_len, num_heads, per_head_dim]
-        k: key tensor with shape [batch_size, seq_len, num_kv_heads, per_head_dim]
-        v: value tensor with shape [batch_size, seq_len, num_kv_heads, per_head_dim]
-        bias: bias tensor with a shape that can broadcast to
-            [batch_size, num_heads, seq_len, seq_len], e.g. [1, 1, seq_len, seq_len].
-        segment_ids: segment ids tensor with shape [batch_size, seq_len].
-        prng_key: prng key for dropout.
-        causal: whether the attention is causal.
-        softmax_scale: a scalar value applied to the logits before softmax.
-        dropout_rate: dropout rate.
-    Returns:
-        A tensor with shape [batch_size, seq_len, num_heads, per_head_dim].
-    """
-    # We apply the scale factor before the attention biases.
-    q *= softmax_scale
-    logits = compute_gqa_logits(q, k)
-
-    # TODO(hanzhi-zhou): Remove segment ids and causal here. Refactor unit tests that use them.
-    # We can construct masks directly.
-    if segment_ids is not None:
-        assert segment_ids.ndim == 2  # shape [batch_size, seq_len]
-        target_segment_ids = jnp.expand_dims(segment_ids, -1)
-        source_segment_ids = jnp.expand_dims(segment_ids, -2)
-        # Target [b..., t] + Source [b..., s] -> [b..., t, s]
-        # [b, 1, ..., t, s] where the value at [..., i, j] = false if
-        # target_segments[..., i] == source_segments[..., j], or true otherwise.
-        mask = jax.lax.ne(source_segment_ids, target_segment_ids)[:, None, ...]
-        logits = jnp.where(mask, NEG_INF, logits)
-
-    if causal:
-        mask_shape = (q.shape[1], k.shape[1])
-        row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
-        col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
-        mask = (row_ids < col_ids)[None, None, :, :]  # Causal mask.
-        logits = jnp.where(mask, NEG_INF, logits)
-
-    probs = softmax_with_biases(logits, bias)
-    if dropout_rate > 0:
-        probs = dropout(probs, prng_key=prng_key, rate=dropout_rate, mask=dropout_mask)
-
-    return compute_gqa_context(probs, v)
+    # The additional argument `dropout_mask` is for unit test only.
+    def __call__(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        bias: BaseAttentionBias,
+        prng_key: Optional[Tensor] = None,
+        dropout_mask: Optional[Tensor] = None,
+    ):
+        # We apply the scale factor before the attention biases.
+        query *= self.cfg.softmax_scale
+        logits = compute_gqa_logits(query, key)
+        probs = softmax_with_biases(logits, bias.value())
+        if self.cfg.dropout_rate > 0:
+            probs = dropout(probs, prng_key=prng_key, rate=self.cfg.dropout_rate, mask=dropout_mask)
+        return compute_gqa_context(probs, value)
 
 
-def _repeat_kv_heads(num_q_heads: int, key_or_value: Tensor) -> Tensor:
-    """Repeats key or value heads dim to match the query.
-
-    TODO(dhwang2): optimize computation like GroupedQueryAttention.
-    """
-    num_head_repeats = num_q_heads // key_or_value.shape[-2]
-    if num_head_repeats == 1:
-        return key_or_value
-    # Repeat along the num_heads dim: [batch, source_length, num_heads, per_head_dim].
-    return jnp.repeat(key_or_value, num_head_repeats, axis=-2)
-
+backends = dict(
+    tpu=[TPUDecoding, TPUSplashAttention, LegacyTPUFlashAttention],
+    gpu=[
+        GPUDecoding,
+        CuDNNGPUFlashAttention,
+        PallasGPUFlashAttention,
+        CuDNNGPUFlashAttentionWithExplicitBias,
+    ],
+    cpu=[ReferenceMHA],
+    xla=[ReferenceMHA],
+)
 
 # Accepts [query, key, value, attention_bias, prng_key] tensors and returns the context Tensor.
 MultiHeadAttentionImpl = Callable[[Tensor, Tensor, Tensor, Tensor, Optional[Tensor]], Tensor]
@@ -108,7 +64,8 @@ def flash_attention_implementation(
     *,
     softmax_scale: float = 1.0,
     is_decoding: bool = False,
-    block_size: int = 128,
+    tpu_block_size: int = 512,
+    gpu_block_size: int = 128,
     dropout_rate: Optional[float] = 0.0,
 ) -> MultiHeadAttentionImpl:
     """Returns a jitted "flash" multihead-attention implementation for the given backend.
@@ -117,16 +74,18 @@ def flash_attention_implementation(
         backend: A valid XLA backend name. 'cpu' intended for testing only.
         softmax_scale: A scalar value applied to the logits before softmax.
         is_decoding: Whether it is in decoding.
-        block_size: The size of the computation-block unit, only applies to the 'tpu' backend.
+        tpu_block_size: The size of the computation-block unit for 'tpu' backend.
             A multiple of 128, and should be less than the target sequence length.
             Smaller values are more memory efficient but less compute efficient.
+        gpu_block_size: Block size for GPU Pallas kernels. The default value of 128 should be the
+            best value for almost all cases.
         dropout_rate: The optional dropout rate.
 
     Returns:
         A jitted function implementing multi-head attention for the given backend.
-
-    Raises:
-        NotImplementedError: If implementation for the backend is not available.
+        This jitted function may raise ValueError: If the given configuration doesn't logically
+        make sense, e.g. if the shapes of q/k/v do not satisfy the requirement of a standard
+        attention.
     """
     if dropout_rate is None:
         dropout_rate = 0.0
@@ -142,210 +101,33 @@ def flash_attention_implementation(
         *,
         backend: str = backend,
     ) -> Tensor:
-        is_single_step_decoding = is_decoding and query.shape[1] == 1
-        # TODO(hanzhi-zhou): Support multi-step GPU and TPU decoding.
-        if not is_single_step_decoding:
-            if is_decoding:
-                # If multi-step decoding, fall back to non-flash implementation.
-                backend = "xla"
-            # Fall back to plain MHA implementation when the seq_len is not be divisible by
-            # block size.
-            # FIXME(hanzhi-zhou): This dispatch is not optimal. Backends like cuDNN have more
-            # relaxed constraints on the input shapes.
-            if query.shape[1] % block_size != 0:
-                backend = "xla"
-        if is_single_step_decoding and backend not in ("gpu", "tpu", "cpu"):
-            backend = "xla"
+        if backend == "neuron":
+            # Register neuron kernel at runtime due to extra dependencies.
+            # pylint: disable-next=import-outside-toplevel
+            from axlearn.common.flash_attention.neuron_attention import NeuronFlashAttention
 
-        if dropout_rate != 0.0 and backend not in ("gpu", "xla", "cpu"):
-            raise NotImplementedError("Dropout is only implemented for GPU, CPU and XLA.")
-
-        bias = CompositeAttentionBias([bias])
-
-        def get_segment_ids(segment_ids: SegmentIdAttentionBias) -> Optional[Tensor]:
-            """Return the segment ids Tensor from the sequence of segment ids attention
-            biases or None if there are no segment ids.
-            """
-            if not segment_ids.has_value():
-                return None
-            if query.shape[1] != key.shape[1]:
-                raise ValueError(
-                    "segment_ids is only supported for query and key with identical lengths."
-                )
-            if segment_ids.eval_shape()[0] != query.shape[0]:
-                raise ValueError(
-                    "segment_ids must have matching batch dim: "
-                    f"{segment_ids.eval_shape()} vs. {query.shape[0]}"
-                )
-            return segment_ids.segment_ids
-
-        if backend == "gpu":
-            if is_single_step_decoding:
-                # Decoding case. We should not repeat kv heads to match q heads for FlashDecoding.
-                # Note: decoding is always causal. Discard the causal mask if present.
-                mask, explicit_bias = split(bias, MaskFnAttentionBias)
-                if mask is None or mask.target_positions is None:
-                    raise RuntimeError("Cannot retrieve MaskFnAttentionBias or target_positions.")
-                mask_fn = mask.mask
-                query_time_step = mask.target_positions[:, -1]
-                kv_seq_len = query_time_step + 1
-                logging.info("Using mask_fn=%s for FlashDecoding.", mask_fn)
-
-                bias = explicit_bias.value()
-                if bias is not None:
-                    logging.info(
-                        "Using explicit_bias=%s for FlashDecoding. "
-                        "This is not expected unless an explicit Tensor bias is used.",
-                        bias,
-                    )
-                return flash_decoding(
-                    query,
-                    key,
-                    value,
-                    bias=bias,
-                    mask_fn=mask_fn,
-                    kv_seq_len=kv_seq_len,
-                    softmax_scale=softmax_scale,
-                    interpret=_interpret(backend),
-                )
-
-            key = _repeat_kv_heads(query.shape[2], key)
-            value = _repeat_kv_heads(query.shape[2], value)
-
-            # We have two implementations to choose from.
-            # Both support `causal`.
-            # Only pallas supports `segment_ids` and `mask_fn`.
-            mask, segment_ids, explicit_bias = split(
-                bias, MaskFnAttentionBias, SegmentIdAttentionBias
-            )
-
-            # Fall back to triton gpu kernel if:
-            # - segment_ids is not None, or
-            # - mask fn is not empty, or
-            # - query/key/value is in float32.
-            if (
-                segment_ids.has_value()
-                or mask.has_value()
-                or jnp.float32 in (query.dtype, key.dtype, value.dtype)
-                or query.shape[1] != key.shape[1]
-            ):
-                logging.warning("Flash attention falling back to Triton GPU kernel.")
-                logging.warning("explicit_bias after extracting mask: %s", explicit_bias.value())
-                return gpu_flash_attention(
-                    query,
-                    key,
-                    value,
-                    bias=explicit_bias.value(),
-                    segment_ids=get_segment_ids(segment_ids),
-                    prng_key=prng_key,
-                    softmax_scale=softmax_scale,
-                    mask_fn=mask.mask if mask.has_value() else None,
-                    dropout_rate=dropout_rate,
-                    interpret=_interpret(backend),
-                )
-            else:
-                causal, explicit_bias = split(
-                    bias,
-                    CausalAttentionBias,
-                )
-                # TODO(kelvinzou): verify cudnn's mask support with BoolAttentionBias.
-                return cudnn_dot_product_attention(
-                    query,
-                    key,
-                    value,
-                    bias=explicit_bias.value(),
-                    softmax_scale=softmax_scale,
-                    causal=causal.has_value(),
-                    dropout_rate=dropout_rate,
-                )
-
-        elif backend == "tpu":
-            if is_single_step_decoding:
-                mask, explicit_bias = split(bias, MaskFnAttentionBias)
-                if mask is None or mask.target_positions is None:
-                    raise RuntimeError("Cannot retrieve MaskFnAttentionBias or target_positions.")
-                mask_fn = mask.mask
-                logging.info("Using mask_fn=%s for FlashDecoding.", mask_fn)
-                query_time_step = mask.target_positions[:, -1]
-                kv_seq_len = query_time_step + 1
-                return tpu_decoding(
-                    query,
-                    key,
-                    value,
-                    bias=explicit_bias.value(),
-                    mask_fn=mask_fn,
-                    kv_seq_len=kv_seq_len,
-                    softmax_scale=softmax_scale,
-                    interpret=_interpret(backend),
-                    block_size=block_size,
-                )
-
-            # TODO(dhwang2): splash attention supports GQA natively, so don't repeat it.
-            # https://github.com/jax-ml/jax/blob/7b9914d711593dca8725d46aa1dadb2194284519/jax/experimental/pallas/ops/tpu/splash_attention/splash_attention_kernel.py#L934
-            key = _repeat_kv_heads(query.shape[2], key)
-            value = _repeat_kv_heads(query.shape[2], value)
-            # `mask` is supported.
-            # `segment_ids` is supported.
-            # Optimized handling for the above two types.
-            # Fallback for types that aren't instances of either of the above.
-            mask, segment_ids, explicit_bias = split(
-                bias, MaskFnAttentionBias, SegmentIdAttentionBias
-            )
-            return tpu_flash_attention(
-                query,
-                key,
-                value,
-                is_decoding=is_decoding,
-                bias=explicit_bias.value(),
-                segment_ids=get_segment_ids(segment_ids),
-                mask=mask,
-                softmax_scale=softmax_scale,
-                block_size=block_size,
-                interpret=_interpret(backend),
-            )
-
-        elif backend == "neuron":
-            # pylint: disable=import-outside-toplevel
-            from axlearn.common.flash_attention.neuron_attention import (
-                flash_attention as neuron_flash_attention,
-            )
-
-            key = _repeat_kv_heads(query.shape[2], key)
-            value = _repeat_kv_heads(query.shape[2], value)
-
-            # other_biases includes SegmentIdAttentionBias among other biases.
-            causal, other_biases = split(bias, CausalAttentionBias)
-
-            # TODO(apoorvtintin): Remove this once dropout support in kernel is ready.
-            if dropout_rate > 0:
-                raise NotImplementedError("Backend Neuron does not have dropout support yet")
-
-            return neuron_flash_attention(
-                query,
-                key,
-                value,
-                bias=other_biases.value(),
-                causal=causal.has_value(),
-                softmax_scale=softmax_scale,
-                dropout_rate=dropout_rate,
-            )
-
-        elif backend in ("cpu", "xla"):
-            if backend == "cpu":
-                logging.info("Flash attention CPU backend is for testing only.")
-            logging.info("Flash attention falling back using plain MHA implementation")
-
-            return mha_reference(
-                query,
-                key,
-                value,
-                bias=bias.value(),
-                prng_key=prng_key,
-                softmax_scale=softmax_scale,
-                dropout_rate=dropout_rate,
-            )
-
-        raise NotImplementedError(f"Backend ({backend}) does not have an implementation.")
+            backends["neuron"] = [NeuronFlashAttention]
+        attn_configs = backends.get(backend, [])
+        common_cfg = dict(
+            is_decoding=is_decoding,
+            dropout_rate=dropout_rate,
+            interpret=_interpret(backend),
+            softmax_scale=softmax_scale,
+            tpu_block_size=tpu_block_size,
+            gpu_block_size=gpu_block_size,
+        )
+        for cfg in attn_configs:
+            attn_fn = cfg.default_config().set(**common_cfg).instantiate()
+            if attn_fn.is_supported(query, key, value, bias):
+                return attn_fn(query, key, value, bias, prng_key)
+        # Fall back to plain XLA implementation if no backend kernels are supported for the given
+        # configuration.
+        logging.warning("Using xla implementation of MHA attention.")
+        return (
+            ReferenceMHA.default_config()
+            .set(**common_cfg)
+            .instantiate()(query, key, value, bias, prng_key)
+        )
 
     return jit_attn
 

--- a/axlearn/common/flash_attention/utils.py
+++ b/axlearn/common/flash_attention/utils.py
@@ -1,6 +1,7 @@
 # Copyright © 2023 Apple Inc.
 
 """FlashAttention utilities shared amongst CPU/GPU/TPU backends."""
+from functools import partial
 from typing import Callable, Literal, Optional
 
 import jax
@@ -25,6 +26,7 @@ class ReferenceMHA(BaseFlashAttention):
     """The reference implementation of attention in XLA."""
 
     # The additional argument `dropout_mask` is for unit test only.
+    @partial(jax.jit, static_argnames=["self"])
     def __call__(
         self,
         query: Tensor,

--- a/axlearn/common/flash_attention/utils.py
+++ b/axlearn/common/flash_attention/utils.py
@@ -101,7 +101,7 @@ def flash_attention_implementation(
         )
         for cfg in attn_configs:
             attn_fn = cfg.default_config().set(**common_cfg).instantiate()
-            if attn_fn.is_supported(query, key, value, bias):
+            if attn_fn.is_supported(query=query, key=key, value=value, bias=bias):
                 return attn_fn(query, key, value, bias, prng_key)
         # Fall back to plain XLA implementation if no backend kernels are supported for the given
         # configuration.

--- a/axlearn/common/flash_attention/utils.py
+++ b/axlearn/common/flash_attention/utils.py
@@ -1,15 +1,13 @@
 # Copyright © 2023 Apple Inc.
 
-"""FlashAttention utilities shared amongst CPU/GPU/TPU backends."""
-from functools import partial
+"""Implements FlashAttention kernel dispatch."""
 from typing import Callable, Literal, Optional
 
 import jax
 from absl import logging
 
-from axlearn.common.attention import compute_gqa_context, compute_gqa_logits, softmax_with_biases
 from axlearn.common.attention_bias import BaseAttentionBias
-from axlearn.common.flash_attention.common import BaseFlashAttention
+from axlearn.common.flash_attention.common import ReferenceMHA
 from axlearn.common.flash_attention.gpu_attention import (
     CuDNNGPUFlashAttention,
     CuDNNGPUFlashAttentionWithExplicitBias,
@@ -18,32 +16,7 @@ from axlearn.common.flash_attention.gpu_attention import (
 from axlearn.common.flash_attention.gpu_decoding import GPUDecoding
 from axlearn.common.flash_attention.tpu_attention import LegacyTPUFlashAttention, TPUSplashAttention
 from axlearn.common.flash_attention.tpu_decoding import TPUDecoding
-from axlearn.common.layers import dropout
 from axlearn.common.utils import Tensor
-
-
-class ReferenceMHA(BaseFlashAttention):
-    """The reference implementation of attention in XLA."""
-
-    # The additional argument `dropout_mask` is for unit test only.
-    @partial(jax.jit, static_argnames=["self"])
-    def __call__(
-        self,
-        query: Tensor,
-        key: Tensor,
-        value: Tensor,
-        bias: BaseAttentionBias,
-        prng_key: Optional[Tensor] = None,
-        dropout_mask: Optional[Tensor] = None,
-    ):
-        # We apply the scale factor before the attention biases.
-        query *= self.cfg.softmax_scale
-        logits = compute_gqa_logits(query, key)
-        probs = softmax_with_biases(logits, bias.value())
-        if self.cfg.dropout_rate > 0:
-            probs = dropout(probs, prng_key=prng_key, rate=self.cfg.dropout_rate, mask=dropout_mask)
-        return compute_gqa_context(probs, value)
-
 
 backends = dict(
     tpu=[TPUDecoding, TPUSplashAttention, LegacyTPUFlashAttention],

--- a/conftest.py
+++ b/conftest.py
@@ -16,4 +16,5 @@ def pytest_configure(config):
     if "PARALLEL_GPU_TEST" not in os.environ:
         return
     worker_id = os.getenv("PYTEST_XDIST_WORKER", "gw0")
-    os.environ["CUDA_VISIBLE_DEVICES"] = worker_id.lstrip("gw")
+    num_gpus = int(os.getenv("NUM_GPUS", "8"))
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(int(worker_id.lstrip("gw")) % num_gpus)


### PR DESCRIPTION
The flash attention dispatch logic is convoluted and overly restrictive. This PR refactors kernel support check into separate backend files, and carefully re-examined the conditions in each kernel.

The following changes are made in this PR:
1. All attention kernels are refactored to separate classes having `is_supported` and `__call__` methods. This also unified the call signature of all kernels which makes it possible to greatly simplify unit tests and benchmarks.
2. The common checks for all attention kernels (e.g. checking if k and v shapes are equal) are lifted to the `BaseFlashAttention` class to reduce duplication.
3. Detailed logging is added to explain why some kernels aren't chosen for easy debug.
4. Some problems that exist within the previous attention kernel dispatch are solved:
    * Splash supports q seq != kv seq, but not enabled
    * Splash supports GQA optimization, but not enabled
    * Splash supports segment id, but not enabled
    * GPU Pallas Flash uses TPU block size for divisibility check. This is overly restrictive.
    * cuDNN supports any even sequence length, no block size restriction, but we use TPU block size for divisibility check.
    * cuDNN supports any head dim <= 128 and head_dim % 8 == 0, but we may still choose the Pallas kernel and error out.
    * No fallback to cuDNN when mask_fn or segments ids are used but seq_len and head_dim are not supported by Palls GPU kernel.
    * cuDNN (partially) supports sliding window, but not enabled.
