### PR TITLE
Support position-dependent query/key scaling

### DIFF
--- a/axlearn/common/flash_attention/layer.py
+++ b/axlearn/common/flash_attention/layer.py
@@ -219,10 +219,6 @@ class FlashAttention(GroupedQueryAttention):
             attention_logit_biases, attention_logit_biases_spec
         )
 
-        # Scale query and key.
-        q_proj = self.scale_query(q_proj)
-        k_proj = self.scale_key(k_proj)
-
         # Constrain input to conform to partitioned MHA expectations.
         q_proj = with_sharding_constraint(q_proj, cfg.mha_dim_to_partition_spec["btnh"])
         k_proj = with_sharding_constraint(k_proj, cfg.mha_dim_to_partition_spec["bsnh"])


### PR DESCRIPTION
As the prerequisite to support position-dependent temperature scaling for attention softmax, this minor refactor adds `positions` argument to `BaseScaleQK.forward` method. 

The attention layer will always pass `query_positions` / `key_positions` to `scale_query`/`scale_key`, and it is up to the scaling layer's implementation to use or discard the provided `positions` argument.