### PR TITLE
Significantly improved performance for GPU FP32 FlashAttention

### DIFF
--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -293,7 +293,11 @@ class ReferenceMHA(BaseFlashAttention):
 
 
 def get_cpu_dot_precision(dtype) -> jax.lax.DotAlgorithmPreset:
-    """Get the suitable DotAlgorithmPreset for the given dtype."""
+    """Get the suitable DotAlgorithmPreset for the given dtype for CPU backend.
+
+    CPU doesn't support different compute and accumulation precision. This should only be used
+    for CPU emulation and unit tests.
+    """
     if dtype == jnp.float32:
         return jax.lax.DotAlgorithmPreset.F32_F32_F32
     if dtype == jnp.float16:
@@ -333,7 +337,7 @@ def get_tpu_dot_precision(dtype) -> jax.lax.Precision:
     if dtype == jnp.float32:
         # HIGHEST uses BF16_BF16_F32_X6, which emulates higher precision with 6 BF16 passes.
         # Note: jax.lax.Precision.HIGH (BF16_BF16_F32_X3) is not yet supported. We should use it
-        # when it's supported.
+        # when it's supported as it's twice as fast and precision is ok.
         return jax.lax.Precision.HIGHEST
     if dtype == jnp.bfloat16:
         return jax.lax.Precision.DEFAULT

--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -290,3 +290,51 @@ class ReferenceMHA(BaseFlashAttention):
         if self.cfg.dropout_rate > 0:
             probs = dropout(probs, prng_key=prng_key, rate=self.cfg.dropout_rate, mask=dropout_mask)
         return compute_gqa_context(probs, value)
+
+
+def get_cpu_dot_precision(dtype) -> jax.lax.DotAlgorithmPreset:
+    """Get the suitable DotAlgorithmPreset for the given dtype."""
+    if dtype == jnp.float32:
+        return jax.lax.DotAlgorithmPreset.F32_F32_F32
+    if dtype == jnp.float16:
+        return jax.lax.DotAlgorithmPreset.F16_F16_F16
+    if dtype == jnp.bfloat16:
+        return jax.lax.DotAlgorithmPreset.BF16_BF16_BF16
+    raise ValueError(f"Unsupported dtype {dtype}")
+
+
+# See https://docs.jax.dev/en/latest/jax.lax.html#jax.lax.DotAlgorithm for information.
+def get_gpu_dot_precision(dtype) -> jax.lax.DotAlgorithmPreset:
+    """Get the suitable DotAlgorithmPreset for the given dtype."""
+    # General rules:
+    # 1. Must accumulate in FP32 precision.
+    # 2. Must use TensorCore.
+    if jax.default_backend() == "cpu":
+        return get_cpu_dot_precision(dtype)
+    if dtype == jnp.float32:
+        # We can use F32_F32_F32, but it disables the use of TensorCore and makes it more than 10x
+        # slower on H100, as matmul fallbacks to using CUDA cores.
+        return jax.lax.DotAlgorithmPreset.TF32_TF32_F32
+    if dtype == jnp.float16:
+        return jax.lax.DotAlgorithmPreset.F16_F16_F32
+    if dtype == jnp.bfloat16:
+        return jax.lax.DotAlgorithmPreset.BF16_BF16_F32
+    raise ValueError(f"Unsupported dtype {dtype}")
+
+
+# See https://docs.jax.dev/en/latest/jax.lax.html#jax.lax.DotAlgorithm for information.
+def get_tpu_dot_precision(dtype) -> jax.lax.Precision:
+    """Get the suitable DotAlgorithmPreset for the given dtype.
+
+    TPU Pallas lowering doesn't yet support DotAlgorithmPreset. Use Precision instead.
+    """
+    if jax.default_backend() == "cpu":
+        return get_cpu_dot_precision(dtype)
+    if dtype == jnp.float32:
+        # HIGHEST uses BF16_BF16_F32_X6, which emulates higher precision with 6 BF16 passes.
+        # Note: jax.lax.Precision.HIGH (BF16_BF16_F32_X3) is not yet supported. We should use it
+        # when it's supported.
+        return jax.lax.Precision.HIGHEST
+    if dtype == jnp.bfloat16:
+        return jax.lax.Precision.DEFAULT
+    raise ValueError(f"Unsupported dtype {dtype}")

--- a/axlearn/common/flash_attention/gpu_attention.py
+++ b/axlearn/common/flash_attention/gpu_attention.py
@@ -58,6 +58,7 @@ from axlearn.common.attention_bias import (
 from axlearn.common.flash_attention.common import (
     BaseFlashAttention,
     build_mask,
+    get_gpu_dot_precision,
     get_segment_ids,
     query_iterator_indices,
     repeat_kv_heads,
@@ -166,11 +167,7 @@ def _mha_forward_kernel(
     kv_seq_len = k_ref.shape[0]
     block_d = q_ref.shape[-1]
     start_q = pl.program_id(0)
-    precision = (
-        lax.Precision.HIGHEST
-        if jnp.float32 in (q_ref.dtype, k_ref.dtype, v_ref.dtype)
-        else lax.Precision.DEFAULT
-    )
+    precision = get_gpu_dot_precision(q_ref.dtype)
 
     # o is the buffer where we accumulate the output on sram.
     # m_i and l_i (see FlashAttention paper) are updated during the k,v loop.
@@ -468,11 +465,7 @@ def _mha_backward_kernel_dkdv(
     """
     q_seq_len = q_ref.shape[0]
     block_d = q_ref.shape[-1]
-    precision = (
-        lax.Precision.HIGHEST
-        if jnp.float32 in (q_ref.dtype, k_ref.dtype, v_ref.dtype)
-        else lax.Precision.DEFAULT
-    )
+    precision = get_gpu_dot_precision(q_ref.dtype)
 
     start_k = pl.program_id(2)
     curr_k_slice = pl.dslice(start_k * block_k, block_k)
@@ -566,11 +559,7 @@ def _mha_backward_kernel_dq(
     """
     kv_seq_len = k_ref.shape[0]
     block_d = q_ref.shape[-1]
-    precision = (
-        lax.Precision.HIGHEST
-        if jnp.float32 in (q_ref.dtype, k_ref.dtype, v_ref.dtype)
-        else lax.Precision.DEFAULT
-    )
+    precision = get_gpu_dot_precision(q_ref.dtype)
 
     start_q = pl.program_id(2)
     curr_q_slice = pl.ds(start_q * block_q, block_q)

--- a/axlearn/common/flash_attention/gpu_attention_benchmark.py
+++ b/axlearn/common/flash_attention/gpu_attention_benchmark.py
@@ -52,6 +52,11 @@ is_decode=False, use_bwd=False, num_heads=32, num_kv_heads=None, seq_len=4096, p
 bs=2                                              6.151616      0.903744      0.453472
 bs=4                                              11.448928     1.728224      0.868096
 bs=8                                              23.125055     3.385728      1.692704
+is_decode=False, use_bwd=False, num_heads=32, num_kv_heads=None, seq_len=4096, per_head_dim=128, sw_sz=-1
+                                                  jax           axlearn
+bs=2,dtype=<class 'jax.numpy.float32'>            9.706688      3.208640
+bs=4,dtype=<class 'jax.numpy.float32'>            19.720287     6.164672
+bs=8,dtype=<class 'jax.numpy.float32'>            39.786495     12.005504
 is_decode=False, use_bwd=False, bs=2, num_kv_heads=None, seq_len=4096, per_head_dim=128, sw_sz=-1
                                                   jax           axlearn       jax-cudnn
 num_heads=12                                      2.344864      0.388864      0.200256
@@ -86,6 +91,11 @@ is_decode=False, use_bwd=True, num_heads=32, num_kv_heads=None, seq_len=4096, pe
 bs=2                                              6.134624      0.940480      0.488192
 bs=4                                              11.365568     1.791296      0.922528
 bs=8                                              22.983904     3.470272      1.795264
+is_decode=False, use_bwd=True, num_heads=32, num_kv_heads=None, seq_len=4096, per_head_dim=128, sw_sz=-1
+                                                  jax           axlearn
+bs=2,dtype=<class 'jax.numpy.float32'>            9.692192      3.243680
+bs=4,dtype=<class 'jax.numpy.float32'>            19.611168     6.216032
+bs=8,dtype=<class 'jax.numpy.float32'>            39.664703     12.213696
 is_decode=False, use_bwd=True, bs=2, num_kv_heads=None, seq_len=4096, per_head_dim=128, sw_sz=-1
                                                   jax           axlearn       jax-cudnn
 num_heads=12                                      2.335136      0.406336      0.215584
@@ -202,6 +212,7 @@ def bench_flash_attention(
     is_decode: bool,
     use_bwd: bool,
     sw_sz: int = -1,
+    dtype=jnp.float16,
 ):
     if use_bwd and is_decode:
         raise ValueError("use_bwd and is_decode cannot both be true.")
@@ -228,7 +239,7 @@ def bench_flash_attention(
         num_kv_heads=num_kv_heads,
         mask_fn=mask_fn,
         sliding_window_sz=sw_sz,
-        dtype=jnp.float16,
+        dtype=dtype,
         query_offset=seq_len - 1 if is_decode else 0,
     )
 
@@ -243,7 +254,7 @@ def bench_flash_attention(
 
     assert base_fn.is_supported(query=q, key=k, value=v, bias=bias)
     if use_bwd:
-        fn = lambda *args: base_fn(*args).mean()
+        fn = jax.grad(lambda *args: base_fn(*args).mean(), argnums=(0, 1, 2))
     else:
         fn = base_fn
     return measure(fn, q, k, v, bias)
@@ -283,7 +294,7 @@ def _sweep(
             result, t = fn(library=library, **bench_kwargs, **common_kwargs)
             if i == 0:
                 ref_result = result
-            elif i > 0 and library != "jax-pallas":
+            elif i > 0:
                 jax.tree.map(check_fn, result, ref_result)
             lib_results.append(t)
         results.append(lib_results)
@@ -335,6 +346,8 @@ def bench_flash_attention_fwd_bwd(use_bwd: bool):
     )
     libraries = ["jax", "axlearn", "jax-cudnn"]
     benchmark_sweep(libraries, common_kwargs, bs=[2, 4, 8])
+    # cuDNN doesn't support fp32.
+    benchmark_sweep(["jax", "axlearn"], common_kwargs, bs=[2, 4, 8], dtype=[jnp.float32])
     benchmark_sweep(libraries, common_kwargs, num_heads=[12, 16, 32, 48, 72])
     # 256 to 8192.
     benchmark_sweep(libraries, common_kwargs, seq_len=[int(2**i) for i in range(8, 14)])

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -249,6 +249,7 @@ def test_sliding_window_mask(
         per_head_dim,
         sliding_window_sz=sliding_window_size,
         with_segment_ids=use_segment_ids,
+        dtype=jnp.float16,
     )
 
     cfg = dict(

--- a/axlearn/common/flash_attention/gpu_decoding.py
+++ b/axlearn/common/flash_attention/gpu_decoding.py
@@ -57,7 +57,7 @@ from axlearn.common.attention_bias import (
     MaskFnAttentionBias,
     split,
 )
-from axlearn.common.flash_attention.common import BaseSingleStepDecoding
+from axlearn.common.flash_attention.common import BaseSingleStepDecoding, get_gpu_dot_precision
 from axlearn.common.flash_attention.gpu_attention import NoPopDict
 from axlearn.common.utils import Tensor
 
@@ -83,11 +83,7 @@ def _attn_forward_kernel(
 ):
     _, head_dim = q_ref.shape
     split_k_seq_len, _ = k_ref.shape
-    precision = (
-        lax.Precision.HIGHEST
-        if jnp.float32 in (q_ref.dtype, k_ref.dtype, v_ref.dtype)
-        else lax.Precision.DEFAULT
-    )
+    precision = get_gpu_dot_precision(q_ref.dtype)
     prog_i, prog_j = pl.program_id(1), pl.program_id(2)
     q_mask = (block_h * prog_i + jnp.arange(block_h) < qhead_per_kvhead)[:, None]
 

--- a/axlearn/common/flash_attention/tpu_decoding.py
+++ b/axlearn/common/flash_attention/tpu_decoding.py
@@ -41,6 +41,7 @@ from axlearn.common.attention_bias import (
 from axlearn.common.flash_attention.common import (
     BaseSingleStepDecoding,
     build_mask,
+    get_tpu_dot_precision,
     query_iterator_indices,
 )
 from axlearn.common.utils import Tensor
@@ -69,9 +70,7 @@ def _tpu_decoding_kernel(
     batch_index = pl.program_id(0)
     non_empty_kv_block_index = pl.program_id(2)
     _, block_k = k_ref.shape
-    precision = (
-        lax.Precision.HIGHEST if jnp.float32 in (q_ref.dtype, k_ref.dtype, v_ref.dtype) else None
-    )
+    precision = get_tpu_dot_precision(q_ref.dtype)
 
     # o is the buffer where we accumulate the output on sram.
     # m_i and l_i (see FlashAttention paper) are updated during the k,v loop.


### PR DESCRIPTION
Previously, FP32 code path for the GPU FlashAttention uses pure FP32 arithmetic, which disabled the use of TensorCore, making the kernel more than **100x** slower than expected. We fixed this by using the TF32 preset rather than `jax.lax.Precision.HIGHEST`. This is also consistent with the default precision of FP32 matmul in Jax GPU.

Additionally, we try to use `jax.lax.DotAlgorithmPreset` when possible, as it's more clear to the reader what the actual compute and accumulation precision is. We only fallbacks to `jax.lax.Precision` when it's not possible to use `DotAlgorithmPreset`.

FP32 benchmarks are added for GPU FlashAttention.

This PR is proved to speed up some FP32 eval workload from 14hr to 35min.

Forward pass numbers with pure FP32 (unit=ms):
```
is_decode=False, use_bwd=False, num_heads=32, num_kv_heads=None, seq_len=4096, per_head_dim=128, sw_sz=-1
                                                  jax           axlearn       
bs=2,dtype=<class 'jax.numpy.float32'>            9.690944      420.148224    
bs=4,dtype=<class 'jax.numpy.float32'>            19.689793     821.556946    
bs=8,dtype=<class 'jax.numpy.float32'>            39.802753     1622.739136   
```

Forward pass numbers with TF32:
```
is_decode=False, use_bwd=False, num_heads=32, num_kv_heads=None, seq_len=4096, per_head_dim=128, sw_sz=-1
                                                  jax           axlearn
bs=2,dtype=<class 'jax.numpy.float32'>            9.706688      3.208640
bs=4,dtype=<class 'jax.numpy.float32'>            19.720287     6.164672
bs=8,dtype=<class 'jax.numpy.float32'>            39.786495     12.005504
```