### PR TITLE
ConditionalUpdateTransformation for alternate learner 

### DIFF
--- a/axlearn/common/optimizer_base.py
+++ b/axlearn/common/optimizer_base.py
@@ -58,7 +58,7 @@ class TransformUpdateFn(typing_extensions.Protocol):
     """
 
     def __call__(
-        self, updates: optax.Updates, state: optax.OptState, params: NestedOptParam
+        self, updates: optax.Updates, state: optax.OptState, params: Optional[NestedOptParam]
     ) -> tuple[optax.Updates, optax.OptState]:
         ...
 

--- a/axlearn/common/update_transformation.py
+++ b/axlearn/common/update_transformation.py
@@ -16,25 +16,35 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Sequence
-from typing import Any, Callable, Literal, Optional, Protocol, Union
+from typing import Any, Callable, Literal, NamedTuple, Optional, Protocol, Union, cast
 
 import jax
+import jax.numpy as jnp
 import optax
 from absl import logging
 from jax.sharding import PartitionSpec
 
 from axlearn.common import struct
 from axlearn.common.base_layer import ParameterSpec
-from axlearn.common.config import REQUIRED, ConfigOr, Required, config_class, maybe_instantiate
+from axlearn.common.config import (
+    REQUIRED,
+    ConfigOr,
+    InstantiableConfig,
+    Required,
+    config_class,
+    maybe_instantiate,
+)
 from axlearn.common.learner_base import LearnerModule
 from axlearn.common.module import Module, OutputCollection
-from axlearn.common.optimizer_base import OptParam, PartitionedGradientTransformation
+from axlearn.common.optimizer_base import OptParam, OptStateSpec, PartitionedGradientTransformation
 from axlearn.common.utils import (
     Nested,
     Tensor,
     flatten_items,
     match_regex_rules,
     non_empty_leaf_merge_fn,
+    prune_empty,
+    prune_tree,
     tree_merge,
     tree_paths,
 )
@@ -98,6 +108,88 @@ class WrappedPartitionedGradientTransformation(UpdateTransformation):
         # Optimizer state from a PartitionedGradientTransformation may be a tuple, so we have to
         # assign it via the parent.
         self.get_invocation_context().set_state_update(optimizer_state)
+        return dataclasses.replace(updates, delta_updates=param_updates)
+
+
+class ShouldUpdateState(NamedTuple):
+    count: Tensor  # Number of steps
+    val: Tensor
+
+
+class ConditionalUpdateTransformation(UpdateTransformation):
+    """A wrapper around a `UpdateTransformation` to conditionally allow or stop
+    gradient and optimizer state updates based on `update_schedule`.
+    """
+
+    @config_class
+    class Config(UpdateTransformation.Config):
+        inner: Required[InstantiableConfig] = REQUIRED
+        update_schedule: Optional[Callable[[Union[int, Tensor]], Union[bool, Tensor]]] = None
+
+    def __init__(self, cfg: Config, *, parent: Optional[Module] = None):
+        super().__init__(cfg, parent=parent)
+        inner = cfg.inner
+        if not isinstance(inner, LearnerModule.Config):
+            inner = WrappedPartitionedGradientTransformation.default_config().set(
+                transformation=inner
+            )
+        self.inner = cast(UpdateTransformation, self._add_child("inner", inner))
+        self._update_schedule = cfg.update_schedule
+        if self._update_schedule is None:
+            self._update_schedule = lambda step: True
+
+    def create_state_partition_specs(
+        self, model_param_specs: Nested[ParameterSpec]
+    ) -> Nested[PartitionSpec]:
+        specs = self.inner.create_state_partition_specs(model_param_specs)
+        should_update_specs = ShouldUpdateState(
+            count=OptStateSpec(dtype=jnp.int32, shape=[], mesh_axes=PartitionSpec()),
+            val=OptStateSpec(dtype=jnp.bool, shape=[], mesh_axes=PartitionSpec()),
+        )
+        return {"should_update": should_update_specs, "inner": specs}
+
+    def init(self, model_params: Nested[OptParam]) -> Nested[Tensor]:
+        state = self.inner.init(model_params)
+        should_update_state = ShouldUpdateState(
+            count=jnp.zeros([], jnp.int32), val=jnp.ones([], jnp.bool)
+        )
+        return {"should_update": should_update_state, "inner": state}
+
+    def transform_update(self, updates: Updates) -> Updates:
+        count_inc = optax.safe_int32_increment(self.state["should_update"].count)
+        val = self._update_schedule(count_inc)
+        should_update_state = ShouldUpdateState(count=count_inc, val=val)
+
+        inplace_updates = prune_tree(
+            prune_empty(updates.inplace_updates), lambda _, v: v == optax.MaskedNode()
+        )
+        if inplace_updates:
+            raise NotImplementedError(
+                "`inplace_updates` are not supported when ConditionalUpdateTransformation "
+                f"is used. Got: {inplace_updates}. Consider moving state updates into "
+                "CompositeLearner or other sub-learners."
+            )
+
+        prev_state = self.state["inner"]
+        # Backward and optimizer state computation need to be carried out
+        # regardless of should_update value.
+        new_updates = self.inner.transform_update(updates=updates)
+        new_state = self.get_invocation_context().get_state_updates()["inner"]
+
+        def real_transform(_):
+            return new_updates.delta_updates, new_state
+
+        def stop_transform(_):
+            return jax.tree_map(jnp.zeros_like, updates.delta_updates), prev_state
+
+        # We do the computation regardless of the should_update value, so we could have
+        # equally used jnp.where() here instead.
+        param_updates, optimizer_state = jax.lax.cond(
+            should_update_state.val, real_transform, stop_transform, operand=None
+        )
+
+        self.add_state_update("should_update", should_update_state)
+        self.add_state_update("inner", optimizer_state)
         return dataclasses.replace(updates, delta_updates=param_updates)
 
 

--- a/axlearn/common/update_transformation_test.py
+++ b/axlearn/common/update_transformation_test.py
@@ -2,6 +2,7 @@
 """Tests for update_transformation.py."""
 import dataclasses
 from collections.abc import Sequence
+from typing import Any, NamedTuple
 
 import chex
 import jax
@@ -13,20 +14,32 @@ import axlearn.common
 from axlearn.common import optimizers, schedule, test_utils
 from axlearn.common.base_layer import FactorizationSpec, ParameterSpec
 from axlearn.common.config import config_for_function, maybe_instantiate
-from axlearn.common.module import (
-    InvocationContext,
-    functional,
-    new_output_collection,
-    set_current_context,
+from axlearn.common.learner import Learner
+from axlearn.common.module import InvocationContext
+from axlearn.common.module import functional as F
+from axlearn.common.module import new_output_collection, set_current_context
+from axlearn.common.optimizer_base import (
+    NestedOptParam,
+    OptParam,
+    PartitionedGradientTransformation,
 )
-from axlearn.common.optimizer_base import OptParam, PartitionedGradientTransformation
 from axlearn.common.update_transformation import (
+    ConditionalUpdateTransformation,
+    ForwardOutputs,
     OverrideInplaceUpdateTransformation,
     Updates,
     UpdateTransformation,
     WrappedPartitionedGradientTransformation,
 )
-from axlearn.common.utils import Nested, Tensor, VDict, tree_paths
+from axlearn.common.utils import (
+    Nested,
+    NestedTensor,
+    NestedTree,
+    PartitionSpec,
+    Tensor,
+    VDict,
+    tree_paths,
+)
 
 
 class UpdateTransformationTest(test_utils.TestCase):
@@ -122,7 +135,7 @@ class UpdateTransformationTest(test_utils.TestCase):
         self.assertNestedAllClose(actual_specs, expected_specs)
 
         # Check that the final update and optimizer state updates are the same.
-        actual_update, actual_output_collection = functional(
+        actual_update, actual_output_collection = F(
             module=update_transformation,
             prng_key=None,
             state=actual_init,
@@ -291,7 +304,7 @@ class OverrideInplaceUpdateTransformationTest(test_utils.TestCase):
         jax.tree.map(lambda path: self.assertNotIn("weight", path), tree_paths(actual_init))
         jax.tree.map(lambda path: self.assertNotIn("weight", path), tree_paths(actual_specs))
 
-        actual_update, _ = functional(
+        actual_update, _ = F(
             module=update_transformation,
             prng_key=None,
             state=actual_init,
@@ -305,6 +318,142 @@ class OverrideInplaceUpdateTransformationTest(test_utils.TestCase):
         self.assertTrue(jax.tree.reduce(lambda a, b: a or b, out))
         out = jax.tree.map(lambda path: "weight" in path, tree_paths(actual_update.inplace_updates))
         self.assertTrue(jax.tree.reduce(lambda a, b: a or b, out))
+
+
+class LearnerStep(NamedTuple):
+    state: Any
+    model_params: Any
+
+
+class ConditionalUpdateTransformationTest(test_utils.TestCase):
+    """Tests for `OverrideInplaceUpdateTransformation`."""
+
+    @parameterized.parameters("adamw", "chained")
+    def test_conditional_update_transformation(self, optimizer_type):
+        def get_learner_from_su(should_update_schedule_fn=None):
+            if optimizer_type in ("adamw", "chained"):
+                optimizer_cfg = config_for_function(optimizers.adamw_optimizer).set(
+                    learning_rate=0.1,
+                    b1=0.9,
+                    b2=0.99,
+                    eps=1e-5,
+                    weight_decay=0,
+                )
+            if optimizer_type == "chained":
+                optimizer_cfg = config_for_function(optimizers.chain).set(
+                    args=[
+                        config_for_function(optimizers.clip_by_global_norm).set(max_norm=10),
+                        optimizer_cfg,
+                    ]
+                )
+            optimizer_cfg = ConditionalUpdateTransformation.default_config().set(
+                inner=optimizer_cfg,
+                update_schedule=should_update_schedule_fn,
+            )
+            cfg = Learner.default_config().set(
+                name="test",
+                optimizer=optimizer_cfg,
+            )
+            cfg.ema.decay = None  # ema is not supported if we use conditional update
+            learner: Learner = cfg.instantiate(parent=None)
+            return learner
+
+        # learner updates at step 1 and step 3
+        learner = get_learner_from_su(should_update_schedule_fn=lambda step: step % 2 == 1)
+        # learner2 is a regular learner
+        learner2 = get_learner_from_su()
+        v_spec = ParameterSpec(
+            dtype=jnp.float32,
+            shape=(4,),
+            mesh_axes=PartitionSpec("model"),
+            factorization=None,
+            weight_decay_scale=1.0,
+        )
+        param_specs = dict(v_all=v_spec)
+        model_params = dict(v_all=jnp.asarray([1, -2, 3, -4], dtype=jnp.float32))
+
+        def opt_params_from_model_params(
+            model_params: NestedTensor, param_specs: NestedTree
+        ) -> NestedOptParam:
+            """Returns a tree of OptParam for Learner.{init,update}."""
+            return jax.tree.map(
+                lambda param, spec: OptParam(
+                    value=param,
+                    factorization_spec=spec.factorization if spec is not None else None,
+                    weight_decay_scale=spec.weight_decay_scale if spec is not None else 1.0,
+                ),
+                model_params,
+                param_specs,
+            )
+
+        params = opt_params_from_model_params(model_params, param_specs=param_specs)
+        params2 = opt_params_from_model_params(model_params, param_specs=param_specs)
+
+        state = learner.init(model_params=params)
+        state2 = learner2.init(model_params=params)
+
+        def loss_fn(model_params, inputs):
+            del inputs
+            m = model_params["v_all"]
+            loss = -1 * (jnp.arange(1, 5) * m).sum()
+            output_collection = new_output_collection()
+            return ForwardOutputs(
+                loss=loss,
+                aux={},
+                output_collection=output_collection,
+            )
+
+        learner_steps, learner2_steps = [], []
+        for step in range(3):
+            assert state["optimizer"]["should_update"].count.item() == step
+            fwd_bwd_outputs, output_collection = F(
+                learner,
+                method="forward_and_backward",
+                state=state,
+                is_training=True,
+                prng_key=jax.random.PRNGKey(123),
+                inputs=dict(
+                    fn=loss_fn,
+                    opt_params=params,
+                    inputs=dict(
+                        input_batch={},
+                    ),
+                ),
+            )
+            fwd_bwd_outputs2, output_collection2 = F(
+                learner2,
+                method="forward_and_backward",
+                state=state2,
+                is_training=True,
+                prng_key=jax.random.PRNGKey(123),
+                inputs=dict(
+                    fn=loss_fn,
+                    opt_params=params2,
+                    inputs=dict(
+                        input_batch={},
+                    ),
+                ),
+            )
+            state = output_collection.state_updates
+            model_params = fwd_bwd_outputs.backward_outputs.updated_params
+            params = opt_params_from_model_params(model_params, param_specs)
+            learner_steps.append(LearnerStep(state=state, model_params=model_params))
+
+            state2 = output_collection2.state_updates
+            model_params2 = fwd_bwd_outputs2.backward_outputs.updated_params
+            params2 = opt_params_from_model_params(model_params2, param_specs)
+            learner2_steps.append(LearnerStep(state=state2, model_params=model_params2))
+
+        def check_state_and_model_params_equal(step1, step2):
+            self.assertNestedAllClose(
+                step1.state["optimizer"]["inner"], step2.state["optimizer"]["inner"]
+            )
+            self.assertNestedAllClose(step1.model_params["v_all"], step2.model_params["v_all"])
+
+        # Check no updates during "off" step
+        check_state_and_model_params_equal(learner_steps[0], learner_steps[1])
+        # Check optimizer state correctly accumulates across steps
+        check_state_and_model_params_equal(learner_steps[2], learner2_steps[1])
 
 
 if __name__ == "__main__":

--- a/axlearn/common/update_transformation_test.py
+++ b/axlearn/common/update_transformation_test.py
@@ -358,8 +358,8 @@ class ConditionalUpdateTransformationTest(test_utils.TestCase):
             learner: Learner = cfg.instantiate(parent=None)
             return learner
 
-        # learner updates at step 1 and step 3
-        learner = get_learner_from_su(should_update_schedule_fn=lambda step: step % 2 == 1)
+        # learner updates at step 0 and step 2 (step is 0-based)
+        learner = get_learner_from_su(should_update_schedule_fn=lambda step: step % 2 == 0)
         # learner2 is a regular learner
         learner2 = get_learner_from_su()
         v_spec = ParameterSpec(


### PR DESCRIPTION
An UpdateTransformer that can pause learning at certain steps and resume learning from where it left off. Pausing and resuming is defined by a schedule function passed in `ConditionalUpdateTransformation.update_schedule`.

When used in a CompositeLearner, such learner can alternate training between multiple model branches, such as during GAN training.