### PR TITLE
Fix Splash Attention unittest for sliding window attention.

### DIFF
--- a/axlearn/common/flash_attention/layer_test.py
+++ b/axlearn/common/flash_attention/layer_test.py
@@ -552,7 +552,7 @@ class TestFlashAttention(TestCase):
             # When sliding window is enabled and q_len > kv_len, there might be be fully masked
             # rows. "custom" is also sliding window, but uses a different function to test support
             # for custom mask fns.
-            pytest.skip(reason="Sliding window attention does not make sense when q_len > kv_len.")
+            pytest.skip(reason="Sliding window attention does not make sense when q_len != kv_len.")
 
         if attn_type == "full":
             mask = None

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -139,6 +139,8 @@ class TestFlashAttention(TestCase):
         if jax.default_backend() == "cpu":
             # TODO(dhwang2): this has been broken for a while on CPU.
             pytest.skip(reason="Backward path is broken on CPU")
+        if mask not in (None, causal_mask) and query_length_multiplier > 1:
+            pytest.skip(reason="Sliding window attention does not make sense when q_len != kv_len.")
         # pylint: disable=protected-access
         fallback_to_legacy = per_head_dim % 128 != 0 or (attention_bias_type is not None)
         q, k, v, bias = generate_attention_data(


### PR DESCRIPTION
This is the same skip to
https://github.com/apple/axlearn/blob/89b5345f0159baebe5d1720d997d92fc8c4ecb66/axlearn/common/flash_attention/layer_test.py#L551

Note: The bias indicates which keys each query is allowed to attend to. If a query is not allowed to attend to any keys, then its output can technically be any arbitrary value. Splash attention returns NaN for those, while reference attentions returns avg value of values.

@lgayathrikolluru reported this issue.

TEST=test_forward_and_backward194