### PR TITLE
fix nodeSelectors when not using bastion

### DIFF
--- a/axlearn/cloud/gcp/jobs/gke_runner.py
+++ b/axlearn/cloud/gcp/jobs/gke_runner.py
@@ -278,7 +278,7 @@ class GKERunnerJob(GCPJob):
                 **custom_jobset_kwargs(),
             )
 
-            tier = os.environ.get("BASTION_TIER", 0)
+            tier = os.environ.get("BASTION_TIER", None)
             reservation = _infer_reservation(resp["spec"])
             if runner_utils.should_recreate_job(tier, reservation):
                 return GKERunnerJob.Status.RESCHEDULED
@@ -396,7 +396,7 @@ class GKERunnerJob(GCPJob):
             node_pool_config = node_pool.get("config", {})
             reservation_affinity = node_pool_config.get("reservationAffinity", {})
             taints = node_pool_config.get("taints", [])
-            tier = os.environ.get("BASTION_TIER", 0)
+            tier = os.environ.get("BASTION_TIER", None)
             has_reservation = (
                 reservation_affinity.get("key") == "compute.googleapis.com/reservation-name"
                 and len(reservation_affinity.get("values", [])) > 0

--- a/axlearn/cloud/gcp/jobset_utils.py
+++ b/axlearn/cloud/gcp/jobset_utils.py
@@ -570,7 +570,7 @@ class TPUReplicatedJob(SingleReplicatedJob):
             if cfg.reservation_project is not None:
                 selector.update({"cloud.google.com/reservation-project": cfg.reservation_project})
             labels.update({"bastion-tier": "reserved"})
-        else:
+        elif tier is not None:
             logging.info("Found tier=%s in env. Using spot quota", tier)
             selector.update({"cloud.google.com/gke-spot": "true"})
             tolerations.append(
@@ -598,7 +598,7 @@ class TPUReplicatedJob(SingleReplicatedJob):
         if cfg.enable_pre_provisioner:
             # Used by pre-provisioner.
             selector.update({PRE_PROVISIONER_LABEL: cfg.name})
-        else:
+        elif tier is not None:
             # Used by GCP auto-provisioner.
             selector.update(
                 {

--- a/axlearn/cloud/gcp/jobset_utils_test.py
+++ b/axlearn/cloud/gcp/jobset_utils_test.py
@@ -238,7 +238,7 @@ class TPUReplicatedJobTest(TestCase):
                 self.assertNotIn("cloud.google.com/gke-spot", node_selector)
                 self.assertEqual([], pod_spec.get("tolerations", []))
                 self.assertEqual("reserved", labels.get("bastion-tier", None))
-            else:
+            elif "BASTION_TIER" in env:
                 self.assertEqual("true", node_selector.get("cloud.google.com/gke-spot", None))
                 self.assertNotIn("cloud.google.com/reservation-name", node_selector)
                 tolerations = {

--- a/axlearn/cloud/gcp/node_pool_provisioner.py
+++ b/axlearn/cloud/gcp/node_pool_provisioner.py
@@ -100,7 +100,7 @@ class TPUNodePoolProvisioner(NodePoolProvisioner):
         job_sys_property = USER_FACING_NAME_TO_SYSTEM_CHARACTERISTICS[tpu_type]
         num_node_pools = acc_cfg.num_replicas
 
-        tier = os.environ.get("BASTION_TIER", 0)
+        tier = os.environ.get("BASTION_TIER", None)
         if tier == "0" and reservation is not None:
             logging.info("Found tier=%s in env. Using reservation=%s", tier, reservation)
             use_spot_vm = False


### PR DESCRIPTION
Removes the spot and provisioner-node-pool-id selector when bastion is not in-use. This allows submitting Jobset on both on-demand, reserved and spot capacity and improves UX for non-Bastion use cases.

Fixes #621

This approach is preferred over #622 and #620