### PR TITLE
[Convolution] Add support for grouped ConvTranspose

### DIFF
--- a/axlearn/common/convolution.py
+++ b/axlearn/common/convolution.py
@@ -24,12 +24,16 @@ ConvPaddingType = Union[str, Sequence[tuple[int, int]]]
 SUPPORT_CONV_PADDING = ("SAME", "VALID", "CAUSAL")
 
 
+# TODO(yuanliu939): Make this take `BaseConv.Config` directly.
 def _check_conv_cfg(
     *,
     window: Sequence[int],
     strides: Sequence[int],
     padding: ConvPaddingType,
     dilation: Optional[Sequence[int]],
+    input_dim: int,
+    output_dim: int,
+    num_input_dim_groups: int,
 ):
     if any(w < 1 for w in window):
         raise ValueError(f"window ({window}) must be a positive integer.")
@@ -48,13 +52,36 @@ def _check_conv_cfg(
     if dilation is not None and any(d < 1 for d in dilation):
         raise ValueError(f"dilation ({dilation}) must be a positive integer.")
 
+    if input_dim % num_input_dim_groups != 0:
+        raise ValueError(
+            f"input_dim ({input_dim}) must be divisible by "
+            f"num_input_dim_groups({num_input_dim_groups})."
+        )
+
+    if output_dim % num_input_dim_groups != 0:
+        raise ValueError(
+            f"output_dim ({output_dim}) must be divisible by "
+            f"num_input_dim_groups({num_input_dim_groups})."
+        )
+
 
 class BaseConv(BaseLayer):
     """Base class for convolution layers."""
 
     @config_class
     class Config(BaseLayer.Config):
+        """Config class for BaseConv."""
+
         input_dim: Required[int] = REQUIRED  # Input feature dim.
+        # The number of groups in which the input is split along the channel axis.
+        # input_dim and output_dim must both be divisible by num_input_dim_groups. For example,
+        # - At num_input_dim_groups=1, all inputs are convolved to all outputs (the default).
+        # - At num_input_dim_groups=2, the operation is equivalent to concatenating two conv layers
+        #   side by side, each seeing half the input and producing half the output channels.
+        # - At num_input_dim_groups=input_dim, each input channel is convolved with its own
+        #   set of filters (of size output_dim / input_dim); if further output_dim == K * input_dim,
+        #   where K is a positive integer, the operation is also known as a "depthwise convolution".
+        num_input_dim_groups: int = 1
 
     # pylint: disable-next=no-self-use
     def _compute_fan_axes(self, name: str, parameter_spec: ParameterSpec) -> Optional[FanAxes]:
@@ -324,15 +351,6 @@ class Conv1D(BaseConv):
         padding: ConvPaddingType = ((0, 0),)
         output_dim: Required[int] = REQUIRED  # Output feature dim.
         bias: bool = True  # Whether to add a bias.
-        # The number of groups in which the input is split along the channel axis.
-        # input_dim and output_dim must both be divisible by num_input_dim_groups. For example,
-        # - At num_input_dim_groups=1, all inputs are convolved to all outputs (the default).
-        # - At num_input_dim_groups=2, the operation is equivalent to concatenating two conv layers
-        #   side by side, each seeing half the input and producing half the output channels.
-        # - At num_input_dim_groups=input_dim, each input channel is convolved with its own
-        #   set of filters (of size output_dim / input_dim); if further output_dim == K * input_dim,
-        #   where K is a positive integer, the operation is also known as a "depthwise convolution".
-        num_input_dim_groups: Optional[int] = 1
         # The convolution dilation, indicating dilation factor applied to the weight. It is also
         # known as atrous convolution or dilated convolution. If None, assume 1.
         dilation: Optional[int] = None
@@ -351,6 +369,9 @@ class Conv1D(BaseConv):
             strides=(cfg.strides,),
             padding=cfg.padding,
             dilation=(dilation,),
+            input_dim=cfg.input_dim,
+            output_dim=cfg.output_dim,
+            num_input_dim_groups=cfg.num_input_dim_groups,
         )
         if cfg.padding not in SUPPORT_CONV_PADDING:
             left, right = cfg.padding[0]
@@ -495,15 +516,6 @@ class Conv2D(BaseConv):
         dilation: Optional[tuple[int, int]] = None
         output_dim: Required[int] = REQUIRED  # Output feature dim.
         bias: bool = True  # Whether to add a bias.
-        # The number of groups in which the input is split along the channel axis.
-        # input_dim and output_dim must both be divisible by num_input_dim_groups. For example,
-        # - At num_input_dim_groups=1, all inputs are convolved to all outputs (the default).
-        # - At num_input_dim_groups=2, the operation is equivalent to concatenating two conv layers
-        #   side by side, each seeing half the input and producing half the output channels.
-        # - At num_input_dim_groups=input_dim, each input channel is convolved with its own
-        #   set of filters (of size output_dim / input_dim); if further output_dim == K * input_dim,
-        #   where K is a positive integer, the operation is also known as a "depthwise convolution".
-        num_input_dim_groups: Optional[int] = 1
 
     @classmethod
     def default_config(cls):
@@ -514,7 +526,13 @@ class Conv2D(BaseConv):
     def _create_layer_parameter_specs(self) -> dict[str, ParameterSpec]:
         cfg = self.config
         _check_conv_cfg(
-            window=cfg.window, strides=cfg.strides, padding=cfg.padding, dilation=cfg.dilation
+            window=cfg.window,
+            strides=cfg.strides,
+            padding=cfg.padding,
+            dilation=cfg.dilation,
+            input_dim=cfg.input_dim,
+            output_dim=cfg.output_dim,
+            num_input_dim_groups=cfg.num_input_dim_groups,
         )
         params = dict(
             weight=ParameterSpec(
@@ -725,16 +743,6 @@ class Conv3D(BaseConv):
         output_dim: Required[int] = REQUIRED  # Output feature dim.
         bias: bool = True  # Whether to add a bias.
 
-        # The number of groups in which the input is split along the channel axis.
-        # input_dim and output_dim must both be divisible by num_input_dim_groups. For example,
-        # - At num_input_dim_groups=1, all inputs are convolved to all outputs (the default).
-        # - At num_input_dim_groups=2, the operation is equivalent to concatenating two conv layers
-        #   side by side, each seeing half the input and producing half the output channels.
-        # - At num_input_dim_groups=input_dim, each input channel is convolved with its own
-        #   set of filters (of size output_dim / input_dim); if further output_dim == K * input_dim,
-        #   where K is a positive integer, the operation is also known as a "depthwise convolution".
-        num_input_dim_groups: Optional[int] = 1
-
     @classmethod
     def default_config(cls):
         cfg = super().default_config()
@@ -744,7 +752,13 @@ class Conv3D(BaseConv):
     def _create_layer_parameter_specs(self) -> dict[str, ParameterSpec]:
         cfg = self.config
         _check_conv_cfg(
-            window=cfg.window, strides=cfg.strides, padding=cfg.padding, dilation=cfg.dilation
+            window=cfg.window,
+            strides=cfg.strides,
+            padding=cfg.padding,
+            dilation=cfg.dilation,
+            input_dim=cfg.input_dim,
+            output_dim=cfg.output_dim,
+            num_input_dim_groups=cfg.num_input_dim_groups,
         )
         params = dict(
             weight=ParameterSpec(
@@ -1347,7 +1361,6 @@ class Conv1DTranspose(BaseConv):
         dilation: int = 1  # Dilation for dilated Convolution.
         output_dim: Required[int] = REQUIRED  # Output feature dim.
         bias: bool = True  # Whether to add a bias.
-
         # An optional integer in the range of [0, window)
         # that specifies the anchor position within the convolution window that is used to
         # determine output paddings. Specifically, the output token is valid iff the input token
@@ -1368,10 +1381,13 @@ class Conv1DTranspose(BaseConv):
             strides=(cfg.strides,),
             padding=cfg.padding,
             dilation=(cfg.dilation,),
+            input_dim=cfg.input_dim,
+            output_dim=cfg.output_dim,
+            num_input_dim_groups=cfg.num_input_dim_groups,
         )
         params = dict(
             weight=ParameterSpec(
-                shape=(cfg.window, cfg.input_dim, cfg.output_dim),
+                shape=(cfg.window, cfg.input_dim // cfg.num_input_dim_groups, cfg.output_dim),
                 mesh_axes=cfg.param_partition_spec,
                 factorization=FactorizationSpec(axes=(None, "row", "col")),
             )
@@ -1426,13 +1442,15 @@ class Conv1DTranspose(BaseConv):
         dilation: Sequence[int],
     ) -> Tensor:
         cfg = self.config
-        output = jax.lax.conv_transpose(
+        output = jax.lax.conv_general_dilated(
             lhs=x,
             rhs=self.parameters["weight"],
-            strides=strides,
+            window_strides=(1,),
             padding=padding,
+            lhs_dilation=strides,
             rhs_dilation=dilation,
             dimension_numbers=("NWC", "WIO", "NWC"),
+            feature_group_count=cfg.num_input_dim_groups,
         )
         if cfg.bias:
             output += self.parameters["bias"]
@@ -1490,12 +1508,18 @@ class Conv2DTranspose(BaseConv):
     def _create_layer_parameter_specs(self) -> dict[str, ParameterSpec]:
         cfg = self.config
         _check_conv_cfg(
-            window=cfg.window, strides=cfg.strides, padding=cfg.padding, dilation=cfg.dilation
+            window=cfg.window,
+            strides=cfg.strides,
+            padding=cfg.padding,
+            dilation=cfg.dilation,
+            input_dim=cfg.input_dim,
+            output_dim=cfg.output_dim,
+            num_input_dim_groups=cfg.num_input_dim_groups,
         )
         if cfg.transpose_kernel:
-            io_shape = (cfg.output_dim, cfg.input_dim)
+            io_shape = (cfg.output_dim, cfg.input_dim // cfg.num_input_dim_groups)
         else:
-            io_shape = (cfg.input_dim, cfg.output_dim)
+            io_shape = (cfg.input_dim // cfg.num_input_dim_groups, cfg.output_dim)
         params = dict(
             weight=ParameterSpec(
                 shape=tuple(cfg.window) + io_shape,
@@ -1525,14 +1549,25 @@ class Conv2DTranspose(BaseConv):
         dilation: Sequence[int],
     ) -> Tensor:
         cfg = self.config
-        output = jax.lax.conv_transpose(
+
+        rhs = self.parameters["weight"]
+        # Since `jax.lax.conv_general_dilated` does not support transpose_kernel yet,
+        # we transpose kernel here.
+        if cfg.transpose_kernel:
+            # Flip spatial dims
+            rhs = jnp.flip(rhs, axis=(0, 1))
+            # Swap input / output channel axes
+            rhs = rhs.swapaxes(2, 3)
+
+        output = jax.lax.conv_general_dilated(
             lhs=x,
-            rhs=self.parameters["weight"],
-            strides=strides,
+            rhs=rhs,
+            window_strides=(1, 1),
             padding=padding,
+            lhs_dilation=strides,
             rhs_dilation=dilation,
             dimension_numbers=("NHWC", "HWIO", "NHWC"),
-            transpose_kernel=cfg.transpose_kernel,
+            feature_group_count=cfg.num_input_dim_groups,
         )
         if cfg.bias:
             output += self.parameters["bias"]
@@ -1640,11 +1675,17 @@ class Conv3DTranspose(BaseConv):
     def _create_layer_parameter_specs(self) -> dict[str, ParameterSpec]:
         cfg = self.config
         _check_conv_cfg(
-            window=cfg.window, strides=cfg.strides, padding=cfg.padding, dilation=cfg.dilation
+            window=cfg.window,
+            strides=cfg.strides,
+            padding=cfg.padding,
+            dilation=cfg.dilation,
+            input_dim=cfg.input_dim,
+            output_dim=cfg.output_dim,
+            num_input_dim_groups=cfg.num_input_dim_groups,
         )
         params = dict(
             weight=ParameterSpec(
-                shape=cfg.window + (cfg.input_dim, cfg.output_dim),
+                shape=cfg.window + (cfg.input_dim // cfg.num_input_dim_groups, cfg.output_dim),
                 mesh_axes=cfg.param_partition_spec,
                 factorization=FactorizationSpec(axes=(None, None, None, "row", "col")),
             )
@@ -1671,13 +1712,15 @@ class Conv3DTranspose(BaseConv):
         dilation: Sequence[int],
     ) -> Tensor:
         cfg = self.config
-        output = jax.lax.conv_transpose(
+        output = jax.lax.conv_general_dilated(
             lhs=x,
             rhs=self.parameters["weight"],
-            strides=strides,
+            window_strides=(1, 1, 1),
             padding=padding,
+            lhs_dilation=strides,
             rhs_dilation=dilation,
             dimension_numbers=("NHWDC", "HWDIO", "NHWDC"),
+            feature_group_count=cfg.num_input_dim_groups,
         )
         if cfg.bias:
             output += self.parameters["bias"]

--- a/axlearn/common/convolution_test.py
+++ b/axlearn/common/convolution_test.py
@@ -13,11 +13,13 @@ from jax import numpy as jnp
 from axlearn.common import convolution, einops, utils
 from axlearn.common.convolution import (
     Conv1D,
+    Conv1DTranspose,
     Conv1DWithPadding,
     Conv2D,
     Conv2DTranspose,
     Conv2DWith1DPadding,
     Conv3D,
+    Conv3DTranspose,
     ConvPaddingType,
     StackOverTime,
     compute_conv_paddings,
@@ -1239,6 +1241,99 @@ class ConvTransposeTest(TestCase):
         expected = jnp.array(expected).astype(outputs.dtype)
         self.assertNestedEqual(outputs[0, :, 0], expected)
 
+    @parameterized.named_parameters(
+        {
+            "testcase_name": "1D_W2_S1",
+            "window": 2,
+            "strides": 1,
+            "padding": "VALID",
+        },
+        {
+            "testcase_name": "1D_W2_S2",
+            "window": 2,
+            "strides": 2,
+            "padding": "VALID",
+        },
+        {
+            "testcase_name": "1D_W3_S2",
+            "window": 3,
+            "strides": 2,
+            "padding": "VALID",
+        },
+    )
+    def test_conv1d_transpose_grouped_against_pytorch(
+        self,
+        window: int,
+        strides: int,
+        padding: str,
+    ):
+        input_dim, output_dim, groups = 78, 52, 13
+        deconv_padding = padding
+        cfg = Conv1DTranspose.default_config().set(
+            name="test",
+            input_dim=input_dim,
+            output_dim=output_dim,
+            window=window,
+            strides=strides,
+            padding=deconv_padding,
+            num_input_dim_groups=groups,
+        )
+        layer: Conv1DTranspose = cfg.instantiate(parent=None)
+
+        # Initialize layer parameters.
+        prng_key = jax.random.PRNGKey(123)
+        prng_key, init_key = jax.random.split(prng_key)
+        layer_params = layer.initialize_parameters_recursively(init_key)
+        self.assertEqual(
+            dict(
+                weight=(window, input_dim // groups, output_dim),
+                bias=(output_dim,),
+            ),
+            shapes(layer_params),
+        )
+        bias = layer_params["bias"]
+        assert_allclose(bias, jnp.zeros_like(bias))
+        # Randomize bias.
+        layer_params["bias"] = jax.random.normal(
+            jax.random.PRNGKey(45), shape=bias.shape, dtype=bias.dtype
+        )
+
+        # Random inputs.
+        prng_key, input_key = jax.random.split(prng_key)
+        inputs = jax.random.normal(input_key, [2, 11, input_dim])
+        # Compute layer outputs.
+        (outputs, _), _ = F(
+            layer,
+            inputs=(inputs,),
+            is_training=True,
+            state=layer_params,
+            prng_key=prng_key,
+        )
+
+        ref = torch.nn.ConvTranspose1d(
+            in_channels=input_dim,
+            out_channels=output_dim,
+            kernel_size=window,
+            stride=strides,
+            padding=0,
+            groups=groups,
+        )
+        # torch.nn.ConvTranspose1d shape: (I, O//G, k0).
+        weight = layer_params["weight"]  # (k0, I//G, O)
+        k0, _, _ = weight.shape
+        weight = jnp.reshape(weight, (k0, input_dim // groups, groups, output_dim // groups))
+        weight = jnp.transpose(weight, (0, 2, 1, 3))
+        weight = jnp.reshape(weight, (k0, input_dim, output_dim // groups))
+        # Flip spatial dim
+        weight = jnp.flip(weight, axis=0)
+        _copy(weight.transpose(1, 2, 0), ref.weight)
+        _copy(layer_params["bias"], ref.bias)
+        ref_outputs = ref(as_torch_tensor(inputs.transpose(0, 2, 1)))
+        assert_allclose(outputs, ref_outputs.detach().numpy().transpose(0, 2, 1))
+        # Tests output_shape.
+        output_shape = layer.output_shape(input_shape=inputs.shape)
+        assert_allclose(outputs.shape, output_shape)
+
     @parameterized.parameters(*CONVT_PARAMS)
     def test_conv2d_transpose_simple(self, window, strides, padding, dilation, expected):
         """Tests the cases in conv_transpose_explicit_padding() description."""
@@ -1370,6 +1465,111 @@ class ConvTransposeTest(TestCase):
         output_shape = layer.output_shape(input_shape=inputs.shape)
         assert_allclose(outputs.shape, output_shape)
 
+    @parameterized.named_parameters(
+        {
+            "testcase_name": "2x2",
+            "window": (2, 2),
+            "strides": (1, 1),
+            "padding": "VALID",
+        },
+        {
+            "testcase_name": "2x2_S2",
+            "window": (2, 2),
+            "strides": (2, 2),
+            "padding": "VALID",
+        },
+        {
+            "testcase_name": "3x3_S2",
+            "window": (3, 3),
+            "strides": (2, 2),
+            "padding": "VALID",
+        },
+    )
+    def test_conv2d_transpose_grouped_against_pytorch(
+        self,
+        window: tuple[int, int],
+        strides: tuple[int, int],
+        padding: Union[str, tuple[int, int]],
+    ):
+        input_dim, output_dim, groups = 78, 52, 13
+        if isinstance(padding, tuple):
+            deconv_padding = ((padding[0], padding[0]), (padding[1], padding[1]))
+        else:
+            deconv_padding = padding
+        cfg = Conv2DTranspose.default_config().set(
+            name="test",
+            input_dim=input_dim,
+            output_dim=output_dim,
+            window=window,
+            strides=strides,
+            padding=deconv_padding,
+            transpose_kernel=True,
+            num_input_dim_groups=groups,
+        )
+        layer: Conv2DTranspose = cfg.instantiate(parent=None)
+
+        # Initialize layer parameters.
+        prng_key = jax.random.PRNGKey(123)
+        prng_key, init_key = jax.random.split(prng_key)
+        layer_params = layer.initialize_parameters_recursively(init_key)
+        self.assertEqual(
+            dict(
+                weight=(window[0], window[1], output_dim, input_dim // groups),
+                bias=(output_dim,),
+            ),
+            shapes(layer_params),
+        )
+        bias = layer_params["bias"]
+        assert_allclose(bias, jnp.zeros_like(bias))
+        # Randomize bias.
+        layer_params["bias"] = jax.random.normal(
+            jax.random.PRNGKey(45), shape=bias.shape, dtype=bias.dtype
+        )
+
+        # Random inputs.
+        prng_key, input_key = jax.random.split(prng_key)
+        inputs = jax.random.normal(input_key, [2, 11, 7, input_dim])
+        # Compute layer outputs.
+        outputs, _ = F(
+            layer,
+            inputs=(inputs,),
+            is_training=True,
+            state=layer_params,
+            prng_key=prng_key,
+        )
+
+        # Compute ref outputs.
+        if isinstance(padding, tuple):
+            ref_padding = padding[0]
+        elif isinstance(padding, str):
+            ref_padding = padding.lower()
+            if ref_padding == "valid":
+                ref_padding = 0
+        else:
+            ref_padding = 0
+
+        ref = torch.nn.ConvTranspose2d(
+            in_channels=input_dim,
+            out_channels=output_dim,
+            kernel_size=window,
+            stride=strides,
+            padding=ref_padding,
+            groups=groups,
+        )
+        # torch.nn.ConvTranspose2d shape: (I, O//G, k0, k1).
+        weight = layer_params["weight"]  # (k0, k1, O, I//G)
+        k0, k1, _, _ = weight.shape
+        weight = jnp.reshape(weight, (k0, k1, groups, output_dim // groups, input_dim // groups))
+        weight = jnp.transpose(weight, (0, 1, 3, 2, 4))
+        weight = jnp.reshape(weight, (k0, k1, output_dim // groups, input_dim))
+        _copy(weight.transpose(3, 2, 0, 1), ref.weight)
+        _copy(layer_params["bias"], ref.bias)
+        ref_outputs = ref(as_torch_tensor(inputs.transpose(0, 3, 1, 2)))
+        assert_allclose(outputs, ref_outputs.detach().numpy().transpose(0, 2, 3, 1))
+        # Tests output_shape.
+        output_shape = layer.output_shape(input_shape=inputs.shape)
+        assert_allclose(outputs.shape, output_shape)
+
     @parameterized.parameters(*CONVT_PARAMS)
     def test_conv3d_transpose_simple(self, window, strides, padding, dilation, expected):
         """Tests the cases in conv_transpose_explicit_padding() description."""
@@ -1402,6 +1602,114 @@ class ConvTransposeTest(TestCase):
         assert_allclose(outputs.shape, out_shape)
         expected = jnp.array(expected).astype(outputs.dtype)
         self.assertNestedEqual(outputs[0, :, 0, 0, 0], expected)
+
+    @parameterized.named_parameters(
+        {
+            "testcase_name": "2x2x2",
+            "window": (2, 2, 2),
+            "strides": (1, 1, 1),
+            "padding": "VALID",
+        },
+        {
+            "testcase_name": "2x2x2_S2",
+            "window": (2, 2, 2),
+            "strides": (2, 2, 2),
+            "padding": "VALID",
+        },
+        {
+            "testcase_name": "3x3_S2",
+            "window": (3, 3, 3),
+            "strides": (2, 2, 2),
+            "padding": "VALID",
+        },
+    )
+    def test_conv3d_transpose_grouped_against_pytorch(
+        self,
+        window: tuple[int, int],
+        strides: tuple[int, int],
+        padding: Union[str, tuple[int, int]],
+    ):
+        input_dim, output_dim, groups = 78, 52, 13
+        if isinstance(padding, tuple):
+            deconv_padding = ((padding[0], padding[0]), (padding[1], padding[1]))
+        else:
+            deconv_padding = padding
+        cfg = Conv3DTranspose.default_config().set(
+            name="test",
+            input_dim=input_dim,
+            output_dim=output_dim,
+            window=window,
+            strides=strides,
+            padding=deconv_padding,
+            num_input_dim_groups=groups,
+        )
+        layer: Conv3DTranspose = cfg.instantiate(parent=None)
+
+        # Initialize layer parameters.
+        prng_key = jax.random.PRNGKey(123)
+        prng_key, init_key = jax.random.split(prng_key)
+        layer_params = layer.initialize_parameters_recursively(init_key)
+        self.assertEqual(
+            dict(
+                weight=(window[0], window[1], window[2], input_dim // groups, output_dim),
+                bias=(output_dim,),
+            ),
+            shapes(layer_params),
+        )
+        bias = layer_params["bias"]
+        assert_allclose(bias, jnp.zeros_like(bias))
+        # Randomize bias.
+        layer_params["bias"] = jax.random.normal(
+            jax.random.PRNGKey(45), shape=bias.shape, dtype=bias.dtype
+        )
+
+        # Random inputs.
+        prng_key, input_key = jax.random.split(prng_key)
+        inputs = jax.random.normal(input_key, [2, 10, 7, 17, input_dim])
+        # Compute layer outputs.
+        outputs, _ = F(
+            layer,
+            inputs=(inputs,),
+            is_training=True,
+            state=layer_params,
+            prng_key=prng_key,
+        )
+
+        # Compute ref outputs.
+        if isinstance(padding, tuple):
+            ref_padding = padding[0]
+        elif isinstance(padding, str):
+            ref_padding = padding.lower()
+            if ref_padding == "valid":
+                ref_padding = 0
+        else:
+            ref_padding = 0
+
+        ref = torch.nn.ConvTranspose3d(
+            in_channels=input_dim,
+            out_channels=output_dim,
+            kernel_size=window,
+            stride=strides,
+            padding=ref_padding,
+            groups=groups,
+        )
+        # torch.nn.ConvTranspose3d shape: (I, O//G, k0, k1, k2).
+        weight = layer_params["weight"]  # (k0, k1, k2, O, I//G)
+        k0, k1, k2, _, _ = weight.shape
+        weight = jnp.reshape(
+            weight, (k0, k1, k2, input_dim // groups, groups, output_dim // groups)
+        )
+        weight = jnp.transpose(weight, (0, 1, 2, 4, 3, 5))
+        weight = jnp.reshape(weight, (k0, k1, k2, input_dim, output_dim // groups))
+        # Flip spatial dims
+        weight = jnp.flip(weight, axis=(0, 1, 2))
+        _copy(weight.transpose(3, 4, 0, 1, 2), ref.weight)
+        _copy(layer_params["bias"], ref.bias)
+        ref_outputs = ref(as_torch_tensor(inputs.transpose(0, 4, 1, 2, 3)))
+        assert_allclose(outputs, ref_outputs.detach().numpy().transpose(0, 2, 3, 4, 1))
+        # Tests output_shape.
+        output_shape = layer.output_shape(input_shape=inputs.shape)
+        assert_allclose(outputs.shape, output_shape)
 
     @parameterized.product(window=(1, 3, 5), padding=("SAME", "VALID", "CAUSAL"), dilation=(1, 2))
     def test_conv1d_transpose_against_conv1d(self, window, padding, dilation):


### PR DESCRIPTION
- Add `num_input_dim_groups` for 1D, 2D and 3D ConvTranspose
- Use `jax.lax.conv_general_dilated` for all transposed convolutions, the same as all regular convolutions
- Add unit tests for grouped convolution, test against PyTorch version
- Check for invalid group configuration in _check_conv_cfg