### PR TITLE
The dtype of `paddings` and `mask` is now `jnp.bool`.

### DIFF
--- a/axlearn/audio/decoder_asr.py
+++ b/axlearn/audio/decoder_asr.py
@@ -498,7 +498,7 @@ class CTCDecoderModel(BaseASRDecoderModel):
         max_decode_len = paddings.shape[-1] + 1
         beam_search_outputs = beam_search_decode(
             inputs=jnp.zeros_like(paddings),
-            time_step=jnp.zeros(paddings.shape[0], dtype=paddings.dtype),
+            time_step=jnp.zeros(paddings.shape[0], dtype=jnp.int32),
             cache={"time_step": jnp.array(0)},
             tokens_to_scores=self._tokens_to_scores(input_batch, num_decodes=num_decodes),
             num_decodes=num_decodes,
@@ -539,7 +539,7 @@ class CTCDecoderModel(BaseASRDecoderModel):
         max_decode_len = paddings.shape[-1] + 1
         sample_decode_outputs = sample_decode(
             inputs=jnp.zeros_like(paddings),
-            time_step=jnp.zeros(paddings.shape[0], dtype=paddings.dtype),
+            time_step=jnp.zeros(paddings.shape[0], dtype=jnp.int32),
             cache={"time_step": jnp.array(0)},
             tokens_to_scores=self._tokens_to_scores(
                 input_batch, num_decodes=num_decodes, logits_modifier=logits_modifier

--- a/axlearn/audio/frontend_utils_test.py
+++ b/axlearn/audio/frontend_utils_test.py
@@ -293,8 +293,11 @@ def _ref_framer(*, inputs: ArrayLike, paddings: ArrayLike, frame_size: int, fram
     https://github.com/tensorflow/lingvo/blob/4a9097a212622d99d7f8e2379804dbffdc44a97f/lingvo/tasks/asr/frontend.py#L404
     """
     outputs = tf.signal.frame(inputs, frame_size, frame_step, pad_end=True)
-    output_paddings = tf.signal.frame(paddings, frame_size, frame_step, pad_end=True)
-    output_paddings = tf.reduce_max(output_paddings, axis=2)
+    # tf.signal.frame doesn't support bool tensor.
+    output_paddings = tf.signal.frame(
+        tf.cast(paddings, tf.int8), frame_size, frame_step, pad_end=True
+    )
+    output_paddings = tf.cast(tf.reduce_max(output_paddings, axis=2), tf.bool)
     # Note: tf.signal.frame appends more padding than necessary.
     num_frames = frontend_utils.num_frames(
         inputs.shape[1], frame_size=frame_size, hop_size=frame_step

--- a/axlearn/audio/input_asr.py
+++ b/axlearn/audio/input_asr.py
@@ -52,7 +52,7 @@ def speech_input(
         lengths = tf.shape(inputs)[-1]
         inputs = input_tf_data.trim_and_pad_tensor(inputs, max_len=max_len)
         example["inputs"] = tf.cast(inputs, tf.float32)
-        example["paddings"] = tf.cast(tf.range(max_len) >= lengths, tf.int32)
+        example["paddings"] = tf.cast(tf.range(max_len) >= lengths, tf.bool)
         return example
 
     processors = []
@@ -196,7 +196,7 @@ def pad_example_fn(element_spec: Nested[Any]) -> Nested[Any]:
     """
     example = input_tf_data.default_pad_example_fn(element_spec)
     # Set source paddings to 1s.
-    example["source"]["paddings"] = tf.ones_like(example["source"]["paddings"], dtype=tf.int32)
+    example["source"]["paddings"] = tf.ones_like(example["source"]["paddings"], dtype=tf.bool)
     # Set text tokens to -1s.
     example["target"]["input_ids"] = -1 * tf.ones_like(
         example["target"]["input_ids"], dtype=tf.int32

--- a/axlearn/audio/test_utils.py
+++ b/axlearn/audio/test_utils.py
@@ -26,5 +26,5 @@ def fake_audio(
         dtype=jnp.float32,
     ).astype(dtype)
     lengths = jax.random.randint(length_key, shape=[batch_size, 1], minval=0, maxval=seq_len)
-    paddings = (jnp.arange(seq_len)[None, :] >= lengths).astype(jnp.int32)
+    paddings = (jnp.arange(seq_len)[None, :] >= lengths).astype(jnp.bool)
     return inputs, paddings

--- a/axlearn/common/quantizer.py
+++ b/axlearn/common/quantizer.py
@@ -400,9 +400,7 @@ class RandomVectorQuantizer(BaseQuantizer):
             quantized_vectors=quantized_vectors,
         )
 
-        onehots = _ids_to_onehots(
-            outputs.ids, codebook_size=cfg.codebook_size, dtype=paddings.dtype
-        )
+        onehots = _ids_to_onehots(outputs.ids, codebook_size=cfg.codebook_size, dtype=jnp.int32)
         _add_codebook_summaries(context=current_context(), onehots=onehots, paddings=paddings)
         return outputs
 
@@ -548,9 +546,7 @@ class KmeansVectorQuantizer(BaseQuantizer):
             ),
             loss=total_loss,
         )
-        onehots = _ids_to_onehots(
-            outputs.ids, codebook_size=cfg.codebook_size, dtype=paddings.dtype
-        )
+        onehots = _ids_to_onehots(outputs.ids, codebook_size=cfg.codebook_size, dtype=jnp.int32)
         _add_codebook_summaries(context=current_context(), onehots=onehots, paddings=paddings)
         return outputs
 
@@ -668,9 +664,7 @@ class GumbelSoftmaxVectorQuantizer(BaseQuantizer):
                 quantized_vectors=quantized_vectors,
             )
 
-        onehots = _ids_to_onehots(
-            outputs.ids, codebook_size=cfg.codebook_size, dtype=paddings.dtype
-        )
+        onehots = _ids_to_onehots(outputs.ids, codebook_size=cfg.codebook_size, dtype=jnp.int32)
         _add_codebook_summaries(context=current_context(), onehots=onehots, paddings=paddings)
         if self.is_training:
             self.add_module_output("probs", y_soft)

--- a/axlearn/common/quantizer_test.py
+++ b/axlearn/common/quantizer_test.py
@@ -87,7 +87,7 @@ class HelpersTest(TestCase):
                 inputs=inputs, codebook=codebook, metric=metric
             )
             # Compute codebook metrics.
-            onehots = _ids_to_onehots(q_outputs.ids, codebook_size=vocab_size, dtype=paddings.dtype)
+            onehots = _ids_to_onehots(q_outputs.ids, codebook_size=vocab_size, dtype=jnp.int32)
             coverage = compute_code_coverage(onehots=onehots, paddings=paddings)
             pplx, entropy = compute_code_pplx(onehots=onehots, paddings=paddings)
 

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -1947,7 +1947,7 @@ class DeviceUsage:
     hbm_memory_bandwidth_utilization: Optional[float] = None
 
 
-def sequence_mask(*, lengths: Tensor, max_len: int, dtype: Optional[jnp.dtype] = None) -> Tensor:
+def sequence_mask(*, lengths: Tensor, max_len: int, dtype: jnp.dtype = jnp.bool) -> Tensor:
     """Computes a mask over sequence positions for each given length.
 
     Args:
@@ -1958,9 +1958,6 @@ def sequence_mask(*, lengths: Tensor, max_len: int, dtype: Optional[jnp.dtype] =
     Returns:
         Tensor [..., T]. 1 is valid and 0 is padding.
     """
-    if dtype is None:
-        dtype = lengths.dtype
-
     prefix_axis = tuple(range(lengths.ndim))
     # [..., T]
     sequence = jnp.expand_dims(jnp.arange(max_len), axis=prefix_axis)

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -933,7 +933,7 @@ class TreeUtilsTest(TestCase):
         self.assertEqual(out, primary)
 
     @parameterized.parameters(
-        dict(lengths=[3, 4], dtype=None, expected=[[1, 1, 1, 0, 0], [1, 1, 1, 1, 0]]),
+        dict(lengths=[3, 4], dtype=jnp.bool, expected=[[1, 1, 1, 0, 0], [1, 1, 1, 1, 0]]),
         dict(lengths=[3, 4], dtype=jnp.int32, expected=[[1, 1, 1, 0, 0], [1, 1, 1, 1, 0]]),
         dict(lengths=[3, 4], dtype=jnp.float32, expected=[[1, 1, 1, 0, 0], [1, 1, 1, 1, 0]]),
         dict(lengths=[[3], [4]], dtype=jnp.int32, expected=[[[1, 1, 1, 0, 0]], [[1, 1, 1, 1, 0]]]),
@@ -942,7 +942,7 @@ class TreeUtilsTest(TestCase):
     def test_sequence_mask(self, lengths, dtype, expected):
         max_len = 5
         mask = utils.sequence_mask(lengths=jnp.array(lengths), max_len=max_len, dtype=dtype)
-        expected = jnp.array(expected).astype(dtype if dtype else jnp.int32)
+        expected = jnp.array(expected).astype(dtype)
         self.assertNestedAllClose(mask, expected)
 
     def test_prune_empty_state(self):

--- a/axlearn/experiments/audio/conformer/common_test.py
+++ b/axlearn/experiments/audio/conformer/common_test.py
@@ -75,8 +75,7 @@ class ConfigTest(TestCase):
             self.assertTrue(
                 tf.reduce_all(
                     tf.logical_or(
-                        ex["source"]["paddings"] == 0,
-                        ex["source"]["paddings"] == 1,
+                        tf.math.logical_not(ex["source"]["paddings"]), ex["source"]["paddings"]
                     )
                 )
             )

--- a/axlearn/vision/beit_image_tokenizer.py
+++ b/axlearn/vision/beit_image_tokenizer.py
@@ -190,7 +190,7 @@ class BEiTImageVQKD(BaseLayer):
             quantized_output.ids,
             num_classes=self.config.quantizer.codebook_size,
             axis=-1,
-            dtype=paddings.dtype,
+            dtype=jnp.int32,
         )
         return jnp.squeeze(quantized_output.ids, axis=-1), {
             "quantized_vectors": jnp.squeeze(quantized_output.quantized_vectors, axis=-2),


### PR DESCRIPTION
Previously, it was typically `int32`, but since `paddings` only store 0/1 values, that's redundant. We prefer to use `jnp.bool`, which uses only 1 byte. For reference, paddings are currently used inconsistently across the codebase; some places use int32, others float32, and elsewhere bool. This PR standardizes all of them to bool.

Additionally, **XLA may store booleans as 1 bit per value on TPU via bit-packing** (though this is not officially documented).

When switching paddings from `int32` to `bool`, the following improvements in memory and runtime were observed:
- **HBM usage**: 86,242.00 MiB → 86,232.91 MiB
- **Step time** (measured 3 times): 1,345,702,414 ± 128,038 ns → 1,345,565,230 ± 136,309 ns

* int32 paddings: 
![image](https://github.com/user-attachments/assets/937fac0e-f5b5-4ef9-a6d6-766c083e75c8)

* bool paddings:
![image](https://github.com/user-attachments/assets/69bae5dd-5db6-43cf-9a7d-178c44caaf69)
