### PR TITLE
fix repeat/n in generator

### DIFF
--- a/axlearn/open_api/generator.py
+++ b/axlearn/open_api/generator.py
@@ -93,7 +93,7 @@ async def generate_from_requests(
         gen_requests=gen_requests, **cfg.decode_parameters
     )
     # Parses responses.
-    if n > 1:
+    if fv.repeat_requests_for_n and n > 1:
         responses = flatten_responses(responses)
 
     return responses

--- a/axlearn/open_api/generator_test.py
+++ b/axlearn/open_api/generator_test.py
@@ -65,3 +65,35 @@ class TestGenerateFromRequests(unittest.IsolatedAsyncioTestCase):
         for response in responses:
             self.assertIn("response", response)
             self.assertEqual(response["response"], "test response")
+
+    @patch(
+        f"{_module_root}.open_api.common.Generator._async_generate_from_request",
+        new_callable=AsyncMock,
+    )
+    async def test_async_generate_from_requests_with_n(self, mock_async_generate_from_request):
+        # Mock async_generate_from_request to return a predefined response.
+        mock_response = {"response": "test response", "async_index": 1}
+        mock_async_generate_from_request.return_value = mock_response
+
+        # Create mock requests.
+        mock_requests = [
+            {"messages": [{"role": "user", "content": "How are you?"}]},
+            {"messages": [{"role": "user", "content": "Tell me a joke."}]},
+            {"messages": [{"role": "user", "content": "What is the weather today?"}]},
+        ]
+
+        fv = flags.FlagValues()
+        Generator.define_flags(fv)
+        fv.set_default("model", "test")
+        fv.set_default("decode_parameters", '{"n": 2}')
+        fv.set_default("repeat_requests_for_n", False)
+        fv.mark_as_parsed()
+
+        # Call the method under test.
+        responses = await generate_from_requests(gen_requests=mock_requests, fv=fv)
+
+        # Assertions to verify behavior.
+        self.assertEqual(len(responses), len(mock_requests))
+        for response in responses:
+            self.assertIn("response", response)
+            self.assertEqual(response["response"], "test response")


### PR DESCRIPTION
this would allow fv.repeat_requests_for_n=False to use native n sampling from inference engine instead of repeating requests. reviewed internally