### PR TITLE
Ignore pyenv version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,9 +87,7 @@ profile_default/
 ipython_config.py
 
 # pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.


### PR DESCRIPTION
Using pyenv to manage multiple python installations is common enough and the `.python-version` should be ignored from version control.