### PR TITLE
Set the logmel upper bound to the Nyquist frequency based on the sample rate.

### DIFF
--- a/axlearn/audio/frontend.py
+++ b/axlearn/audio/frontend.py
@@ -86,9 +86,22 @@ class BaseFrontend(BaseLayer):
 
 
 def _log_mel_spectrogram(
-    *, num_filters: int, sample_rate: int, fft_size: int, mel_floor: float
+    *,
+    num_filters: int,
+    sample_rate: int,
+    fft_size: int,
+    mel_floor: float,
+    lower_edge_hertz: float = 125.0,
+    upper_edge_hertz: Optional[float] = None,
 ) -> StageFn:
     """Returns a StageFn that computes Log Mel spectrogram."""
+    if upper_edge_hertz is None:
+        # When sample_rate=16k, upper_edge_hertz=7600 like Lingvo.
+        # If your filterbank has bins or filters close to Nyquist (e.g., a triangle filter peaking
+        # at 7900–8100 Hz), any response beyond 8000 Hz will wrap around and alias back into
+        # the signal.
+        # Reducing the upper edge to ~95% of Nyquist (e.g., 7600 Hz) creates a safety margin.
+        upper_edge_hertz = 0.95 * (sample_rate // 2)
 
     # Mel filterbank, used to convert magnitude spectrogram to mel spectrogram. Only needs to be
     # constructed once.
@@ -96,8 +109,8 @@ def _log_mel_spectrogram(
         num_filters=num_filters,
         num_spectrogram_bins=fft_size // 2 + 1,
         sample_rate=sample_rate,
-        lower_edge_hertz=125.0,
-        upper_edge_hertz=7600.0,
+        lower_edge_hertz=lower_edge_hertz,
+        upper_edge_hertz=upper_edge_hertz,
     )
 
     def fn(fft: Tensor, *, dtype: jnp.dtype) -> Tensor:

--- a/axlearn/audio/frontend_test.py
+++ b/axlearn/audio/frontend_test.py
@@ -76,10 +76,13 @@ class LogMelFrontendTest(parameterized.TestCase, tf.test.TestCase):
             dict(frame_size_ms=31.9375, hop_size_ms=10),
         ],
         pre_emphasis=[True, False],
+        sample_rate=[16_000, 24_000],
     )
     @pytest.mark.fp64
-    def test_against_ref(self, frame_size_ms, hop_size_ms, pre_emphasis):
-        sample_rate, batch_size, max_seconds = 16_000, 4, 13
+    def test_against_ref(self, frame_size_ms, hop_size_ms, pre_emphasis, sample_rate):
+        if sample_rate == 24_000 and frame_size_ms == 31.9375:
+            pytest.skip(reason="ms_to_samples is not integer in the case.")
+        batch_size, max_seconds = 4, 13
         num_filters = 80
 
         # Construct fake inputs.
@@ -100,7 +103,6 @@ class LogMelFrontendTest(parameterized.TestCase, tf.test.TestCase):
             coeff=0.97,
             num_filters=num_filters,
             lower_edge_hertz=125.0,
-            upper_edge_hertz=7600.0,
             mel_floor=1.0,
             pre_emphasis=pre_emphasis,
         )
@@ -371,7 +373,6 @@ def _ref_frontend(
     coeff: float,
     num_filters: int,
     lower_edge_hertz: float,
-    upper_edge_hertz: float,
     mel_floor: float,
     pre_emphasis: bool,
 ):
@@ -398,7 +399,7 @@ def _ref_frontend(
         num_filters=num_filters,
         sample_rate=sample_rate,
         lower_edge_hertz=lower_edge_hertz,
-        upper_edge_hertz=upper_edge_hertz,
+        upper_edge_hertz=0.95 * (sample_rate // 2),
         compute_energy=False,
         mel_floor=mel_floor,
     )

--- a/axlearn/experiments/testdata/axlearn.experiments.audio.conformer.librispeech_trainer/conformer-l-rnnt.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.audio.conformer.librispeech_trainer/conformer-l-rnnt.txt
@@ -520,6 +520,7 @@ model.encoder.feature.frontend.pre_emphasis.coeff: 0.97
 model.encoder.feature.frontend.pre_emphasis.fn: 'axlearn.audio.frontend._pre_emphasis'
 model.encoder.feature.frontend.sample_rate: 16000
 model.encoder.feature.frontend.spectrogram.fn: 'axlearn.audio.frontend._log_mel_spectrogram'
+model.encoder.feature.frontend.spectrogram.lower_edge_hertz: 125.0
 model.encoder.feature.klass: 'axlearn.audio.encoder_asr.SpeechFeatureLayer'
 model.encoder.feature.output_dim: 512
 model.encoder.feature.subsampler.activation: 'nn.relu'

--- a/axlearn/experiments/testdata/axlearn.experiments.audio.conformer.librispeech_trainer/conformer-test-ctc.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.audio.conformer.librispeech_trainer/conformer-test-ctc.txt
@@ -222,6 +222,7 @@ model.encoder.feature.frontend.pre_emphasis.coeff: 0.97
 model.encoder.feature.frontend.pre_emphasis.fn: 'axlearn.audio.frontend._pre_emphasis'
 model.encoder.feature.frontend.sample_rate: 16000
 model.encoder.feature.frontend.spectrogram.fn: 'axlearn.audio.frontend._log_mel_spectrogram'
+model.encoder.feature.frontend.spectrogram.lower_edge_hertz: 125.0
 model.encoder.feature.klass: 'axlearn.audio.encoder_asr.SpeechFeatureLayer'
 model.encoder.feature.output_dim: 4
 model.encoder.feature.subsampler.activation: 'nn.relu'


### PR DESCRIPTION
The previous value 7600 was hard-coded, corresponds to the Nyquist rate for 16kHz. For 24kHz, the upper bound should be different. This PR fixes 24kHz's the upper bound while no change for 16kHz.

There are currently no production models using 24kHz logmel. Experimental models will need to be retrained.

Authored by m_padinjaruveetti@apple.com