### PR TITLE
Clarify that the k_proj/v_proj's dtype maybe changed by the kv_cache.

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -197,6 +197,9 @@ class BaseKVCache(BaseLayer):
         """Configures BaseKVCache."""
 
         # Autoregressive KV cache dtype, which the input KV is converted into.
+        # This dtype is not only used for storing the KV cache, but it also applies to
+        # the returned KV activations. Therefore, before computing attention, we need to cast
+        # the KV tensors to match the query's dtype.
         cache_dtype: Optional[jnp.dtype] = None
 
     class Output(KVState):
@@ -1898,6 +1901,8 @@ class MultiheadAttention(BaseLayer):
             and probs of shape [batch, num_heads, target_length, source_length].
         """
         del mode
+        # KV cache may cast them in lower precision.
+        k_proj, v_proj = k_proj.astype(q_proj.dtype), v_proj.astype(q_proj.dtype)
         logits = self._compute_logits(q_proj, k_proj)
         logits = self._cap_logits(logits)
         self.vlog(3, "atten.logits=%s", logits[0, 0, 0, :])
@@ -2268,6 +2273,8 @@ class SigmoidAttention(MultiheadAttention):
         """See `MultiheadAttention._compute_attention` for details."""
         del mode
         cfg = self.config
+        # KV cache may cast them in lower precision.
+        k_proj, v_proj = k_proj.astype(q_proj.dtype), v_proj.astype(q_proj.dtype)
         logits = self._compute_logits(q_proj, k_proj)
         logits = self._cap_logits(logits)
         self.vlog(3, "atten.logits=%s", logits[0, 0, 0, :])

--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -2779,8 +2779,11 @@ class MultiheadAttentionTest(TestCase):
             bias=bias,
         )
 
-    @parameterized.product(mode=[ForwardMode.FORWARD, ForwardMode.EXTEND_STEP])
-    def test_gqa_against_mha(self, mode):
+    @parameterized.product(
+        mode=[ForwardMode.FORWARD, ForwardMode.EXTEND_STEP],
+        kv_dtype=[jnp.float64, jnp.float32, jnp.bfloat16],
+    )
+    def test_gqa_against_mha(self, mode, kv_dtype):
         model_dim = 16
         num_heads = 4
         num_kv_heads = 2
@@ -2813,6 +2816,7 @@ class MultiheadAttentionTest(TestCase):
         q = jax.random.uniform(data_key, (batch, seq_len, num_heads, per_head_dim))
         k = jax.random.uniform(data_key, (batch, seq_len, num_kv_heads, per_head_dim))
         v = jax.random.uniform(data_key, (batch, seq_len, num_kv_heads, per_head_dim))
+        q, k, v = q.astype(jnp.float32), k.astype(kv_dtype), v.astype(kv_dtype)
         attention_logit_biases = attention_logit_biases = attention_bias.ZeroAttentionBias()
 
         (test_context, ref_probs), _ = F(
@@ -2849,6 +2853,8 @@ class MultiheadAttentionTest(TestCase):
         )
 
         assert_allclose(ref_context, test_context)
+        self.assertEqual(ref_context.dtype, q.dtype)
+        self.assertEqual(test_context.dtype, q.dtype)
         assert_allclose(ref_probs, ref_probs)
 
 
@@ -2996,9 +3002,15 @@ class ScaleFunctionsTest(TestCase):
             ),
         ],
         mode=[ForwardMode.FORWARD, ForwardMode.EXTEND_STEP],
+        kv_dtype=[jnp.float64, jnp.float32, jnp.bfloat16],
     )
     def test_sigmoid_compute_attention(
-        self, qkv_value: float, expected_value: float, seq_len: int, mode: ForwardMode
+        self,
+        qkv_value: float,
+        expected_value: float,
+        seq_len: int,
+        mode: ForwardMode,
+        kv_dtype: jnp.dtype,
     ):
         model_dim = 16
         num_heads = 4
@@ -3021,9 +3033,9 @@ class ScaleFunctionsTest(TestCase):
         qkv_shape = [batch_size, seq_len, num_heads, num_heads]
         inputs = dict(
             mode=mode,
-            q_proj=jnp.full(qkv_shape, fill_value=qkv_value),
-            k_proj=jnp.full(qkv_shape, fill_value=qkv_value),
-            v_proj=jnp.full(qkv_shape, fill_value=qkv_value),
+            q_proj=jnp.full(qkv_shape, fill_value=qkv_value, dtype=jnp.float32),
+            k_proj=jnp.full(qkv_shape, fill_value=qkv_value, dtype=kv_dtype),
+            v_proj=jnp.full(qkv_shape, fill_value=qkv_value, dtype=kv_dtype),
             attention_logit_biases=attention_bias.CausalAttentionBias(
                 target_positions=jnp.arange(seq_len)[None],
                 source_positions=jnp.arange(seq_len)[None],
@@ -3033,7 +3045,7 @@ class ScaleFunctionsTest(TestCase):
         # Get outputs.
         forward_key = jax.random.PRNGKey(456)
 
-        (_, probs), _ = F(
+        (context, probs), _ = F(
             sigmoid_attention,
             method="_compute_attention",
             state=state,
@@ -3042,6 +3054,7 @@ class ScaleFunctionsTest(TestCase):
             inputs=inputs,
         )
 
+        self.assertEqual(context.dtype, inputs["q_proj"].dtype)
         output_shape = [batch_size, num_heads, seq_len, seq_len]
         indexes = jnp.arange(seq_len)
         # Zeros outside of the causal triangle.

--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -153,6 +153,23 @@ class FlashAttention(GroupedQueryAttention):
         v_proj: Tensor,
         attention_logit_biases: BaseAttentionBias,
     ) -> tuple[Tensor, Tensor]:
+        """Computes attention context and probs.
+
+        Note: KV cache may cast k_proj/v_proj in lower precision, so flash attention kernel must
+        cast them to q_proj.dtype.
+
+        Args:
+            mode: Configures whether `cached_states` are consumed or emitted. See `ForwardMode` for
+                details.
+            q_proj: [batch_size, target_length, num_heads, per_head_dim].
+            k_proj: [batch_size, source_length, num_heads, per_head_dim].
+            v_proj: [batch_size, source_length, num_heads, per_head_dim].
+            attention_logit_biases: See ``On attention logit biases`` in the file comments.
+
+        Returns:
+            The context of shape [batch_size, target_length, num_heads, per_head_dim],
+            and probs of shape [batch, num_heads, target_length, source_length].
+        """
         cfg: FlashAttention.Config = self.config
         backend = self._backend()
 


### PR DESCRIPTION
This PR introduces no logic change, since low-precision floats are automatically upcast when operated on with higher-precision floats. The only difference is that the upcasting is now made explicit in the code.