### PR TITLE
TPU flash attention: Allow custom mask. 2/2

### DIFF
--- a/axlearn/common/flash_attention/layer_test.py
+++ b/axlearn/common/flash_attention/layer_test.py
@@ -32,6 +32,7 @@ from axlearn.common.attention import Dropout, GroupedQKVLinear, GroupedQueryAtte
 from axlearn.common.attention_bias import (
     CausalAttentionBias,
     CompositeAttentionBias,
+    MaskFnAttentionBias,
     SegmentIdAttentionBias,
     SlidingWindowAttentionBias,
     TensorAttentionBias,
@@ -146,6 +147,10 @@ def _prepare_layers(
     # Use the same params for both. Only attention implementation differs.
     params = ref_layer.initialize_parameters_recursively(prng_key=jax.random.PRNGKey(123))
     return test_layer, ref_layer, params, hidden_dim
+
+
+def jax_fn_mask(query_position: Tensor, key_position: Tensor) -> Tensor:
+    return query_position >= key_position
 
 
 class DummyModel(BaseLayer):
@@ -497,7 +502,7 @@ class TestFlashAttention(TestCase):
     @parameterized.product(
         _TEST_CONFIGS,
         query_len_multiplier=[0.5, 1, 2],
-        attn_type=["full", "causal", "sliding_window"],
+        attn_type=["full", "causal", "sliding_window", "custom"],
         use_bias=[False, True],
         use_segment_ids=[False, True],
         input_dtype=[jnp.bfloat16, jnp.float32],
@@ -542,6 +547,8 @@ class TestFlashAttention(TestCase):
             mask = CausalAttentionBias.default_config()
         elif attn_type == "sliding_window":
             mask = SlidingWindowAttentionBias.default_config(sliding_window_size=4)
+        elif attn_type == "custom":
+            mask = MaskFnAttentionBias.default_config(mask=jax_fn_mask)
 
         with Mesh(mesh_utils.create_device_mesh(mesh), mesh_axis_names):
             test_layer, ref_layer, params, hidden_dim = _prepare_layers(
@@ -593,7 +600,7 @@ class TestFlashAttention(TestCase):
     @parameterized.product(
         _TEST_CONFIGS,
         query_len_multiplier=[0.5, 1, 2],
-        attn_type=["full", "causal", "sliding_window"],
+        attn_type=["full", "causal", "sliding_window", "custom"],
         use_bias=[False, True],
         use_segment_ids=[False, True],
         set_layer_bias_recursively=[False, True],
@@ -647,6 +654,8 @@ class TestFlashAttention(TestCase):
                 kwargs["mask"] = CausalAttentionBias.default_config()
             elif attn_type == "sliding_window":
                 kwargs["mask"] = SlidingWindowAttentionBias.default_config(sliding_window_size=4)
+            elif attn_type == "custom":
+                kwargs["mask"] = MaskFnAttentionBias.default_config(mask=jax_fn_mask)
 
             ref_layer_cfg = GroupedQueryAttention.default_config().set(**kwargs)
             test_layer_cfg = FlashAttention.default_config().set(

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -328,11 +328,14 @@ def _to_splash_mask(
             shape=mask_shape, window_size=(left_size, 0), offset=0, shard_count=q_seq_shards
         )
 
-    with jax.ensure_compile_time_eval():
-        # MaskFn always supports compile time eval.
-        mask_array = np.asarray(mask.bool_value())
-        # Squeeze first two leading dimensions.
-        mask_array = mask_array.reshape(mask_array.shape[-2:])
+    # This code is reached only when `is_decoding == False` (i.e., forward and prefill) and
+    # `target_len == source_len` (i.e., self-attention) (see `check_tpu_splash_attention`).
+    # In this case, `target_positions` and `source_positions` are always in the range [0, seq_len].
+    target_positions = np.arange(mask_shape[0])[None, :, None]
+    source_positions = np.arange(mask_shape[1])[None, None, :]
+    # `mask.mask` expects rank 3 tensors.
+    mask_array = np.asarray(mask.mask(target_positions, source_positions))
+    mask_array = np.squeeze(mask_array, axis=0)
 
     # NumpyMask is backed by a dense [target_len, source_len] numpy array.
     # May consume a large amount of host memory for long sequences at compile time.


### PR DESCRIPTION
This is follow-up of https://github.com/apple/axlearn/pull/1050

`mask.bool_value()` internally uses `mask.target_positions` tensor, so it cannot be used inside `with jax.ensure_compile_time_eval():`, even if its shape is statically determined.

Before the changes in the previous PR, https://github.com/apple/axlearn/pull/1028 `mask.bool_value()` worked because mask did not store any tensors.

To resolve this, this PR reimplemented the same logic without using `jax.ensure_compile_time_eval()`.

As mentioned earlier, since the shape is statically determined, `target_positions` can be converted into a NumPy array at runtime.