### PR TITLE
The Speech frontend uses chunking more intelligently.

### DIFF
--- a/axlearn/audio/frontend_benchmark.py
+++ b/axlearn/audio/frontend_benchmark.py
@@ -2,13 +2,56 @@
 
 """Benchmark Frontend.
 
-1) frontend_utils.frame benchmark
-* TPU v4
-  * frame_time: 0.0686s.
-  * Note: before pull/807, frame_time: 1.7839s
-* CPU
-  * frame_time:0.2298s
-  * Note: before pull/807, frame_time: 0.1403s
+> python -m axlearn.audio.frontend_benchmark
+
+ChunkSize1 and ChunkSize80 are important. ChunkSize80 corresponds to a frame size of 25ms and
+hop size of 10ms at 16kHz (for both Logmel and STFT), while ChunkSize1 represents Logmel with
+pre_emphasis=0.97 (or not None).
+
+A notable point is that while GPU is consistently fast, TPU is more than 10 times slower than GPU.
+Especially at ChunkSize1, the performance is so slow that it almost seems like a bug.
+
+TPU v5p
+ChunkSize1: frame_time 104.716ms
+ChunkSize2: frame_time 91.805ms
+ChunkSize4: frame_time 58.432ms
+ChunkSize5: frame_time 46.348ms
+ChunkSize8: frame_time 38.428ms
+ChunkSize10: frame_time 35.586ms
+ChunkSize16: frame_time 22.548ms
+ChunkSize20: frame_time 21.454ms
+ChunkSize32: frame_time 11.166ms
+ChunkSize40: frame_time 11.875ms
+ChunkSize80: frame_time 1.276ms
+ChunkSize160: frame_time 0.976ms
+
+GPU H100
+ChunkSize1: frame_time 0.276ms
+ChunkSize2: frame_time 0.249ms
+ChunkSize4: frame_time 0.157ms
+ChunkSize5: frame_time 0.186ms
+ChunkSize8: frame_time 0.109ms
+ChunkSize10: frame_time 0.142ms
+ChunkSize16: frame_time 0.094ms
+ChunkSize20: frame_time 0.101ms
+ChunkSize32: frame_time 0.090ms
+ChunkSize40: frame_time 0.096ms
+ChunkSize80: frame_time 0.087ms
+ChunkSize160: frame_time 0.096ms
+
+CPU
+ChunkSize1: frame_time 4.576ms
+ChunkSize2: frame_time 4.437ms
+ChunkSize4: frame_time 5.087ms
+ChunkSize5: frame_time 4.672ms
+ChunkSize8: frame_time 3.846ms
+ChunkSize10: frame_time 4.572ms
+ChunkSize16: frame_time 4.287ms
+ChunkSize20: frame_time 4.755ms
+ChunkSize32: frame_time 3.966ms
+ChunkSize40: frame_time 3.988ms
+ChunkSize80: frame_time 3.823ms
+ChunkSize160: frame_time 4.526ms
 """
 
 import functools
@@ -19,52 +62,55 @@ import jax
 
 from axlearn.audio import frontend_utils, test_utils
 
+# Map frame_offset to chunk_size by `[(i, np.gcd(160, 400 + i)) for i in range(81)]`.
 _BENCHMARK_CONFIGS = {
-    "b32s600": dict(
-        batch_size=32,
-        seq_secs=600,
-    ),
+    "ChunkSize1": dict(batch_size=8, seq_secs=120, frame_offset=1),
+    "ChunkSize2": dict(batch_size=8, seq_secs=120, frame_offset=2),
+    "ChunkSize4": dict(batch_size=8, seq_secs=120, frame_offset=4),
+    "ChunkSize5": dict(batch_size=8, seq_secs=120, frame_offset=5),
+    "ChunkSize8": dict(batch_size=8, seq_secs=120, frame_offset=8),
+    "ChunkSize10": dict(batch_size=8, seq_secs=120, frame_offset=10),
+    "ChunkSize16": dict(batch_size=8, seq_secs=120, frame_offset=32),
+    "ChunkSize20": dict(batch_size=8, seq_secs=120, frame_offset=20),
+    "ChunkSize32": dict(batch_size=8, seq_secs=120, frame_offset=16),
+    "ChunkSize40": dict(batch_size=8, seq_secs=120, frame_offset=40),
+    "ChunkSize80": dict(batch_size=8, seq_secs=120, frame_offset=0),
+    "ChunkSize160": dict(batch_size=8, seq_secs=120, frame_offset=80),
 }
 
 
-def _time_call(fn: Callable, *, num_iters: int = 5) -> float:
+def _time_call(fn: Callable, *, num_iters: int = 20) -> float:
     """Times average execution time for fn call over num_iters after warmup."""
     fn().block_until_ready()
     tic = time.perf_counter()
-    for _ in range(num_iters):
-        fn().block_until_ready()
+    for _ in range(num_iters - 1):
+        fn()
+    fn().block_until_ready()
     toc = time.perf_counter()
     return (toc - tic) / num_iters
 
 
-def _benchmark(
-    *,
-    batch_size: int,
-    seq_secs: int,
-):
+def _benchmark(exp: str, *, batch_size: int, seq_secs: int, frame_offset: int):
     """Benchmarks TPU FlashAttention vs reference impl."""
     sample_rate = 16_000
     frame_size_ms = 25
-    frame_step_ms = 10
+    hop_size_ms = 10
     frame_size = frontend_utils.ms_to_samples(frame_size_ms, sample_rate=sample_rate)
-    frame_step = frontend_utils.ms_to_samples(frame_step_ms, sample_rate=sample_rate)
+    # For Logmel, frame_offset=0 imitates pre_emphasis=None, and 1 does pre_emphasis=0.97.
+    frame_size += frame_offset
+    hop_size = frontend_utils.ms_to_samples(hop_size_ms, sample_rate=sample_rate)
     seq_len = seq_secs * sample_rate
     inputs, _ = test_utils.fake_audio(
         prng_key=jax.random.PRNGKey(123), batch_size=batch_size, seq_len=seq_len
     )
 
-    fn = functools.partial(
-        frontend_utils.frame, x=inputs, frame_size=frame_size, hop_size=frame_step
-    )
+    fn = functools.partial(frontend_utils.frame, x=inputs, frame_size=frame_size, hop_size=hop_size)
     fn = jax.jit(fn)
     frame_time = _time_call(fn)
-
-    print(f"frame_time: {frame_time:.4f}s.")
+    print(f"{exp}: frame_time {frame_time * 1000:.3f}ms")
 
 
 if __name__ == "__main__":
     print(f"Benchmarking on {jax.default_backend()} backend.")
-    device_kind = jax.devices()[0].device_kind
     for name, cfg in _BENCHMARK_CONFIGS.items():
-        print(f"Benchmarking frame() representative of {name} config on {device_kind}.")
-        _benchmark(**cfg)
+        _benchmark(name, **cfg)

--- a/axlearn/audio/frontend_test.py
+++ b/axlearn/audio/frontend_test.py
@@ -13,7 +13,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 import tensorflow as tf
-from absl.testing import parameterized
+from absl.testing import absltest, parameterized
 from jax.experimental import mesh_utils
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
@@ -435,3 +435,7 @@ def _ref_stft_frontend(
         tf.maximum(tf.math.abs(outputs), tf.experimental.numpy.finfo(outputs.dtype).tiny)
     )
     return outputs, output_paddings
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/axlearn/audio/frontend_utils.py
+++ b/axlearn/audio/frontend_utils.py
@@ -13,6 +13,7 @@ import math
 from functools import partial
 from typing import Callable, Union
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 from jax._src.mesh import thread_resources
@@ -172,21 +173,40 @@ def frame(x: Tensor, *, frame_size: int, hop_size: int, pad_value: int = 0) -> T
 
     # For optimization, the index will be created at the chunk level, rather than for every sample.
     chunk_size = math.gcd(frame_size, hop_size)
-    chunk_x = einops.rearrange(x, "b (t c) -> b t c", c=chunk_size)
-    num_chunk = chunk_x.shape[1]
+    backend = jax.default_backend()
+    if backend == "tpu":
+        # Starting from chunk_size=2, chunking becomes faster than advanced indexing.
+        # As the chunk size increases, the performance improves further, and by chunk_size=80,
+        # chunking is approximately 100 times faster.
+        use_advanced_index = chunk_size <= 1
+    elif backend == "gpu":
+        # Starting from chunk_size=2, chunking becomes faster than advanced indexing.
+        # As the chunk size increases, the performance improves further, and by chunk_size=80,
+        # chunking is approximately 3 times faster.
+        use_advanced_index = chunk_size <= 1
+    else:
+        # On CPU, chunking does not reduce floating-point operations compared to advanced
+        # indexing. As a result, chunking introduces pure overhead (~5%).
+        use_advanced_index = True
 
-    frame_ratio = frame_size // chunk_size
-    hop_ratio = hop_size // chunk_size
-    assert flatten_size(output_size, frame_ratio, hop_ratio) == num_chunk
+    if use_advanced_index:
+        idx = hop_size * jnp.arange(output_size)[:, None] + jnp.arange(frame_size)[None, :]
+        frame_x = x[..., idx]
+    else:
+        chunk_x = einops.rearrange(x, "b (t c) -> b t c", c=chunk_size)
+        num_chunk = chunk_x.shape[1]
 
-    in_frame_indices = jnp.arange(frame_ratio)[jnp.newaxis, :]
-    out_frame_indices = (jnp.arange(output_size) * hop_ratio)[:, jnp.newaxis]
-    frame_x = chunk_x[:, out_frame_indices + in_frame_indices, :]
-    frame_x = einops.rearrange(
-        frame_x, "b ow iw c-> b ow (iw c)", ow=output_size, iw=frame_ratio, c=chunk_size
-    )
-    y = jnp.reshape(frame_x, (*orig_shape[:-1], *frame_x.shape[-2:]))  # Restore orig_shape[:-1].
-    return y
+        frame_ratio = frame_size // chunk_size
+        hop_ratio = hop_size // chunk_size
+        assert flatten_size(output_size, frame_ratio, hop_ratio) == num_chunk
+
+        in_frame_indices = jnp.arange(frame_ratio)[jnp.newaxis, :]
+        out_frame_indices = (jnp.arange(output_size) * hop_ratio)[:, jnp.newaxis]
+        frame_x = chunk_x[:, out_frame_indices + in_frame_indices, :]
+        frame_x = einops.rearrange(
+            frame_x, "b ow iw c-> b ow (iw c)", ow=output_size, iw=frame_ratio, c=chunk_size
+        )
+    return jnp.reshape(frame_x, (*orig_shape[:-1], *frame_x.shape[-2:]))  # Restore orig_shape[:-1].
 
 
 def frame_paddings(paddings: Tensor, *, frame_size: int, hop_size: int) -> Tensor:

--- a/axlearn/audio/frontend_utils_test.py
+++ b/axlearn/audio/frontend_utils_test.py
@@ -15,7 +15,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 import tensorflow as tf
-from absl.testing import parameterized
+from absl.testing import absltest, parameterized
 from jax.experimental import mesh_utils
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from numpy.typing import ArrayLike
@@ -417,3 +417,7 @@ class ShardedFftTest(TestCase):
         # Run the following on gpu.
         jax.debug.inspect_array_sharding(test_ffts, callback=print)
         jax.debug.inspect_array_sharding(ref_ffts, callback=print)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
During framing, the Speech frontend applies chunking for optimization, which is effective when the GCD of frame_size and hop_size is large. For example, with 16kHz audio, 10ms hop (160 samples), and 25ms frame (400 samples), the GCD is 80, allowing us to reduce indexing by a factor of 80×.

However, when log-mel uses pre-emphasis, the frame size becomes 401 instead of 400, and chunking becomes pure overhead.
So in that case, chunking is disabled, and pure advanced indexing is used for framing instead.

frontend_benchmark.py has been updated (to have stable results and) to set
platform-specific thresholds. Based on the results below, advanced indexing is
used only for chunk_size=1 on GPU/TPU, and always used on CPU.

In the table, ChunkSize1 and ChunkSize80 are particularly important.
ChunkSize80 corresponds to a frame size of 25ms and hop size of 10ms at 16kHz
(used by both Logmel and STFT), while ChunkSize1 represents Logmel with
pre_emphasis=0.97 (or any value other than None).

A notable point is that GPU is consistently fast, whereas TPU is more than 10
times slower than GPU. In particular, for ChunkSize1, the performance is so
slow that it almost seems like a bug.


| Platform | ChunkSize | Advanced_Indexing (ms) | Chunking (ms) | Speedup(x) |
|----------|-----------|-------------------------|----------------|------------|
| **CPU**      | **1**         | **4.576**                   | **4.665**          | **0.98**       |
| CPU      | 2         | 4.437                   | 4.461          | 0.99       |
| CPU      | 4         | 5.087                   | 3.916          | 1.30       |
| CPU      | 5         | 4.672                   | 4.538          | 1.03       |
| CPU      | 8         | 3.846                   | 4.861          | 0.79       |
| CPU      | 10        | 4.572                   | 4.601          | 0.99       |
| CPU      | 16        | 4.287                   | 5.262          | 0.82       |
| CPU      | 20        | 4.755                   | 5.165          | 0.92       |
| CPU      | 32        | 3.966                   | 4.820          | 0.82       |
| CPU      | 40        | 3.988                   | 4.397          | 0.91       |
| **CPU**      | **80**        | **3.823**                   | **3.725**          | **1.03**       |
| CPU      | 160       | 4.526                   | 4.661          | 0.97       |
| **GPU**      | **1**         | **0.276**                   | **0.278**          | **0.99**       |
| GPU      | 2         | 0.326                   | 0.249          | 1.31       |
| GPU      | 4         | 0.282                   | 0.157          | 1.80       |
| GPU      | 5         | 0.282                   | 0.186          | 1.52       |
| GPU      | 8         | 0.285                   | 0.109          | 2.61       |
| GPU      | 10        | 0.334                   | 0.142          | 2.35       |
| GPU      | 16        | 0.303                   | 0.094          | 3.22       |
| GPU      | 20        | 0.295                   | 0.101          | 2.92       |
| GPU      | 32        | 0.290                   | 0.090          | 3.22       |
| GPU      | 40        | 0.310                   | 0.096          | 3.23       |
| **GPU**      | **80**        | **0.275**                   | **0.087**          | **3.16**       |
| GPU      | 160       | 0.350                   | 0.096          | 3.65       |
| **TPU**      | **1**         | **104.716**                 | **104.799**        | **1.00**       |
| TPU      | 2         | 110.186                 | 91.805         | 1.20       |
| TPU      | 4         | 105.457                 | 58.432         | 1.80       |
| TPU      | 5         | 109.818                 | 46.348         | 2.37       |
| TPU      | 8         | 110.130                 | 38.428         | 2.87       |
| TPU      | 10        | 107.540                 | 35.586         | 3.02       |
| TPU      | 16        | 117.870                 | 22.548         | 5.23       |
| TPU      | 20        | 109.776                 | 21.454         | 5.12       |
| TPU      | 32        | 125.775                 | 11.166         | 11.26      |
| TPU      | 40        | 120.062                 | 11.875         | 10.11      |
| **TPU**      | **80**        | **109.894**                 | **1.276**          | **86.14**      |
| TPU      | 160       | 135.281                 | 0.976          | 138.58     |
