### PR TITLE
Implement set_double_shard_weights_config() for Conformer like Transformer.

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -84,9 +84,8 @@ TODO(changlan): Merge the use of `positions` and `time_step` to reduce cognitive
 import enum
 import functools
 import math
-from collections.abc import Sequence
 from enum import Enum, unique
-from typing import Any, Callable, NamedTuple, Optional, Protocol, Union
+from typing import Any, Callable, NamedTuple, Optional, Protocol, Sequence, Union
 
 import chex
 import jax
@@ -3504,6 +3503,52 @@ class BottleNeckAdapterTransformerLayer(BaseTransformerLayer):
         )
 
 
+def set_attention_partition_specs(
+    cfg: MultiheadAttention.Config,
+    *,
+    fsdp_axis_names: Union[str, Sequence[str]] = "fsdp",
+    tp_axis_names: Union[str, Sequence[str]] = "model",
+):
+    """Sets `cfg` to shard attention weights over both fsdp and tp axes.
+
+    Args:
+        cfg: A MultiheadAttention layer config to apply sharding spec to.
+        fsdp_axis_names: Axis name(s) over which we shard fully-sharded-data-parallel tensors.
+        tp_axis_names: Axis name(s) over which we shard tensor-parallel tensors.
+    """
+    # Shard weights.
+    input_linear_cfg = cfg.input_linear
+    if hasattr(input_linear_cfg, "input_linear"):
+        input_linear_cfg = input_linear_cfg.input_linear
+    input_linear_cfg.layer.param_partition_spec = (fsdp_axis_names, tp_axis_names, None)
+    cfg.output_linear.param_partition_spec = (fsdp_axis_names, tp_axis_names, None)
+
+
+def set_feed_forward_partition_specs(
+    cfg: TransformerFeedForwardLayer.Config,
+    *,
+    batch_axis_names: Union[str, Sequence[str]] = ("data", "fsdp"),
+    fsdp_axis_names: Union[str, Sequence[str]] = "fsdp",
+    tp_axis_names: Union[str, Sequence[str]] = "model",
+    seq_axis_names: Union[str, Sequence[str]] = "seq",
+):
+    """Sets `cfg` to shard FFN weights over both fsdp and tp axes.
+
+    Args:
+        cfg: A TransformerFeedForwardLayer layer config to apply sharding spec to.
+        batch_axis_names: Axis name(s) over which we shard the batch dimension of output tensors.
+        fsdp_axis_names: Axis name(s) over which we shard fully-sharded-data-parallel tensors.
+        tp_axis_names: Axis name(s) over which we shard tensor-parallel tensors.
+        seq_axis_names: Axis name(s) over which we shard sequence-parallel tensors.
+    """
+    # Shard weights.
+    cfg.linear1.param_partition_spec = (fsdp_axis_names, tp_axis_names)
+    cfg.linear2.param_partition_spec = (tp_axis_names, fsdp_axis_names)
+    # Encourage the right activation sharding.
+    cfg.linear1.output_partition_spec = (batch_axis_names, seq_axis_names, tp_axis_names)
+    cfg.linear2.output_partition_spec = (batch_axis_names, seq_axis_names, tp_axis_names)
+
+
 def set_double_shard_weights_config(
     cfg: Union[TransformerLayer.Config, Sequence[TransformerLayer.Config]],
     *,
@@ -3523,31 +3568,29 @@ def set_double_shard_weights_config(
     """
 
     # pytype: disable=attribute-error
-    def set_attn_partition_specs(attn_layer: MultiheadAttention.Config):
-        # Shard weights.
-        input_linear_cfg = attn_layer.input_linear
-        if hasattr(input_linear_cfg, "input_linear"):
-            input_linear_cfg = input_linear_cfg.input_linear
-        input_linear_cfg.layer.param_partition_spec = (fsdp_axis_names, tp_axis_names, None)
-        attn_layer.output_linear.param_partition_spec = (fsdp_axis_names, tp_axis_names, None)
-
-    def set_ffn_partition_specs(ff_layer: TransformerFeedForwardLayer.Config):
-        # Shard weights.
-        ff_layer.linear1.param_partition_spec = (fsdp_axis_names, tp_axis_names)
-        ff_layer.linear2.param_partition_spec = (tp_axis_names, fsdp_axis_names)
-        # Encourage the right activation sharding.
-        ff_layer.linear1.output_partition_spec = (batch_axis_names, seq_axis_names, tp_axis_names)
-        ff_layer.linear2.output_partition_spec = (batch_axis_names, seq_axis_names, tp_axis_names)
-
     if not isinstance(cfg, Sequence):
         cfg = [cfg]
 
     for layer_cfg in cfg:
-        set_attn_partition_specs(layer_cfg.self_attention.attention)
+        set_attention_partition_specs(
+            layer_cfg.self_attention.attention,
+            fsdp_axis_names=fsdp_axis_names,
+            tp_axis_names=tp_axis_names,
+        )
         if layer_cfg.cross_attention is not None:
-            set_attn_partition_specs(layer_cfg.cross_attention.attention)
+            set_attention_partition_specs(
+                layer_cfg.cross_attention.attention,
+                fsdp_axis_names=fsdp_axis_names,
+                tp_axis_names=tp_axis_names,
+            )
         if isinstance(layer_cfg.feed_forward, TransformerFeedForwardLayer.Config):
-            set_ffn_partition_specs(layer_cfg.feed_forward)
+            set_feed_forward_partition_specs(
+                layer_cfg.feed_forward,
+                batch_axis_names=batch_axis_names,
+                fsdp_axis_names=fsdp_axis_names,
+                tp_axis_names=tp_axis_names,
+                seq_axis_names=seq_axis_names,
+            )
     # pytype: enable=attribute-error
 
 


### PR DESCRIPTION
When AFM uses Conformer for speech tokenizer, we want to shard it like Transformer.