### PR TITLE
[Jax API update] Update `jax.core.Primitive` to `jax.extend.core.Primitive`

### DIFF
--- a/axlearn/common/adapter_flax_test.py
+++ b/axlearn/common/adapter_flax_test.py
@@ -260,12 +260,12 @@ class FlaxLayerTest(TestCase):
             )
             layer_params = jit_init_state(jax.random.PRNGKey(1))
 
-            jax.tree_map(
+            jax.tree_util.tree_map(
                 lambda x: self.assertFalse(x.value.is_fully_replicated),
                 layer_params,
                 is_leaf=lambda x: isinstance(x, nn.Partitioned),
             )
-            jax.tree_map(
+            jax.tree_util.tree_map(
                 lambda x: jax.debug.visualize_array_sharding(x.value),
                 layer_params,
                 is_leaf=lambda x: isinstance(x, nn.Partitioned),

--- a/axlearn/common/adapter_flax_test.py
+++ b/axlearn/common/adapter_flax_test.py
@@ -260,12 +260,12 @@ class FlaxLayerTest(TestCase):
             )
             layer_params = jit_init_state(jax.random.PRNGKey(1))
 
-            jax.tree_util.tree_map(
+            jax.tree.map(
                 lambda x: self.assertFalse(x.value.is_fully_replicated),
                 layer_params,
                 is_leaf=lambda x: isinstance(x, nn.Partitioned),
             )
-            jax.tree_util.tree_map(
+            jax.tree.map(
                 lambda x: jax.debug.visualize_array_sharding(x.value),
                 layer_params,
                 is_leaf=lambda x: isinstance(x, nn.Partitioned),

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -166,8 +166,8 @@ async def _slice_shard_and_copy_to_host(shard_infos: list[_ShardInfo]):
     The .data field of each shard_info is modified in-place.
     """
     # Note: jax.lax.slice_in_dim in _slice_fn will be cached in jit cache after first call.
-    shard_data = jax.tree_util.tree_map(_slice_fn, shard_infos)
-    shard_data = jax.tree_util.tree_map(_transfer_to_host, shard_data)
+    shard_data = jax.tree.map(_slice_fn, shard_infos)
+    shard_data = jax.tree.map(_transfer_to_host, shard_data)
 
     await asyncio.sleep(0)  # Allow other D2Hs to launch.
 
@@ -447,7 +447,7 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
             # pylint: disable-next=protected-access
             byte_limiter = serialization._LimitInFlightBytes(concurrent_bytes)
 
-            future_arrays = jax.tree_util.tree_map(
+            future_arrays = jax.tree.map(
                 functools.partial(serialization.async_deserialize, byte_limiter=byte_limiter),
                 shardings,
                 tensorstore_specs,

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -166,8 +166,8 @@ async def _slice_shard_and_copy_to_host(shard_infos: list[_ShardInfo]):
     The .data field of each shard_info is modified in-place.
     """
     # Note: jax.lax.slice_in_dim in _slice_fn will be cached in jit cache after first call.
-    shard_data = jax.tree_map(_slice_fn, shard_infos)
-    shard_data = jax.tree_map(_transfer_to_host, shard_data)
+    shard_data = jax.tree_util.tree_map(_slice_fn, shard_infos)
+    shard_data = jax.tree_util.tree_map(_transfer_to_host, shard_data)
 
     await asyncio.sleep(0)  # Allow other D2Hs to launch.
 
@@ -200,8 +200,7 @@ def _fix_metadata(tspec: dict[str, Any], shard_infos: list[_ShardInfo]):
 
 
 class TensorstoreSpecModifier:
-    def __call__(self, spec: dict[str, Any], *, shard_infos: list[_ShardInfo]):
-        ...
+    def __call__(self, spec: dict[str, Any], *, shard_infos: list[_ShardInfo]): ...
 
 
 async def _async_serialize(
@@ -429,6 +428,7 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
 
     # Copied from (with modifications)
     # https://github.com/jax-ml/jax/blob/66037d10e7742c4fcadd07f0459a00813ec7ed5f/jax/experimental/array_serialization/serialization.py#L413-L429
+    # pylint: disable=R0917
     def deserialize(
         self,
         shardings: Sequence[Union[jax.sharding.Sharding, layout.Layout]],

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -428,7 +428,7 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
 
     # Copied from (with modifications)
     # https://github.com/jax-ml/jax/blob/66037d10e7742c4fcadd07f0459a00813ec7ed5f/jax/experimental/array_serialization/serialization.py#L413-L429
-    # pylint: disable=R0917
+    # pylint: disable=too-many-arguments
     def deserialize(
         self,
         shardings: Sequence[Union[jax.sharding.Sharding, layout.Layout]],

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -200,7 +200,8 @@ def _fix_metadata(tspec: dict[str, Any], shard_infos: list[_ShardInfo]):
 
 
 class TensorstoreSpecModifier:
-    def __call__(self, spec: dict[str, Any], *, shard_infos: list[_ShardInfo]): ...
+    def __call__(self, spec: dict[str, Any], *, shard_infos: list[_ShardInfo]):
+        ...
 
 
 async def _async_serialize(

--- a/axlearn/common/base_layer.py
+++ b/axlearn/common/base_layer.py
@@ -532,7 +532,8 @@ class BaseLayer(Module):
         return FanAxes(in_axis=-2, out_axis=-1)
 
     def _remat_name(self, x: Tensor, name: str) -> Tensor:
-        """Tags 'x' with 'name' using a custom jax.extend.core.Primitive, which is otherwise a no-op.
+        """Tags 'x' with 'name' using a custom jax.extend.core.Primitive, which
+        is otherwise a no-op.
 
         This is useful for custom activation rematerialization policies, as it allows
         us to filter on tagged points in the jaxpr.

--- a/axlearn/common/base_layer.py
+++ b/axlearn/common/base_layer.py
@@ -532,7 +532,7 @@ class BaseLayer(Module):
         return FanAxes(in_axis=-2, out_axis=-1)
 
     def _remat_name(self, x: Tensor, name: str) -> Tensor:
-        """Tags 'x' with 'name' using a custom jax.core.Primitive, which is otherwise a no-op.
+        """Tags 'x' with 'name' using a custom jax.extend.core.Primitive, which is otherwise a no-op.
 
         This is useful for custom activation rematerialization policies, as it allows
         us to filter on tagged points in the jaxpr.

--- a/axlearn/common/base_layer_test.py
+++ b/axlearn/common/base_layer_test.py
@@ -126,7 +126,7 @@ def _callback_primitive(forward, backward):
         backward()
         return (x,)
 
-    prim = jax.core.Primitive("passthrough_with_callback")
+    prim = jax.extend.core.Primitive("passthrough_with_callback")
     prim.def_impl(forward_impl)
     prim.def_abstract_eval(forward_impl)
     jax.interpreters.ad.deflinear(prim, backward_impl)
@@ -302,7 +302,7 @@ class BaseLayerTest(TestCase):
         tagged_params = [el for el in jaxpr.eqns if "name" in el.params]
         self.assertEqual(len(tagged_params), 1)
         tagged_param = tagged_params.pop()
-        self.assertIsInstance(tagged_param.primitive, jax.core.Primitive)
+        self.assertIsInstance(tagged_param.primitive, jax.extend.core.Primitive)
         self.assertEqual(tagged_param.primitive.name, "name")
         self.assertEqual(f"{type(test_module).__name__}.{var_tag}", tagged_param.params.get("name"))
 

--- a/axlearn/common/decoding_test.py
+++ b/axlearn/common/decoding_test.py
@@ -221,9 +221,13 @@ class DecodeTest(parameterized.TestCase):
         # with no length normalization and length normalization.
         # bp_scores[0][2] should be nobp_scores[0][0] / (len('START-AA-ENDPAD') ** alpha)
         # Here len('START-AA-ENDPAD') is 4 since PAD is ignored.
-        np.testing.assert_almost_equal(no_bp_scores[0][0] / (4**alpha), bp_scores[0][2], decimal=5)
+        np.testing.assert_almost_equal(
+            no_bp_scores[0][0] / (4**alpha), bp_scores[0][2], decimal=5
+        )
         # no_bp_scores[0][2] and bp_scores[0][0] correspond the log probs of 'START-AAB-END'
-        np.testing.assert_almost_equal(no_bp_scores[0][2] / (5**alpha), bp_scores[0][0], decimal=5)
+        np.testing.assert_almost_equal(
+            no_bp_scores[0][2] / (5**alpha), bp_scores[0][0], decimal=5
+        )
 
     def test_add_decoding_dim(self):
         x = np.array([[0, 5, 1, 0], [0, 8, 6, 9]], dtype=np.int32)

--- a/axlearn/common/decoding_test.py
+++ b/axlearn/common/decoding_test.py
@@ -1555,7 +1555,7 @@ class DecodeTest(parameterized.TestCase):
         )
 
         # Compare against expected.
-        target = jnp.asarray(jax.tree_util.tree_map(vocab.tokenizer.piece_to_id, expected))
+        target = jnp.asarray(jax.tree.map(vocab.tokenizer.piece_to_id, expected))
         self.assertTrue(jnp.all(sequences == target))
 
         # Check that the token scores are 0 for pad_id tokens.

--- a/axlearn/common/decoding_test.py
+++ b/axlearn/common/decoding_test.py
@@ -221,13 +221,9 @@ class DecodeTest(parameterized.TestCase):
         # with no length normalization and length normalization.
         # bp_scores[0][2] should be nobp_scores[0][0] / (len('START-AA-ENDPAD') ** alpha)
         # Here len('START-AA-ENDPAD') is 4 since PAD is ignored.
-        np.testing.assert_almost_equal(
-            no_bp_scores[0][0] / (4**alpha), bp_scores[0][2], decimal=5
-        )
+        np.testing.assert_almost_equal(no_bp_scores[0][0] / (4**alpha), bp_scores[0][2], decimal=5)
         # no_bp_scores[0][2] and bp_scores[0][0] correspond the log probs of 'START-AAB-END'
-        np.testing.assert_almost_equal(
-            no_bp_scores[0][2] / (5**alpha), bp_scores[0][0], decimal=5
-        )
+        np.testing.assert_almost_equal(no_bp_scores[0][2] / (5**alpha), bp_scores[0][0], decimal=5)
 
     def test_add_decoding_dim(self):
         x = np.array([[0, 5, 1, 0], [0, 8, 6, 9]], dtype=np.int32)
@@ -827,6 +823,7 @@ class DecodeTest(parameterized.TestCase):
         prefix_merger=[None, _TokenSumPrefixMerger()],
         brevity_penalty=[None, decoding.brevity_penalty_fn(bp_type="hf", alpha=1.0)],
     )
+    # pylint: disable=R0917
     def test_beam_search_prefill(
         self,
         prompt_length: Sequence[int],
@@ -1554,7 +1551,7 @@ class DecodeTest(parameterized.TestCase):
         )
 
         # Compare against expected.
-        target = jnp.asarray(jax.tree_map(vocab.tokenizer.piece_to_id, expected))
+        target = jnp.asarray(jax.tree_util.tree_map(vocab.tokenizer.piece_to_id, expected))
         self.assertTrue(jnp.all(sequences == target))
 
         # Check that the token scores are 0 for pad_id tokens.

--- a/axlearn/common/gradient_accumulation.py
+++ b/axlearn/common/gradient_accumulation.py
@@ -195,7 +195,7 @@ def with_minibatch_steps(
                 x = x.reshape(minibatch_size, -1, *x.shape[1:])
                 return jnp.swapaxes(x, 0, 1)
 
-            inputs["input_batch"] = jax.tree_util.tree_map(reshape_for_scan, inputs["input_batch"])
+            inputs["input_batch"] = jax.tree.map(reshape_for_scan, inputs["input_batch"])
 
             # Create a sample minibatch for the carry buffer creation below
             (
@@ -323,9 +323,7 @@ def with_minibatch_steps(
             """Defines backward pass for the custom vjp based gradient computation."""
             grad_from_earlier, num_args = saved_fwd_state
             # Compute the backward pass gradient value.
-            grad = jax.tree_util.tree_map(
-                lambda x: x * grad_from_later_in_network.loss, grad_from_earlier
-            )
+            grad = jax.tree.map(lambda x: x * grad_from_later_in_network.loss, grad_from_earlier)
             # Return gradient along with None so the output length equals to that of primal input.
             return (grad,) + (None,) * (num_args - 1)
 

--- a/axlearn/common/gradient_accumulation.py
+++ b/axlearn/common/gradient_accumulation.py
@@ -195,7 +195,7 @@ def with_minibatch_steps(
                 x = x.reshape(minibatch_size, -1, *x.shape[1:])
                 return jnp.swapaxes(x, 0, 1)
 
-            inputs["input_batch"] = jax.tree_map(reshape_for_scan, inputs["input_batch"])
+            inputs["input_batch"] = jax.tree_util.tree_map(reshape_for_scan, inputs["input_batch"])
 
             # Create a sample minibatch for the carry buffer creation below
             (
@@ -323,7 +323,9 @@ def with_minibatch_steps(
             """Defines backward pass for the custom vjp based gradient computation."""
             grad_from_earlier, num_args = saved_fwd_state
             # Compute the backward pass gradient value.
-            grad = jax.tree_map(lambda x: x * grad_from_later_in_network.loss, grad_from_earlier)
+            grad = jax.tree_util.tree_map(
+                lambda x: x * grad_from_later_in_network.loss, grad_from_earlier
+            )
             # Return gradient along with None so the output length equals to that of primal input.
             return (grad,) + (None,) * (num_args - 1)
 

--- a/axlearn/common/gradient_accumulation_test.py
+++ b/axlearn/common/gradient_accumulation_test.py
@@ -77,7 +77,7 @@ class TestMinibatchSharding(test_utils.TestCase):
                         value, callback=lambda sharding: callback(path, sharding)
                     )
 
-                jax.tree_map(check_sharding, tree_paths(input_batch), input_batch)
+                jax.tree_util.tree_map(check_sharding, tree_paths(input_batch), input_batch)
                 return input_batch
 
             callback = lambda path, sharding: self.assertEqual(expected[path], sharding.spec)

--- a/axlearn/common/gradient_accumulation_test.py
+++ b/axlearn/common/gradient_accumulation_test.py
@@ -77,7 +77,7 @@ class TestMinibatchSharding(test_utils.TestCase):
                         value, callback=lambda sharding: callback(path, sharding)
                     )
 
-                jax.tree_util.tree_map(check_sharding, tree_paths(input_batch), input_batch)
+                jax.tree.map(check_sharding, tree_paths(input_batch), input_batch)
                 return input_batch
 
             callback = lambda path, sharding: self.assertEqual(expected[path], sharding.spec)

--- a/axlearn/common/input_base.py
+++ b/axlearn/common/input_base.py
@@ -114,7 +114,7 @@ def partition_by_path_rank(
                 "specify `PartitionSpec.UNCONSTRAINED` explicitly."
             )
 
-        return jax.tree_util.tree_map(maybe_constrain, tree_paths(input_batch), input_batch)
+        return jax.tree.map(maybe_constrain, tree_paths(input_batch), input_batch)
 
     return fn
 

--- a/axlearn/common/input_base.py
+++ b/axlearn/common/input_base.py
@@ -114,7 +114,7 @@ def partition_by_path_rank(
                 "specify `PartitionSpec.UNCONSTRAINED` explicitly."
             )
 
-        return jax.tree_map(maybe_constrain, tree_paths(input_batch), input_batch)
+        return jax.tree_util.tree_map(maybe_constrain, tree_paths(input_batch), input_batch)
 
     return fn
 

--- a/axlearn/common/input_base_test.py
+++ b/axlearn/common/input_base_test.py
@@ -123,7 +123,7 @@ def dispatch_and_check_sharding(
     @partial(pjit, in_shardings=None)
     def fn(input_batch):
         output_batch = ds.dispatch_global_batch(input_batch)
-        jax.tree_util.tree_map(check_sharding, tree_paths(output_batch), output_batch)
+        jax.tree.map(check_sharding, tree_paths(output_batch), output_batch)
         return output_batch
 
     fn.lower(input_batch).compile()

--- a/axlearn/common/input_base_test.py
+++ b/axlearn/common/input_base_test.py
@@ -123,7 +123,7 @@ def dispatch_and_check_sharding(
     @partial(pjit, in_shardings=None)
     def fn(input_batch):
         output_batch = ds.dispatch_global_batch(input_batch)
-        jax.tree_map(check_sharding, tree_paths(output_batch), output_batch)
+        jax.tree_util.tree_map(check_sharding, tree_paths(output_batch), output_batch)
         return output_batch
 
     fn.lower(input_batch).compile()

--- a/axlearn/common/learner_test.py
+++ b/axlearn/common/learner_test.py
@@ -1168,7 +1168,7 @@ class CompositeLearnerTest(TestCase):
             result = jax.tree_util.tree_reduce(lambda x, y: x.sum() + y.sum(), model_params)
             return ForwardOutputs(loss=result, aux={}, output_collection=output_collection)
 
-        grads = jax.tree_map(lambda p: jnp.ones_like(p.value), params)
+        grads = jax.tree_util.tree_map(lambda p: jnp.ones_like(p.value), params)
 
         if method == "update":
             inputs = [

--- a/axlearn/common/learner_test.py
+++ b/axlearn/common/learner_test.py
@@ -1168,7 +1168,7 @@ class CompositeLearnerTest(TestCase):
             result = jax.tree_util.tree_reduce(lambda x, y: x.sum() + y.sum(), model_params)
             return ForwardOutputs(loss=result, aux={}, output_collection=output_collection)
 
-        grads = jax.tree_util.tree_map(lambda p: jnp.ones_like(p.value), params)
+        grads = jax.tree.map(lambda p: jnp.ones_like(p.value), params)
 
         if method == "update":
             inputs = [

--- a/axlearn/common/optimizers.py
+++ b/axlearn/common/optimizers.py
@@ -468,7 +468,7 @@ def scale_update_per_param(
             path=context.path() if context else None,
         )
 
-        updates = jax.tree_util.tree_map(
+        updates = jax.tree.map(
             # Apply the scaling to each update.
             lambda g, m: g * m,
             updates,
@@ -1647,7 +1647,7 @@ def scale_by_lion(
         del params
         mu = optax.update_moment(updates, state.mu, b2, 1)
         if mu_dtype is not None:
-            mu = jax.tree_util.tree_map(lambda x: x.astype(mu_dtype), mu)
+            mu = jax.tree.map(lambda x: x.astype(mu_dtype), mu)
         count_inc = optax.safe_int32_increment(state.count)
         updates = jax.tree.map(lambda g, m: jnp.sign((1.0 - b1) * g + b1 * m), updates, state.mu)
         return updates, ScaleByLionState(count=count_inc, mu=mu)

--- a/axlearn/common/optimizers.py
+++ b/axlearn/common/optimizers.py
@@ -163,9 +163,9 @@ def copy_partition(
             dtype=spec.dtype,
             shape=spec.shape,
             mesh_axes=spec.mesh_axes,
-            memory_kind=memory_kind
-            if pattern and re.fullmatch(pattern, path)
-            else spec.memory_kind,
+            memory_kind=(
+                memory_kind if pattern and re.fullmatch(pattern, path) else spec.memory_kind
+            ),
         ),
         tree_paths(specs),
         specs,
@@ -468,7 +468,7 @@ def scale_update_per_param(
             path=context.path() if context else None,
         )
 
-        updates = jax.tree_map(
+        updates = jax.tree_util.tree_map(
             # Apply the scaling to each update.
             lambda g, m: g * m,
             updates,
@@ -704,6 +704,7 @@ def sgd_optimizer(
         )
 
 
+# pylint: disable=R0913
 def adamw_optimizer(
     learning_rate: schedule.Schedule,
     *,
@@ -759,6 +760,7 @@ def adamw_optimizer(
     return chain(*tx)
 
 
+# pylint: disable=R0913
 def adamw_decoupled_optimizer(
     learning_rate: float,
     *,
@@ -822,6 +824,7 @@ def adamw_decoupled_optimizer(
     return chain(*tx)
 
 
+# pylint: disable=R0913
 def adam_optimizer(
     learning_rate: schedule.Schedule,
     *,
@@ -1021,6 +1024,7 @@ def ema(
     return PartitionedGradientTransformation(init=init_fn, update=update_fn, partition=partition_fn)
 
 
+# pylint: disable=R0913
 def adafactor_optimizer(
     learning_rate: schedule.Schedule,
     *,
@@ -1324,6 +1328,7 @@ def skip_and_clip_by_global_norm(
             new_square_ema = decay * norm_square_ema + (1 - decay) * (val**2)
             return new_norm_ema, new_square_ema
 
+        # pylint: disable=R0913
         def _is_valid_step(
             g_norm: Tensor,
             drop_norm: Union[float, DropNormThresholdFn],
@@ -1642,7 +1647,7 @@ def scale_by_lion(
         del params
         mu = optax.update_moment(updates, state.mu, b2, 1)
         if mu_dtype is not None:
-            mu = jax.tree_map(lambda x: x.astype(mu_dtype), mu)
+            mu = jax.tree_util.tree_map(lambda x: x.astype(mu_dtype), mu)
         count_inc = optax.safe_int32_increment(state.count)
         updates = jax.tree.map(lambda g, m: jnp.sign((1.0 - b1) * g + b1 * m), updates, state.mu)
         return updates, ScaleByLionState(count=count_inc, mu=mu)
@@ -1664,6 +1669,7 @@ def scale_by_lion(
     return PartitionedGradientTransformation(init=init_fn, update=update_fn, partition=partition_fn)
 
 
+# pylint: disable=R0917
 def lion_optimizer(
     learning_rate: schedule.Schedule,
     b1: float,
@@ -2104,9 +2110,11 @@ def offload_optimizer(
         # memory usage of all states. Moreover, when the optimizer is run, all activations are
         # released, so we have less memory pressure at that point in time.
         return jax.tree.map(
-            lambda path, tensor: jax.device_put(tensor, TransferToMemoryKind(dst))
-            if re.fullmatch(pattern, path)
-            else tensor,
+            lambda path, tensor: (
+                jax.device_put(tensor, TransferToMemoryKind(dst))
+                if re.fullmatch(pattern, path)
+                else tensor
+            ),
             tree_paths(state),
             state,
         )

--- a/axlearn/common/optimizers_test.py
+++ b/axlearn/common/optimizers_test.py
@@ -684,7 +684,7 @@ class OptimizerTest(TestCase):
         )
         state = optimizer.init(params)
 
-        grads = jax.tree_map(jnp.ones_like, opt_param_values(params))
+        grads = jax.tree_util.tree_map(jnp.ones_like, opt_param_values(params))
 
         updates, _ = optimizer.update(grads, state=state, params=params)
         updated_value = optax.apply_updates(opt_param_values(params), updates)
@@ -1281,6 +1281,8 @@ class OptimizerTest(TestCase):
         update_schedule=(0.1,),
         weight_decay=(1e-4,),
     )
+
+    # pylint: disable=R0917
     def test_adastar_vs_adamw_decoupled(
         self, learning_rate, b1, b2, eps, update_schedule, weight_decay
     ):
@@ -1326,6 +1328,7 @@ class OptimizerTest(TestCase):
         clipping_threshold=(None, 1e-2, 1.0),
         weight_decay=(1e-4,),
     )
+    # pylint: disable=R0917
     def test_adastar_vs_adafactor(
         self,
         learning_rate,
@@ -1423,6 +1426,7 @@ class OptimizerTest(TestCase):
             weight_decay=3e-4,
         ),
     )
+    # pylint: disable=R0917
     def test_adastar_summaries(
         self,
         learning_rate,

--- a/axlearn/common/optimizers_test.py
+++ b/axlearn/common/optimizers_test.py
@@ -684,7 +684,7 @@ class OptimizerTest(TestCase):
         )
         state = optimizer.init(params)
 
-        grads = jax.tree_util.tree_map(jnp.ones_like, opt_param_values(params))
+        grads = jax.tree.map(jnp.ones_like, opt_param_values(params))
 
         updates, _ = optimizer.update(grads, state=state, params=params)
         updated_value = optax.apply_updates(opt_param_values(params), updates)

--- a/axlearn/common/state_builder.py
+++ b/axlearn/common/state_builder.py
@@ -291,7 +291,7 @@ class MergeStateConverter(Converter):
 
     def source_to_target(self, source: Builder.State, aux: Builder.State) -> Builder.State:
         """Source is newly loaded state, aux is original state."""
-        new_trainer_state = jax.tree_util.tree_map(
+        new_trainer_state = jax.tree.map(
             self._selector,
             utils.tree_paths(aux.trainer_state),
             aux.trainer_state,
@@ -866,7 +866,7 @@ class ModelStateScopeConverter(BaseConverterFromPretrainedModel):
 
         for target_scope, source_scope in self.scopes.items():
             orig_source_model = utils.get_recursively(source.trainer_state.model, source_scope)
-            source_model = jax.tree_util.tree_map_with_path(
+            source_model = jax.tree.map_with_path(
                 lambda path, leaf, source_scope=source_scope: _copy_leaf(
                     path, leaf, source_scope=source_scope
                 ),

--- a/axlearn/common/state_builder.py
+++ b/axlearn/common/state_builder.py
@@ -291,7 +291,7 @@ class MergeStateConverter(Converter):
 
     def source_to_target(self, source: Builder.State, aux: Builder.State) -> Builder.State:
         """Source is newly loaded state, aux is original state."""
-        new_trainer_state = jax.tree_map(
+        new_trainer_state = jax.tree_util.tree_map(
             self._selector,
             utils.tree_paths(aux.trainer_state),
             aux.trainer_state,

--- a/axlearn/common/state_builder_test.py
+++ b/axlearn/common/state_builder_test.py
@@ -976,7 +976,7 @@ class HuggingFacePreTrainedBuilderTest(TestCase):
             ref_repeat = torch.nn.Linear(in_features=2, out_features=3, bias=True)
             ref_repeat_params = torch_to_axlearn(ref_repeat)
             # Tile the params across repeat dim.
-            ref_repeat_params = jax.tree_util.tree_map(
+            ref_repeat_params = jax.tree.map(
                 lambda x: jnp.tile(x, [repeat_cfg.num_layers] + [1] * x.ndim), ref_repeat_params
             )
 

--- a/axlearn/common/state_builder_test.py
+++ b/axlearn/common/state_builder_test.py
@@ -701,6 +701,7 @@ class TestConv2DStateBuilders(TestCase):
         converted_weight = replicate_to_local_data(converted_weight)
         return source_weight, converted_weight
 
+    # pylint: disable=R0917
     def _dummy_model_config(
         self,
         patch_size: tuple[int, ...],
@@ -721,6 +722,7 @@ class TestConv2DStateBuilders(TestCase):
             dtype=jnp.float32,
         )
 
+    # pylint: disable=R0917
     def _mock_image_config(
         self,
         patch_size: tuple[int, ...],
@@ -974,7 +976,7 @@ class HuggingFacePreTrainedBuilderTest(TestCase):
             ref_repeat = torch.nn.Linear(in_features=2, out_features=3, bias=True)
             ref_repeat_params = torch_to_axlearn(ref_repeat)
             # Tile the params across repeat dim.
-            ref_repeat_params = jax.tree_map(
+            ref_repeat_params = jax.tree_util.tree_map(
                 lambda x: jnp.tile(x, [repeat_cfg.num_layers] + [1] * x.ndim), ref_repeat_params
             )
 

--- a/axlearn/common/t5_test.py
+++ b/axlearn/common/t5_test.py
@@ -379,12 +379,12 @@ class T5EncoderDecoderModelTest(TestCase):
 
                 return dict(
                     prng_key=new_prng_key,
-                    model=jax.tree_map(lambda x, y: x + y, state["model"], grads),
+                    model=jax.tree_util.tree_map(lambda x, y: x + y, state["model"], grads),
                 )
 
             state_partition_specs = dict(
                 prng_key=None,
-                model=jax.tree_map(
+                model=jax.tree_util.tree_map(
                     lambda spec: spec.mesh_axes,
                     layer.create_parameter_specs_recursively(),
                 ),

--- a/axlearn/common/t5_test.py
+++ b/axlearn/common/t5_test.py
@@ -379,12 +379,12 @@ class T5EncoderDecoderModelTest(TestCase):
 
                 return dict(
                     prng_key=new_prng_key,
-                    model=jax.tree_util.tree_map(lambda x, y: x + y, state["model"], grads),
+                    model=jax.tree.map(lambda x, y: x + y, state["model"], grads),
                 )
 
             state_partition_specs = dict(
                 prng_key=None,
-                model=jax.tree_util.tree_map(
+                model=jax.tree.map(
                     lambda spec: spec.mesh_axes,
                     layer.create_parameter_specs_recursively(),
                 ),

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -469,14 +469,16 @@ def _complete_param_init_spec_tree(
 
     # Complete the param_init_specs to match the params treedef.
     # Replace with Nones so that jax doesn't treat them as leaves.
-    params_with_nones = jax.tree_map(
+    params_with_nones = jax.tree_util.tree_map(
         partial(replace_keys, mapping={k: None for k in delegates}), params, is_leaf=is_leaf
     )
     _, treedef = jax.tree_util.tree_flatten(params_with_nones)
     inits_with_nones = jax.tree_util.tree_unflatten(treedef, param_init_specs)
 
     # Replace the Nones with a delegate.
-    return jax.tree_map(partial(replace_keys, mapping=delegates), inits_with_nones, is_leaf=is_leaf)
+    return jax.tree_util.tree_map(
+        partial(replace_keys, mapping=delegates), inits_with_nones, is_leaf=is_leaf
+    )
 
 
 def read_param_init_specs_recursively(

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -469,16 +469,14 @@ def _complete_param_init_spec_tree(
 
     # Complete the param_init_specs to match the params treedef.
     # Replace with Nones so that jax doesn't treat them as leaves.
-    params_with_nones = jax.tree_util.tree_map(
+    params_with_nones = jax.tree.map(
         partial(replace_keys, mapping={k: None for k in delegates}), params, is_leaf=is_leaf
     )
     _, treedef = jax.tree_util.tree_flatten(params_with_nones)
     inits_with_nones = jax.tree_util.tree_unflatten(treedef, param_init_specs)
 
     # Replace the Nones with a delegate.
-    return jax.tree_util.tree_map(
-        partial(replace_keys, mapping=delegates), inits_with_nones, is_leaf=is_leaf
-    )
+    return jax.tree.map(partial(replace_keys, mapping=delegates), inits_with_nones, is_leaf=is_leaf)
 
 
 def read_param_init_specs_recursively(

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -49,7 +49,7 @@ from jax._src.lax import lax as lax_internal
 from jax._src.mesh import thread_resources
 from jax._src.tree_util import KeyEntry, KeyPath
 from jax.ad_checkpoint import Offloadable, Recompute, Saveable
-from jax.core import Primitive
+from jax.extend.core import Primitive
 from jax.experimental import mesh_utils, multihost_utils
 from jax.sharding import PartitionSpec
 

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -148,7 +148,8 @@ register_validator(
 
 
 class RematPolicy(Protocol):
-    def __call__(self, prim: Primitive, *args: Any, **params: Any) -> Union[RematType, bool]: ...
+    def __call__(self, prim: Primitive, *args: Any, **params: Any) -> Union[RematType, bool]:
+        ...
 
 
 def save_and_offload_only_these_names_regex(

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -49,8 +49,8 @@ from jax._src.lax import lax as lax_internal
 from jax._src.mesh import thread_resources
 from jax._src.tree_util import KeyEntry, KeyPath
 from jax.ad_checkpoint import Offloadable, Recompute, Saveable
-from jax.extend.core import Primitive
 from jax.experimental import mesh_utils, multihost_utils
+from jax.extend.core import Primitive
 from jax.sharding import PartitionSpec
 
 from axlearn.common import serialization
@@ -148,8 +148,7 @@ register_validator(
 
 
 class RematPolicy(Protocol):
-    def __call__(self, prim: Primitive, *args: Any, **params: Any) -> Union[RematType, bool]:
-        ...
+    def __call__(self, prim: Primitive, *args: Any, **params: Any) -> Union[RematType, bool]: ...
 
 
 def save_and_offload_only_these_names_regex(
@@ -1159,7 +1158,7 @@ def per_param_dtype_by_path(
     """
 
     def fn(
-        tree: Union[Nested[Tensor], Nested[TensorSpec]]
+        tree: Union[Nested[Tensor], Nested[TensorSpec]],
     ) -> Union[Nested[Tensor], Nested[TensorSpec]]:
         if update_rules is None:
             return jax.tree.map(lambda x: default_dtype, tree_paths(tree))
@@ -1214,7 +1213,7 @@ def cast_floats_per_param(
 
 
 def canonicalize_per_param_dtype(
-    param_dtype: Union[jnp.dtype, ConfigOr[PerParamFn[jnp.dtype]]]
+    param_dtype: Union[jnp.dtype, ConfigOr[PerParamFn[jnp.dtype]]],
 ) -> ConfigOr[PerParamFn[jnp.dtype]]:
     """Canonicalize the input `param_dtype` to a consistent format of
     `ConfigOr[PerParamFn[jnp.dtype]]`, which handles three possible cases:

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -405,7 +405,7 @@ def tree_paths(
         Note that None is not considered a leaf by jax.tree_util, hence also preserved by
         tree_paths.
     """
-    return jax.tree_util.tree_map_with_path(
+    return jax.tree.map_with_path(
         lambda kp, _: separator.join(_key_entry_to_str(k) for k in kp), tree, is_leaf=is_leaf
     )
 


### PR DESCRIPTION
This PR updaates `jax.core.Primitive` to `jax.extend.core.Primitive`, as the former ends up with this error: 
```bash 
  File "/opt/axlearn/axlearn/common/utils.py", line 52, in <module>
    from jax.core import Primitive
ImportError: cannot import name 'Primitive' from 'jax.core' (/opt/jax/jax/core.py). Did you mean: 'CallPrimitive'?
```
Update this to new API to temporary unblock NV from testing new XLA:GPU features