### PR TITLE
Adds env_id flag.

### DIFF
--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -132,7 +132,7 @@ from axlearn.cloud.common.utils import (
 )
 from axlearn.cloud.gcp import runners
 from axlearn.cloud.gcp.bundler import CloudBuildBundler
-from axlearn.cloud.gcp.config import default_project, default_zone, gcp_settings
+from axlearn.cloud.gcp.config import default_env_id, default_project, default_zone, gcp_settings
 from axlearn.cloud.gcp.jobs.bastion_vm import bastion_root_dir, shared_bastion_name
 from axlearn.cloud.gcp.jobs.launch_utils import (
     JobsToTableFn,
@@ -204,6 +204,7 @@ class BaseBastionManagedJob(FlagConfigurable):
         # Command to submit to the bastion.
         command: Optional[str] = None
         # Used along with project to identify `gcp_settings`.
+        # TODO(markblee): Move to where project/zone are defined and use `common_flags`.
         env_id: Optional[str] = None
         # Where to run the remote job.
         zone: Required[str] = REQUIRED
@@ -240,6 +241,12 @@ class BaseBastionManagedJob(FlagConfigurable):
         common_kwargs = dict(flag_values=fv, allow_override=True)
         bundler_flags(required=False, **common_kwargs)
         flags.DEFINE_string("name", None, "Name of the job.", **common_kwargs)
+        flags.DEFINE_string(
+            "env_id",
+            None,
+            "The env_id, used along with project to identify `gcp_settings`.",
+            **common_kwargs,
+        )
         flags.DEFINE_string("bastion", None, "Name of bastion VM to use.", **common_kwargs)
         flags.DEFINE_integer(
             "priority",
@@ -272,6 +279,7 @@ class BaseBastionManagedJob(FlagConfigurable):
         super().set_defaults(fv)
         # Don't override `name` if already specified, since the default is non-deterministic.
         fv.set_default("name", fv.name or generate_job_name())
+        fv.set_default("env_id", default_env_id())
 
     @classmethod
     def from_flags(

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -872,3 +872,22 @@ class MainTest(parameterized.TestCase):
             fv(argv)  # Parse flags.
             launch.main(argv, fv=fv)
             mock_instantiate.assert_called_once()
+
+    @parameterized.parameters(dict(argv=[]), dict(argv=["--env_id=test-env"]))
+    def test_list(self, argv):
+        argv = ["cli", "list", *argv]  # Don't run anything.
+        mock_job = mock.Mock()
+
+        def instantiate(cfg: BaseBastionManagedJob.Config):
+            self.assertIsNotNone(cfg.env_id)
+            return mock_job
+
+        patch_job = mock.patch.object(
+            BaseBastionManagedJob.Config, "instantiate", side_effect=instantiate, autospec=True
+        )
+        with mock.patch("sys.argv", argv), patch_job:
+            fv = flags.FlagValues()  # Don't modify global FLAGS.
+            _private_flags(fv)
+            fv(argv)  # Parse flags.
+            launch.main(argv, fv=fv)
+            self.assertTrue(mock_job.list.called)


### PR DESCRIPTION
So that `--env_id` can be provided to `axlearn gcp launch list`.