### PR TITLE
Remove `einops` dependency in attention

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -89,7 +89,6 @@ from enum import Enum, unique
 from typing import Any, Callable, NamedTuple, Optional, Protocol, Union
 
 import chex
-import einops
 import jax
 from absl import logging
 from jax import numpy as jnp
@@ -1222,9 +1221,9 @@ def _rotary_sinusoidal_positional_embeddings(
     dim_array = jnp.arange(dim // 2).astype(jnp.float32)
     pos_array = positions.astype(jnp.float32)  # [batch_size, seq_len]
     exponents = jnp.power(theta, 2 * dim_array / dim)  # 10000 ** (2i / dim), [dim/2]
-    position_enc = einops.rearrange(pos_array, "b t -> b t 1") / einops.rearrange(
-        exponents, "d -> 1 1 d"
-    )  # [batch_size, seq_len, dim/2]
+
+    # [batch_size, seq_len, dim/2]
+    position_enc = pos_array[:, :, None] / exponents[None, None, :]
 
     rope_part_1 = jnp.sin(position_enc)
     rope_part_2 = jnp.cos(position_enc)
@@ -1321,16 +1320,13 @@ def apply_rotary_position_embeddings(
     """
     # sin/cos: [batch_size, seq_len, 1, dim/2]
     sin, cos = jnp.split(sinusoidal_pos, 2, axis=-1)
-    # Note: '...' is used instead of 'b s n' because downstream uses it with different ranks.
     # sin [θ0,θ1,θ2......θd/2-1] -> sin_pos [θ0,θ0,θ1,θ1,θ2,θ2......θd/2-1,θd/2-1]
-    sin_pos = einops.repeat(sin, "... h -> ... (h k)", k=2)
+    sin_pos = jnp.repeat(sin, 2, axis=-1)
     # cos [θ0,θ1,θ2......θd/2-1] -> cos_pos [θ0,θ0,θ1,θ1,θ2,θ2......θd/2-1,θd/2-1]
-    cos_pos = einops.repeat(cos, "... h -> ... (h k)", k=2)
+    cos_pos = jnp.repeat(cos, 2, axis=-1)
 
     def rotate_half(x):
-        return einops.rearrange(
-            jnp.stack([-x[..., 1::2], x[..., ::2]], axis=-1), "... h k -> ... (h k)", k=2
-        )
+        return jnp.reshape(jnp.stack([-x[..., 1::2], x[..., ::2]], axis=-1), x.shape)
 
     # rotate_half_query_layer [-q1,q0,-q3,q2......,-qd-1,qd-2]
     query = query * cos_pos + rotate_half(query) * sin_pos
@@ -2151,10 +2147,18 @@ def compute_gqa_logits(q_proj: Tensor, k_proj: Tensor) -> Tensor:
     kv_heads = k_proj.shape[2]
     num_head_group = q_proj.shape[2] // kv_heads
     assert q_proj.shape[2] % kv_heads == 0
-    q_proj = einops.rearrange(q_proj, "b t (k g) h -> b t k g h", k=kv_heads, g=num_head_group)
-    k_proj = einops.rearrange(k_proj, "b s k h -> b s k 1 h")
+
+    # [batch, target_length, kv_heads, num_head_group, per_head_dim]
+    q_proj = jnp.reshape(q_proj, [*q_proj.shape[:2], kv_heads, num_head_group, *q_proj.shape[3:]])
+
+    # [batch, source_length, kv_heads, 1, per_head_dim]
+    k_proj = jnp.expand_dims(k_proj, axis=3)
+
+    # [batch, kv_heads, num_head_group, target_length, source_length]
     logits = jnp.einsum("btkgh,bsk1h->bkgts", q_proj, k_proj)
-    return einops.rearrange(logits, "b k g t s -> b (k g) t s")
+
+    # [batch, num_heads, target_length, source_length]
+    return jnp.reshape(logits, [*logits.shape[:1], -1, *logits.shape[3:]])
 
 
 def compute_gqa_context(probs: Tensor, v_proj: Tensor) -> Tensor:
@@ -2170,10 +2174,18 @@ def compute_gqa_context(probs: Tensor, v_proj: Tensor) -> Tensor:
     kv_heads = v_proj.shape[2]
     num_head_group = probs.shape[1] // kv_heads
     assert probs.shape[1] % kv_heads == 0
-    probs = einops.rearrange(probs, "b (k g) t s -> b k g t s", k=kv_heads, g=num_head_group)
-    v_proj = einops.rearrange(v_proj, "b s k h -> b s k 1 h")
+
+    # [batch, kv_heads, num_head_group, target_length, source_length]
+    probs = jnp.reshape(probs, [*probs.shape[:1], kv_heads, num_head_group, *probs.shape[2:]])
+
+    # [batch, source_length, kv_heads, 1, per_head_dim]
+    v_proj = jnp.expand_dims(v_proj, axis=3)
+
+    # [batch, target_length, kv_heads, num_head_group, per_head_dim]
     context = jnp.einsum("bkgts,bsk1h->btkgh", probs, v_proj)
-    return einops.rearrange(context, "b t k g h -> b t (k g) h")
+
+    # [batch, target_length, num_heads, per_head_dim]
+    return jnp.reshape(context, [*context.shape[:2], -1, *context.shape[4:]])
 
 
 class GroupedQueryAttention(MultiheadAttention):

--- a/axlearn/common/attention_bias.py
+++ b/axlearn/common/attention_bias.py
@@ -33,7 +33,6 @@ from typing import (
     final,
 )
 
-import einops
 import jax
 from jax import numpy as jnp
 from jax.sharding import PartitionSpec
@@ -526,8 +525,9 @@ class MaskFnAttentionBias(BoolAttentionBias):
             raise ValueError(
                 f"{target_positions.shape=} or {source_positions.shape=} is not rank 2."
             )
-        target_positions = einops.rearrange(target_positions, "b t -> b t 1")
-        source_positions = einops.rearrange(source_positions, "b s -> b 1 s")
+
+        target_positions = jnp.expand_dims(target_positions, axis=2)  # [batch, target_length, 1]
+        source_positions = jnp.expand_dims(source_positions, axis=1)  # [batch, 1, source_length]
         return self.mask(target_positions, source_positions)  # pylint: disable=not-callable
 
     @classmethod


### PR DESCRIPTION
`einops` is not threadsafe and can lead to unexpected problems. Our use case of `einops` in attention can be trivially replaced by native jax implementation. 