### PR TITLE
Temporarily retain instance_type behavior and fixes aliased defaults.

### DIFF
--- a/axlearn/cloud/common/utils.py
+++ b/axlearn/cloud/common/utils.py
@@ -385,7 +385,7 @@ class FlagConfigurable(Configurable):
         super().set_defaults(fv)
 
         # Use the existing default (if any), else use our own default.
-        fv.set_default("my_flag", fv["my_flag"].default or "backup-default")
+        fv.set_default("my_flag", fv.my_flag or "backup-default")
         ```
         On the other hand, to override a default, one can do:
         ```

--- a/axlearn/cloud/gcp/job.py
+++ b/axlearn/cloud/gcp/job.py
@@ -127,8 +127,8 @@ class GKEJob(GCPJob):
     @classmethod
     def set_defaults(cls, fv):
         super().set_defaults(fv)
-        fv.set_default("max_tries", fv["max_tries"].default or 10)
-        fv.set_default("retry_interval", fv["retry_interval"].default or 60)
+        fv.set_default("max_tries", fv.max_tries or 10)
+        fv.set_default("retry_interval", fv.retry_interval or 60)
         fv.set_default(
             "service_account", gcp_settings("k8s_service_account", default="default", fv=fv)
         )

--- a/axlearn/cloud/gcp/jobs/gke_runner.py
+++ b/axlearn/cloud/gcp/jobs/gke_runner.py
@@ -175,7 +175,10 @@ class GKERunnerJob(GCPJob):
     def set_defaults(cls, fv: flags.FlagValues):
         super().set_defaults(fv)
         # Don't override `name` if already specified, since the default is non-deterministic.
-        fv.set_default("name", fv["name"].default or generate_job_name())
+        # NOTE: Accessing fv.name directly reads any values or default values set on either --name
+        # or its aliases. On the other hand, accessing fv["name"].default ignores any values or
+        # default values set by aliases.
+        fv.set_default("name", fv.name or generate_job_name())
         fv.set_default("namespace", "default")
         fv.set_default(
             "output_dir", f"gs://{gcp_settings('ttl_bucket', fv=fv)}/axlearn/jobs/{fv.name}"

--- a/axlearn/cloud/gcp/jobs/gke_runner_test.py
+++ b/axlearn/cloud/gcp/jobs/gke_runner_test.py
@@ -960,6 +960,24 @@ class TPUGKERunnerJobTest(parameterized.TestCase):
                 job._inner._delete.assert_called()
                 # pytype: enable=attribute-error
 
+    def test_name_alias(self):
+        with (
+            mock_gcp_settings(
+                [gke_runner.__name__, bundler.__name__, node_pool_provisioner.__name__],
+                default_mock_settings(),
+            ),
+        ):
+            fv = flags.FlagValues()
+            gke_runner.TPUGKERunnerJob.define_flags(fv)
+            fv.mark_as_parsed()
+            self.assertIsNone(fv.name)
+            self.assertIsNone(fv["name"].default)
+            flags.DEFINE_alias("alias_name", "name", flag_values=fv)
+            fv.set_default("alias_name", "test-name")
+            gke_runner.TPUGKERunnerJob.set_defaults(fv)
+            self.assertEqual(fv.name, fv.alias_name)
+            self.assertEqual(fv["name"].default, fv.alias_name)
+
 
 class FlinkGKERunnerJobTest(parameterized.TestCase):
     @contextlib.contextmanager

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -436,7 +436,7 @@ class BastionManagedGKEJob(BaseBastionManagedJob):
     def set_defaults(cls, fv: flags.FlagValues):
         super().set_defaults(fv)
         # Don't override `name` if already specified, since the default is non-deterministic.
-        fv.set_default("name", fv["name"].default or generate_job_name())
+        fv.set_default("name", fv.name or generate_job_name())
         fv.set_default("project", default_project())
         fv.set_default("zone", default_zone())
         fv.set_default("namespace", "default")

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -564,3 +564,12 @@ class TestBastionManagedGKEJob(TestWithTemporaryCWD):
             updated_version = (job_spec.metadata.version or 0) + 1
 
             self.assertEqual(updated_job_spec.metadata.version, updated_version)
+
+    def test_instance_type(self):
+        """Tests --instance_type is retained for backwards compat."""
+
+        fv = flags.FlagValues()
+        flags.DEFINE_string("instance_type", "tpu-v4-8", "", flag_values=fv)
+        BastionManagedGKEJob.with_runner(_DummyRunner).define_flags(fv)
+        fv.mark_as_parsed()
+        self.assertEqual(fv.instance_type, "tpu-v4-8")

--- a/axlearn/cloud/gcp/jobset_utils.py
+++ b/axlearn/cloud/gcp/jobset_utils.py
@@ -63,7 +63,15 @@ class AcceleratorConfig(ConfigBase):
 
 def accelerator_flags(flag_values: flags.FlagValues, **kwargs):
     """Defines resource flags, e.g. --instance_type and --num_replicas."""
-    flags.DEFINE_string("instance_type", None, "Instance type.", flag_values=flag_values, **kwargs)
+    flags.DEFINE_string(
+        "instance_type",
+        # --instance_type is often defined at the launcher, so use any existing value by default.
+        # TODO(markblee): Remove this after we migrate launch command away from `--instance_type`.
+        getattr(flag_values, "instance_type", None),
+        "Instance type.",
+        flag_values=flag_values,
+        **kwargs,
+    )
     flags.DEFINE_integer(
         "num_replicas", 1, "Number of replicas.", flag_values=flag_values, **kwargs
     )


### PR DESCRIPTION
For users' convenience, until we migrate away from instance type in the launch script.

Also fixes + adds testing for aliased flag defaults:
```
# NOTE: Accessing fv.name directly reads any values or default values set on either --name
# or its aliases. On the other hand, accessing fv["name"].default ignores any values or
# default values set by aliases.
```

(See internal bump for additional testing)