### PR TITLE
Consolidate QuotaInfo and UserQuotaInfo into one class

### DIFF
--- a/axlearn/cloud/common/bastion.py
+++ b/axlearn/cloud/common/bastion.py
@@ -517,7 +517,7 @@ def download_job_batch(
         local_spec_dir: Directory to store downloaded job specs.
         verbose: Verbose logging.
         remove_invalid_job_specs: Whether to remove invalid job specs.
-        quota: A thunk returning the UserQuotaInfo to use for validating
+        quota: A thunk returning the QuotaInfo to use for validating
                user project membership.
                If None, do not validate project membership.
 

--- a/axlearn/cloud/common/bastion_test.py
+++ b/axlearn/cloud/common/bastion_test.py
@@ -45,7 +45,7 @@ from axlearn.cloud.common.bastion import (
     set_runtime_options,
 )
 from axlearn.cloud.common.cleaner import Cleaner
-from axlearn.cloud.common.quota import UserQuotaInfo
+from axlearn.cloud.common.quota import QuotaInfo
 from axlearn.cloud.common.scheduler import JobScheduler
 from axlearn.cloud.common.scheduler_test import mock_quota_config
 from axlearn.cloud.common.types import JobMetadata, JobSpec, ResourceMap
@@ -257,7 +257,7 @@ class TestDownloadJobBatch(parameterized.TestCase):
                 user_state_dir="FAKE_USER_STATES",
                 local_spec_dir="FAKE",
                 remove_invalid_job_specs=True,
-                quota=lambda: UserQuotaInfo(
+                quota=lambda: QuotaInfo(
                     total_resources=None,
                     project_resources=None,
                     project_membership=project_membership,

--- a/axlearn/cloud/common/cleaner_test.py
+++ b/axlearn/cloud/common/cleaner_test.py
@@ -100,6 +100,7 @@ class UnschedulableCleanerTest(parameterized.TestCase):
                     "aws_4:p5.48xlarge": 400,
                 },
             },
+            project_membership={},
         )
 
         schedulable_jobs = mock_jobs(prefix="schedulable", resource_count=8)

--- a/axlearn/cloud/common/quota_test.py
+++ b/axlearn/cloud/common/quota_test.py
@@ -11,23 +11,17 @@ from absl.testing import parameterized
 
 from axlearn.cloud.common.quota import QuotaInfo, get_resource_limits, get_user_projects
 
-_mock_config = {
+_MOCK_TOTAL_RESOURCES = [{"resource_type1": 16, "resource_type2": 8}]
+_MOCK_PROJECT_RESOURCES = {
+    "team1": {"resource_type1": 0.3},
+    "team2": {"resource_type1": 0.6, "resource_type2": 1.0},
+}
+_MOCK_PROJECT_MEMBERSHIP = {"team1": ["user1"], "team2": ["user[12]"], "team3": [".*"]}
+_MOCK_CONFIG = {
     "toml-schema": {"version": "1"},
-    "total_resources": [
-        {
-            "resource_type1": 16,
-            "resource_type2": 8,
-        }
-    ],
-    "project_resources": {
-        "team1": {"resource_type1": 0.3},
-        "team2": {"resource_type1": 0.6, "resource_type2": 1.0},
-    },
-    "project_membership": {
-        "team1": ["user1"],
-        "team2": ["user[12]"],
-        "team3": [".*"],
-    },
+    "total_resources": _MOCK_TOTAL_RESOURCES,
+    "project_resources": _MOCK_PROJECT_RESOURCES,
+    "project_membership": _MOCK_PROJECT_MEMBERSHIP,
 }
 
 
@@ -37,39 +31,38 @@ class QuotaUtilsTest(parameterized.TestCase):
     def test_resource_limits(self):
         # Make sure fractions are converted properly.
         with tempfile.NamedTemporaryFile("r+") as f:
-            toml.dump(_mock_config, f)
+            toml.dump(_MOCK_CONFIG, f)
             f.seek(0)
             self.assertEqual(
                 QuotaInfo(
-                    total_resources=[{"resource_type1": 16, "resource_type2": 8}],
-                    project_resources={
-                        "team1": {"resource_type1": 0.3},
-                        "team2": {"resource_type1": 0.6, "resource_type2": 1.0},
-                    },
+                    total_resources=_MOCK_TOTAL_RESOURCES,
+                    project_resources=_MOCK_PROJECT_RESOURCES,
+                    project_membership=_MOCK_PROJECT_MEMBERSHIP,
                 ),
-                get_resource_limits(f.name).quota_info(),
+                get_resource_limits(f.name),
             )
 
         # Test a case where the totals don't add up.
         with tempfile.NamedTemporaryFile("r+") as f:
-            broken_config = copy.deepcopy(_mock_config)
+            broken_config = copy.deepcopy(_MOCK_CONFIG)
             broken_config["project_resources"]["team1"]["resource_type1"] = 0.8
             toml.dump(broken_config, f)
             f.seek(0)
             self.assertEqual(
                 QuotaInfo(
-                    total_resources=[{"resource_type1": 16, "resource_type2": 8}],
+                    total_resources=_MOCK_TOTAL_RESOURCES,
                     project_resources={
                         "team1": {"resource_type1": 0.8},
                         "team2": {"resource_type1": 0.6, "resource_type2": 1.0},
                     },
+                    project_membership=_MOCK_PROJECT_MEMBERSHIP,
                 ),
-                get_resource_limits(f.name).quota_info(),
+                get_resource_limits(f.name),
             )
 
         # Test a case where the set of resource types changed.
         with tempfile.NamedTemporaryFile("r+") as f:
-            config = copy.deepcopy(_mock_config)
+            config = copy.deepcopy(_MOCK_CONFIG)
             # Remove "resource_type2" from "total_resources".
             for resources in config["total_resources"]:
                 resources.pop("resource_type2", None)
@@ -78,27 +71,25 @@ class QuotaUtilsTest(parameterized.TestCase):
             self.assertEqual(
                 QuotaInfo(
                     total_resources=[{"resource_type1": 16}],
-                    project_resources={
-                        "team1": {"resource_type1": 0.3},
-                        "team2": {"resource_type1": 0.6, "resource_type2": 1.0},
-                    },
+                    project_resources=_MOCK_PROJECT_RESOURCES,
+                    project_membership=_MOCK_PROJECT_MEMBERSHIP,
                 ),
-                get_resource_limits(f.name).quota_info(),
+                get_resource_limits(f.name),
             )
 
         # Implicitly we have 1 tier.
         with tempfile.NamedTemporaryFile("r+") as f:
-            config = copy.deepcopy(_mock_config)
+            config = copy.deepcopy(_MOCK_CONFIG)
             toml.dump(config, f)
             f.seek(0)
             self.assertEqual(
-                [{"resource_type1": 16, "resource_type2": 8}],
+                _MOCK_TOTAL_RESOURCES,
                 get_resource_limits(f.name).total_resources,
             )
 
         # Test specifying tiers explicitly.
         with tempfile.NamedTemporaryFile("r+") as f:
-            config = copy.deepcopy(_mock_config)
+            config = copy.deepcopy(_MOCK_CONFIG)
             config["total_resources"] = [{"resource_type1": 10}, {"resource_type1": 10}]
             toml.dump(config, f)
             f.seek(0)
@@ -109,14 +100,10 @@ class QuotaUtilsTest(parameterized.TestCase):
 
         # Test that it returns user project membership
         with tempfile.NamedTemporaryFile("r+") as f:
-            toml.dump(_mock_config, f)
+            toml.dump(_MOCK_CONFIG, f)
             f.seek(0)
             self.assertEqual(
-                {
-                    "team1": ["user1"],
-                    "team2": ["user[12]"],
-                    "team3": [".*"],
-                },
+                _MOCK_PROJECT_MEMBERSHIP,
                 get_resource_limits(f.name).project_membership,
             )
 
@@ -126,9 +113,9 @@ class QuotaUtilsTest(parameterized.TestCase):
         dict(user="user12", expected=["team3"]),
     )
     def test_get_user_projects(self, user: str, expected: Sequence[str]):
-        """Tests `get_user_projects()` and `UserQuotaInfo.user_projects()`."""
+        """Tests `get_user_projects()` and `QuotaInfo.user_projects()`."""
         with tempfile.NamedTemporaryFile("r+") as f:
-            toml.dump(_mock_config, f)
+            toml.dump(_MOCK_CONFIG, f)
             f.seek(0)
             self.assertEqual(
                 expected,

--- a/axlearn/cloud/common/scheduler_test.py
+++ b/axlearn/cloud/common/scheduler_test.py
@@ -10,7 +10,7 @@ from unittest import mock
 
 from absl.testing import absltest, parameterized
 
-from axlearn.cloud.common.quota import QuotaInfo, UserQuotaInfo
+from axlearn.cloud.common.quota import QuotaInfo
 from axlearn.cloud.common.scheduler import (
     JobMetadata,
     JobQueue,
@@ -572,7 +572,7 @@ class TierSchedulerTest(parameterized.TestCase):
 
 def _mock_get_resource_limits(*args):
     del args
-    return UserQuotaInfo(
+    return QuotaInfo(
         total_resources=[{"v4": 15, "v3": 8, "v5": 5}],
         project_resources={
             "project1": {"v4": 10, "v5": 5},
@@ -670,6 +670,7 @@ class TestJobScheduler(parameterized.TestCase):
                 "project_b": {"gpu": 1},
                 "project_c": {"gpu": 1},
             },
+            project_membership={},
         )
         cfg = JobScheduler.default_config().set(
             quota=config_for_function(lambda: lambda *args: quota_info),


### PR DESCRIPTION
Consolidate these two classes into one to simplify the inheritance hierarchy as:
1. We always use the subclass
2. The only difference is whether a project membership is provided or not.