### PR TITLE
Fix GPU decoding dtype and flash tests

### DIFF
--- a/axlearn/common/flash_attention/gpu_decoding.py
+++ b/axlearn/common/flash_attention/gpu_decoding.py
@@ -111,6 +111,7 @@ def _attn_forward_kernel(
             def compute():
                 curr_k_slice = pl.ds(start_k * block_k, block_k)
                 k = pl.load(k_ref, (curr_k_slice, slice(None)), mask=mask[:, None], other=0.0)
+                k = k.astype(q.dtype)
                 qk = pl.dot(q, k.T, precision=precision)  # [block_h, block_k]
                 if bias_ref is not None:
                     qk += pl.load(
@@ -128,6 +129,7 @@ def _attn_forward_kernel(
                 l_curr = s_curr.sum(axis=-1)
                 l_next = l_prev_corr + l_curr
                 v = pl.load(v_ref, (curr_k_slice, slice(None)), mask=mask[:, None], other=0.0)
+                v = v.astype(q.dtype)
                 o_curr = pl.dot(s_curr.astype(v.dtype), v, precision=precision)
 
                 # Flash2 unscaled_o.

--- a/axlearn/common/flash_attention/layer_test.py
+++ b/axlearn/common/flash_attention/layer_test.py
@@ -548,9 +548,10 @@ class TestFlashAttention(TestCase):
             pytest.skip(reason="Unsupported large bias matrix in fp32 format.")
         if dropout_rate > 0.0 and jax.default_backend() == "tpu":
             pytest.skip("Dropout is implemented for GPU only.")
-        if attn_type == "sliding_window" and query_len_multiplier > 1:
+        if attn_type in ("sliding_window", "custom") and query_len_multiplier > 1:
             # When sliding window is enabled and q_len > kv_len, there might be be fully masked
-            # rows.
+            # rows. "custom" is also sliding window, but uses a different function to test support
+            # for custom mask fns.
             pytest.skip(reason="Sliding window attention does not make sense when q_len > kv_len.")
 
         if attn_type == "full":

--- a/axlearn/common/flash_attention/layer_test.py
+++ b/axlearn/common/flash_attention/layer_test.py
@@ -639,9 +639,10 @@ class TestFlashAttention(TestCase):
             pytest.skip(reason=f"Unsupported mesh {mesh}.")
         if use_segment_ids and query_len_multiplier != 1:
             pytest.skip("Segment IDs are not supported for Q and K with different lengths.")
-        if attn_type == "sliding_window" and query_len_multiplier > 1:
+        if attn_type in ("sliding_window", "custom") and query_len_multiplier > 1:
             # When sliding window is enabled and q_len > kv_len, there might be be fully masked
-            # rows.
+            # rows. "custom" is also sliding window, but uses a different function to test support
+            # for custom mask fns.
             pytest.skip(reason="Sliding window attention does not make sense when q_len > kv_len.")
         if dropout_rate > 0.0 and jax.default_backend() == "tpu":
             pytest.skip("Dropout is implemented for GPU only.")


### PR DESCRIPTION
Similar fix as in https://github.com/apple/axlearn/pull/1049 for mixed qkv dtypes but for GPU decoding kernel.

Also fixed flash attention tests problems introduced in https://github.com/apple/axlearn/pull/1081