### PR TITLE
Split quota_path into two variables.

### DIFF
--- a/axlearn/cloud/common/quota.py
+++ b/axlearn/cloud/common/quota.py
@@ -11,7 +11,8 @@ import toml
 from axlearn.cloud.common.types import ProjectResourceMap, ResourceMap
 from axlearn.common.file_system import readfile
 
-QUOTA_CONFIG_PATH = "project-quotas/project-quotas.config"
+QUOTA_CONFIG_DIR = "project-quotas"
+QUOTA_CONFIG_FILE = "project-quotas.config"
 
 
 @dataclass

--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -29,7 +29,7 @@ from typing import Optional
 from absl import app, flags, logging
 
 from axlearn.cloud.common.bastion import bastion_job_flags
-from axlearn.cloud.common.quota import QUOTA_CONFIG_PATH, get_resource_limits
+from axlearn.cloud.common.quota import QUOTA_CONFIG_DIR, QUOTA_CONFIG_FILE, get_resource_limits
 from axlearn.cloud.common.utils import configure_logging, parse_action
 from axlearn.cloud.gcp.config import default_env_id, default_project, default_zone, gcp_settings
 from axlearn.cloud.gcp.utils import GCPAPI, catch_auth, common_flags
@@ -136,7 +136,8 @@ def quota_file(flag_values: flags.FlagValues) -> str:
         "gs://",
         gcp_settings("private_bucket", fv=flag_values),
         flag_values.name,
-        QUOTA_CONFIG_PATH,
+        QUOTA_CONFIG_DIR,
+        QUOTA_CONFIG_FILE,
     )
 
 

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -116,7 +116,7 @@ from axlearn.cloud.common.bastion import BastionDirectory
 from axlearn.cloud.common.bastion import Job as BastionJob
 from axlearn.cloud.common.bastion import new_jobspec, serialize_jobspec
 from axlearn.cloud.common.bundler import Bundler, bundler_flags, get_bundler_config
-from axlearn.cloud.common.quota import QUOTA_CONFIG_PATH, get_user_projects
+from axlearn.cloud.common.quota import QUOTA_CONFIG_DIR, QUOTA_CONFIG_FILE, get_user_projects
 from axlearn.cloud.common.scheduler import JobMetadata
 from axlearn.cloud.common.types import JobSpec, ResourceMap
 from axlearn.cloud.common.utils import (
@@ -373,8 +373,12 @@ class BaseBastionManagedJob(FlagConfigurable):
         if cfg.project_id:
             if not from_vm:
                 logging.warning("Supplying --project_id has no purpose if not running in bastion.")
-            quota_file = (
-                f"gs://{gcp_settings('private_bucket')}/{cfg.bastion_name}/{QUOTA_CONFIG_PATH}"
+            quota_file = os.path.join(
+                "gs://",
+                gcp_settings("private_bucket"),
+                cfg.bastion_name,
+                QUOTA_CONFIG_DIR,
+                QUOTA_CONFIG_FILE,
             )
             user_projects = get_user_projects(quota_file, user_id=cfg.user_id)
             if cfg.project_id.lower() not in user_projects:


### PR DESCRIPTION
Split `QUOTA_CONFIG_PATH` into directory and file name. This makes it easier to store other quota related info under the directeory.