### PR TITLE
Upgrade grain version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## 0.1.6
 
 * Changes
-  * Upgrade Jax from 0.4.37 to 0.4.38
+  * Upgrade Jax from 0.4.37 to 0.4.38.
   * Removes all QRM (queued resource manager) codepaths from `axlearn.cloud.gcp`.
   * Introduces `named_runner_configs`. See `axlearn gcp launch --help` for details.
+  * Upgrade Grain from 0.2.3 to 0.2.7. This removes `input_grain.trim_and_pack_dataset`.
 
 ## 0.1.5
 

--- a/axlearn/common/input_grain.py
+++ b/axlearn/common/input_grain.py
@@ -41,7 +41,6 @@ from absl import logging
 from array_record.python.array_record_data_source import PathLikeOrFileInstruction
 from grain._src.python.data_loader import _determine_worker_count
 from grain._src.python.dataset import dataset as dataset_base
-from grain._src.python.dataset.transformations import packing
 from grain._src.python.dataset.transformations import slice as slice_dataset
 from jax.experimental import multihost_utils
 
@@ -394,28 +393,6 @@ def _ensure_iter_dataset(ds: Dataset):
             f"Expected a {grain.IterDataset.__name__}, got {type(ds)}. "
             f"Please use {maybe_to_iter_dataset.__name__} to convert the dataset."
         )
-
-
-def trim_and_pack_dataset(ds: Dataset, *, feature_lengths: utils.Nested[int]) -> Dataset:
-    """Similar to `seqio.trim_and_pack_dataset`.
-
-    Different from `seqio.trim_and_pack_dataset`, elements may be packed out of order if doing so
-    produces less padding. Further, elements may be truncated (with remainder dropped). See
-    `SingleBinPackIterDataset` in `grain` or test cases for details.
-
-    Args:
-        ds: A Dataset containing keys in `feature_lengths`.
-        feature_lengths: A (nested) mapping from of feature key to target length.
-            Packing will happen across 0th dimension. Features must be array-like.
-
-    Returns:
-        A Dataset with packed features. Similar to `seqio.trim_and_pack_dataset`, packing introduces
-        additional fields for each feature:
-        - `{feature}_segment_ids`: segment IDs for each packed example, where 0's represent padding;
-        - `{feature}_positions`: positions for each segment, where 0's represent padding.
-    """
-    _ensure_iter_dataset(ds)
-    return packing.SingleBinPackIterDataset(parent=ds, length_struct=feature_lengths)
 
 
 class _ShardDataset(slice_dataset.SliceMapDataset):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,9 +154,9 @@ orbax = [
     "humanize==4.10.0",
     "orbax-checkpoint==0.11.1",
 ]
-# Grain input processing. Currently does not support macos.
+# Grain input processing. 0.2.6 onwards supports macos.
 grain = [
-    "grain==0.2.3; platform_machine == 'x86_64'",
+    "grain==0.2.7",
 ]
 # Audio dependencies.
 audio = [


### PR DESCRIPTION
The update allows us to run grain tests locally on macos. 

`packing.SingleBinPackIterDataset` is removed in grain, so we remove `trim_and_pack_dataset`. (Not currently used.)