### PR TITLE
Re-purpose shared_bastion_name()

### DIFF
--- a/axlearn/cloud/gcp/jobs/bastion_vm.py
+++ b/axlearn/cloud/gcp/jobs/bastion_vm.py
@@ -32,7 +32,7 @@ from axlearn.cloud.common.bastion import bastion_job_flags
 from axlearn.cloud.common.quota import QUOTA_CONFIG_DIR, QUOTA_CONFIG_FILE, get_resource_limits
 from axlearn.cloud.common.utils import configure_logging, parse_action
 from axlearn.cloud.gcp.config import default_env_id, default_project, default_zone, gcp_settings
-from axlearn.cloud.gcp.utils import GCPAPI, catch_auth, common_flags
+from axlearn.cloud.gcp.utils import catch_auth, common_flags
 from axlearn.common.file_system import exists, glob
 from axlearn.common.file_system import open as fs_open
 from axlearn.common.file_system import readfile
@@ -61,25 +61,15 @@ def _private_flags(flag_values: flags.FlagValues = FLAGS):
     )
 
 
-def shared_bastion_name(
-    fv: Optional[flags.FlagValues], gcp_api: Optional[str] = None
-) -> Optional[str]:
+def infer_bastion_name(fv: Optional[flags.FlagValues]) -> Optional[str]:
     # The env_id-namespacing is necessary because of quirks with compute API. Specifically, even if
-    # creating VMs within a specific zone, names are global. On the other hand, the list API only
-    # returns VMs within a zone, so there's no easy way to check if a shared bastion already exists
-    # in another zone.
-    # If env_id is not set, fall back to "zone" for backwards compatibility.
-    env_id = gcp_settings("env_id", fv=fv, required=False) or gcp_settings("zone", fv=fv)
-    if gcp_api is not None and gcp_api.lower() == GCPAPI.GKE.lower():
-        default = f"{env_id}-gke-bastion"
-    else:
-        default = f"{env_id}-shared-bastion"
-    bastion_name = gcp_settings(  # pytype: disable=bad-return-type
+    # creating VMs within a specific zone, names are global.
+    env_id = gcp_settings("env_id", fv=fv)
+    return gcp_settings(  # pytype: disable=bad-return-type
         "bastion_name",
-        default=default,
+        default=f"{env_id}-gke-bastion",
         fv=fv,
     )
-    return bastion_name
 
 
 def bastion_root_dir(bastion: str, *, fv: Optional[flags.FlagValues]) -> str:

--- a/axlearn/cloud/gcp/jobs/launch.py
+++ b/axlearn/cloud/gcp/jobs/launch.py
@@ -133,11 +133,10 @@ from axlearn.cloud.common.utils import (
 from axlearn.cloud.gcp import runners
 from axlearn.cloud.gcp.bundler import CloudBuildBundler
 from axlearn.cloud.gcp.config import default_env_id, default_project, default_zone, gcp_settings
-from axlearn.cloud.gcp.jobs.bastion_vm import bastion_root_dir, shared_bastion_name
+from axlearn.cloud.gcp.jobs.bastion_vm import bastion_root_dir, infer_bastion_name
 from axlearn.cloud.gcp.jobs.launch_utils import (
     JobsToTableFn,
     Matcher,
-    infer_gcp_api,
     infer_module_qualname,
     jobs_table,
     match_gcp_api,
@@ -300,7 +299,7 @@ class BaseBastionManagedJob(FlagConfigurable):
         """
         cfg: BaseBastionManagedJob.Config = super().from_flags(fv, **kwargs)
         if not cfg.bastion_name:
-            cfg.bastion_name = fv.bastion or shared_bastion_name(fv, gcp_api=infer_gcp_api(fv))
+            cfg.bastion_name = fv.bastion or infer_bastion_name(fv)
         cfg.bastion_dir.root_dir = bastion_root_dir(cfg.bastion_name, fv=fv)
         # Default output_dir depends on the final value of --name.
         if not cfg.output_dir:

--- a/axlearn/cloud/gcp/jobs/launch_test.py
+++ b/axlearn/cloud/gcp/jobs/launch_test.py
@@ -410,7 +410,7 @@ class TestBastionManagedGKEJob(TestWithTemporaryCWD):
             dict(
                 name=None,
                 output_dir=None,
-                zone=None,
+                env_id=None,
                 bastion=None,
                 bundler_type=None,
                 bundler_exclude=None,
@@ -421,7 +421,7 @@ class TestBastionManagedGKEJob(TestWithTemporaryCWD):
             dict(
                 name="test-name",
                 output_dir="test-output",
-                zone="test-zone",
+                env_id="test-env-id",
                 bastion="test-bastion",
                 bundler_type="artifactregistry",
                 bundler_exclude=["a", "b"],
@@ -437,7 +437,7 @@ class TestBastionManagedGKEJob(TestWithTemporaryCWD):
         action,
         name,
         output_dir,
-        zone,
+        env_id,
         bastion,
         bundler_type,
         bundler_exclude,
@@ -464,8 +464,8 @@ class TestBastionManagedGKEJob(TestWithTemporaryCWD):
             argv.append(f"--output_dir={output_dir}")
         if project is not None:
             argv.append(f"--project={project}")
-        if zone is not None:
-            argv.append(f"--zone={zone}")
+        if env_id is not None:
+            argv.append(f"--env_id={env_id}")
         if bastion is not None:
             argv.append(f"--bastion={bastion}")
         if bundler_type is not None:
@@ -493,7 +493,7 @@ class TestBastionManagedGKEJob(TestWithTemporaryCWD):
 
         self.assertEqual(cfg.name, name or "job-name")
         self.assertEqual(cfg.project, project or self._settings["project"])
-        self.assertEqual(cfg.zone, zone or self._settings["zone"])
+        self.assertEqual(cfg.env_id, env_id or self._settings["env_id"])
         self.assertEqual(cfg.namespace, namespace or "default")
 
         if action in _RUNNER_ACTIONS:
@@ -504,16 +504,16 @@ class TestBastionManagedGKEJob(TestWithTemporaryCWD):
                 # Defaults to cloud build.
                 self.assertIs(cfg.bundler.klass, bundler.CloudBuildBundler)
 
-        # Check bastion flag. If None, we should infer from zone in mock_settings.
+        # Check bastion flag. If None, we should infer from env_id in mock_settings.
         if bastion:
             self.assertEqual(bastion, cfg.bastion_name)
-        elif zone is None:
+        elif env_id is None:
             self.assertEqual(
-                f"{self._settings['zone']}-gke-bastion",
+                f"{self._settings['env_id']}-gke-bastion",
                 cfg.bastion_name,
             )
         else:
-            self.assertEqual(f"{zone}-gke-bastion", cfg.bastion_name)
+            self.assertEqual(f"{env_id}-gke-bastion", cfg.bastion_name)
 
         # Check output_dir.
         if output_dir is None:

--- a/axlearn/cloud/gcp/test_utils.py
+++ b/axlearn/cloud/gcp/test_utils.py
@@ -17,6 +17,7 @@ def default_mock_settings() -> dict[str, str]:
 
     return {
         "project": "settings-project",
+        "env_id": "settings-env-id",
         "zone": "settings-zone",
         "permanent_bucket": "settings-permanent-bucket",
         "private_bucket": "settings-private-bucket",


### PR DESCRIPTION
We only run Bastion under gke mode. shared_bastion_name() is misleading and unnecessary.
Rename this to infer_bastion_name() and get rid of the gcp_api argument.