### PR TITLE
Makes logic in optimizers use 1-based steps.

### DIFF
--- a/axlearn/common/learner_test.py
+++ b/axlearn/common/learner_test.py
@@ -186,7 +186,7 @@ class LearnerTest(TestCase):
         )
         learning_rate_fn = schedule.as_schedule_fn(learning_rate)
         weight_decay = 1e-4
-        step = 0
+        step = 1
         sgd_cfg = config_for_function(sgd_optimizer).set(
             learning_rate=learning_rate,
             decouple_weight_decay=True,
@@ -315,9 +315,9 @@ class LearnerTest(TestCase):
         self.assertNestedAllClose(
             {
                 "learning_rate": learning_rate_fn(step),
-                "lr_schedule_step": 0,
+                "lr_schedule_step": step,
                 "gradient_norm": 1.0093285,
-                "schedule_step": 0,
+                "schedule_step": step,
                 "schedule_scale": -1.0 * learning_rate_fn(step),
             },
             summaries,
@@ -487,9 +487,9 @@ class LearnerTest(TestCase):
         self.assertNestedAllClose(
             {
                 "learning_rate": learning_rate_fn(step),
-                "lr_schedule_step": 0,
+                "lr_schedule_step": 1,
                 "gradient_norm": expected_grad_norm,
-                "schedule_step": 0,
+                "schedule_step": 1,
                 "schedule_scale": -1.0 * learning_rate_fn(step),
             },
             summaries["optimizer"],
@@ -649,13 +649,13 @@ class LearnerTest(TestCase):
         self.assertNestedAllClose(
             {
                 "optimizer/learning_rate": 1.0,
-                "optimizer/lr_schedule_step": 0,
+                "optimizer/lr_schedule_step": 1,
                 "optimizer/gradient_norm": jnp.sqrt(jnp.sum(2 * expected_grad**2)),
                 "param_rms/weight": jnp.sqrt((0 + 4 + 4 + 9) / 4),
                 "param_rms/moving_mean": 0.5,
                 "grad_rms/weight": jnp.sqrt(jnp.mean(expected_grad**2)),
                 "grad_rms/moving_mean": jnp.sqrt(jnp.mean(expected_grad**2)),
-                "optimizer/schedule_step": 0,
+                "optimizer/schedule_step": 1,
                 "optimizer/schedule_scale": -1.0,
             },
             output_collection.summaries,

--- a/axlearn/common/optimizers.py
+++ b/axlearn/common/optimizers.py
@@ -1314,7 +1314,6 @@ def skip_and_clip_by_global_norm(
 
     def update_fn(updates, state, params=None):
         inner_state = state.inner_state
-        count = state.count
         grad_norm_ema = state.grad_norm_ema
         grad_norm_square_ema = state.grad_norm_square_ema
         drop_stats = state.drop_stats
@@ -1373,7 +1372,7 @@ def skip_and_clip_by_global_norm(
                 drop_norm,
                 norm_ema=grad_norm_ema,
                 norm_square_ema=grad_norm_square_ema,
-                count=count,
+                count=state.count,
                 drop_stats=drop_stats,
             )
             is_valid_step = jnp.logical_and(is_finite, is_valid_step)
@@ -1390,8 +1389,8 @@ def skip_and_clip_by_global_norm(
         if use_adaptive_drop_norm:
             count_inc = jnp.where(
                 is_valid_step,
-                optax.safe_int32_increment(count),
-                count,
+                optax.safe_int32_increment(state.count),
+                state.count,
             )
             new_norm_ema, new_norm_square_ema = _moment(
                 g_norm, grad_norm_ema, grad_norm_square_ema, count_inc

--- a/axlearn/common/optimizers.py
+++ b/axlearn/common/optimizers.py
@@ -230,12 +230,12 @@ def scale_by_schedule(
     def update_fn(updates, state, params=None):
         del params
         count_inc = optax.safe_int32_increment(state.count)
-        scale = schedule_fn(count_inc)
+        step_size = schedule_fn(count_inc)
         context = current_context()
         if context:
             context.add_summary(summary_name_prefix + "schedule_step", count_inc)
-            context.add_summary(summary_name_prefix + "schedule_scale", scale)
-        updates = jax.tree.map(lambda g: jnp.array(scale, dtype=g.dtype) * g, updates)
+            context.add_summary(summary_name_prefix + "schedule_scale", step_size)
+        updates = jax.tree.map(lambda g: jnp.array(step_size, dtype=g.dtype) * g, updates)
         return updates, optax.ScaleByScheduleState(count=count_inc)
 
     return PartitionedGradientTransformation(

--- a/axlearn/common/optimizers_test.py
+++ b/axlearn/common/optimizers_test.py
@@ -1290,7 +1290,8 @@ class OptimizerTest(TestCase):
         )
         state = schedule_fn.init(params)
         update = jnp.array(5.0)
-        for i in range(max_step + 1):
+        # Note scale_by_schedule starts at step 1 (not step 0).
+        for i in range(1, max_step + 1):
             scaled_update, state = schedule_fn.update(update, state, params)
             if i < warmup_steps:
                 scale = peak_lr / warmup_steps * i

--- a/axlearn/common/schedule.py
+++ b/axlearn/common/schedule.py
@@ -167,8 +167,8 @@ def adafactor_decay_rate(c: float = 0.8, step_offset: int = 0) -> ScheduleFn:
     """
 
     def fn(step):
-        step = jnp.maximum(step - step_offset, 0)
-        return 1 - (step + 1) ** (-c)
+        step = jnp.maximum(step - step_offset, 1)
+        return 1 - step ** (-c)
 
     return fn
 
@@ -183,8 +183,8 @@ def decay_bias_correction(decay: float) -> ScheduleFn:
     """
 
     def fn(step):
-        t = jnp.asarray(step, dtype=jnp.float32) + 1.0
-        return decay * (1.0 - jnp.power(decay, t - 1.0)) / (1.0 - jnp.power(decay, t))
+        t = jnp.asarray(step, dtype=jnp.float32)
+        return decay * (1.0 - jnp.power(decay, t - 1)) / (1.0 - jnp.power(decay, t))
 
     return fn
 

--- a/axlearn/common/schedule_test.py
+++ b/axlearn/common/schedule_test.py
@@ -84,7 +84,7 @@ class ScheduleTest(parameterized.TestCase):
         samples = [3, 4, 1, 2, 4, 6, 8, 9]
         moment = 0
         for i, sample in enumerate(samples):
-            decay_i = s(i)
+            decay_i = s(i + 1)  # step starts from 1.
             moment = (1 - decay_i) * sample + decay_i * moment
             # Initially moment is an approximation of the mean value.
             self.assertAlmostEqual(moment, sum(samples[: i + 1]) / (i + 1), places=2)
@@ -220,7 +220,8 @@ class ScheduleTest(parameterized.TestCase):
         fn = adafactor_decay_rate(step_offset=100)
         self.assertAlmostEqual(fn(1), 0)
         self.assertAlmostEqual(fn(100), 0)
-        self.assertAlmostEqual(fn(200), 1 - (101) ** (-0.8))
+        self.assertAlmostEqual(fn(101), 0)
+        self.assertAlmostEqual(fn(200), 1 - (100) ** (-0.8))
 
     def test_ema_schedule(self):
         warmup_steps = 5


### PR DESCRIPTION
Resolves inconsistent definitions of "step" between SpmdTrainer and optimizers.

# Background

SpmdTrainer.step is used for summaries and checkpoints and defined as:
* step=0: the state after initialization. A checkpoint and summaries may be saved at step 0 to reflect the initial state before the first training step;
* step=n: summaries during the n'th training step and checkpoint (if any) saved after n steps

In optimizers, the use of steps are inconsistent. Most use 0-based steps, where the first training step uses the schedule value computed from count=0:
* `scale_by_schedule` (used for learning rate schedules)
* `add_decayed_weights`
* `param_ema` (different from `ema`)
* `skip_and_clip_by_global_norm` uses 0-based steps to compute the drop_norm threshold
* `decay_bias_correction` assumes a 0-based step

# Resolution

After discussion, we decided to change the optimizer logic to be consistent with SpmdTrainer.step. Specifically, we change `decay_bias_correction`, `adafactor_decay_rate`, `scale_by_schedule`, `add_decayed_weights`, `param_ema`, and `skip_and_clip_by_global_norm` to assume that the first step is 1.

This will make optimizer steps to be consistent with summary steps, e.g., the summary at step N will reflect the learning rate schedule computed for step N.