### PR TITLE
Optimize deserialize -- up to 5x faster

### DIFF
--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -393,7 +393,8 @@ async def _async_deserialize(
     capacity in the pre-mapped buffer, we can perform several linearization concurrently for
     improved performance. However, if there isn't sufficient capacity in the premapped buffer,
     on-demand DMA buffer mapping is needed, and this is often very slow. Additionally, concurrently
-    mapping DMA buffers are neither faster (due to OS overhead) nor memory-efficient.
+    mapping DMA buffers are neither faster (due to OS overhead) nor memory-efficient. Transparent
+    huge pages (THP) can help, but it's only for jax 0.5.1+.
     """
     in_sharding = (
         user_in_sharding.sharding if isinstance(user_in_sharding, Layout) else user_in_sharding

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -617,16 +617,14 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
 class BoundedDataShardedAsyncCheckpointManager(GlobalAsyncCheckpointManager):
     """Similar to GlobalAsyncCheckpointManager but with few improvements:
 
-    1. Writing to tensorstore requires no host-to-host copy most of the time. This reduces host
-    memory usage while also reduces blocking time of the checkpointing process.
-    2. Tensorstore calls now run in a background event loop, hiding the cost of `ts.open` and
+    1. Tensorstore calls now run in a background event loop, hiding the cost of `ts.open` and
     `ts.copy`. Now, only D2H blocks training while serialization is fully asynchronous.
-    3. Added additional sharding along data-parallel axis during save to further reduce host memory
+    2. Added additional sharding along data-parallel axis during save to further reduce host memory
     overhead and improves D2H time. It's achieved by sharding the first dim that's divisible by the
     data-parallel dim. We manipulate shard.index to match the sliced shard, so to tensorstore it
     behaves as if we're sharding along the data-parallel axis. If no such dim is found, we use the
     old way to save-restore, i.e. using the first (0th) replica to do the save only.
-    4. Optionally one can specify max_concurrent_gb to limit in-flight host memory during
+    3. Optionally one can specify max_concurrent_gb to limit in-flight host memory during
     device-to-host transfers and tensorstore writes.
 
     Args:


### PR DESCRIPTION
This improved end-to-end loading time from 100s+ to 25s for a single v5p-8 loading a 70B ckpt in bf16.

It also improves the ckpt load time for GCS too, from ~120s to ~75s.

Ablations:

Baseline: time dominated by numpy `zeros` and `astype`
![image](https://github.com/user-attachments/assets/d784b961-0e05-4bcb-a540-604c44cba554)

With optimization 1 and 2 (no np.zeros and astype), and parallelize all map dma buffers (this consumes ~150G additional memory!). Note that this method leads to high variance in load time. Worse case load time could be 150s+, and best cases would be around ~45s
![image](https://github.com/user-attachments/assets/2e3d724e-fcf6-4643-90c5-031ed5dfa6c6)

Sequential linearization with 16GB pre-mapped buffer (**this PR**):
![image](https://github.com/user-attachments/assets/220612cb-6db9-4c9c-a3ac-78a1ab904d51)

Concurrent linearization with 32GB pre-mapped buffer (**this PR**):

By controlling the pre-mapped buffer size, one can improve performance by increasing the parallelization of linearization operations.
![image](https://github.com/user-attachments/assets/e8ae6bcb-7231-421b-bc87-00a1ee4fe4fe)
