### PR TITLE
Fallback to standard mesh on neuron backend for incompatible multi-granule meshes

### DIFF
--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -1740,13 +1740,15 @@ def create_device_mesh(
     assert num_devices % num_granules == 0, "Number of devices should divide number of granules."
     num_devices_per_granule = num_devices // num_granules
 
-    # Fallback to a standard mesh if on GPU with incompatible multi-granule mesh.
+    # Fallback to a standard mesh if on GPU or neuron with incompatible multi-granule mesh.
     if (
-        device_platform == "gpu"
+        device_platform in ("gpu", "neuron")
         and isinstance(mesh_shape, MeshShape)
         and mesh_shape[0] % num_granules != 0
     ):
-        logging.warning("Falling back to ICI-only mesh on GPU, performance may be reduced.")
+        logging.warning(
+            "Falling back to ICI-only mesh on %s, performance may be reduced.", device_platform
+        )
         return build_standard_mesh(mesh_shape, devices=devices)
 
     # Canonicalize to HybridMeshShape. If DCN mesh is not specified, break the first non-singleton

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -1858,6 +1858,76 @@ class DeviceMeshTest(TestCase):
             device_mesh = create_device_mesh(mesh_shape=logical_mesh, devices=devices)
             self.assertEqual(expected or logical_mesh, device_mesh.shape)
 
+    @parameterized.parameters(
+        {"logical_mesh": (16, 4, 8)},
+        {"logical_mesh": (64, 8)},
+        # Test fallback to standard mesh.
+        {"logical_mesh": (16, 32)},
+        # Test a case where we infer -1 in ICI mesh.
+        {"logical_mesh": (8, -1, 4), "expected": (8, 16, 4)},
+        # Test a case where we infer -1 in DCN mesh.
+        {"logical_mesh": (-1, 16, 4), "expected": (8, 16, 4)},
+        # Test a basic hybrid mesh case.
+        {
+            "logical_mesh": HybridMeshShape(ici_mesh_shape=(1, 16, 4), dcn_mesh_shape=(8, 1, 1)),
+            "expected": (8, 16, 4),
+        },
+        # If expressed as a hybrid mesh, fail if DCN mesh is invalid rather than using fallback.
+        {
+            "logical_mesh": HybridMeshShape(ici_mesh_shape=(4, 16, 4), dcn_mesh_shape=(2, 1, 1)),
+            "expected": ValueError("DCN mesh"),
+        },
+        # Test that ICI mesh should respect the number of devices.
+        {
+            "logical_mesh": HybridMeshShape(ici_mesh_shape=(8, 1, 16), dcn_mesh_shape=(2, -1, 1)),
+            "expected": ValueError("Product of ICI"),
+        },
+        # Test that DCN mesh should respect the number of slices.
+        {
+            "logical_mesh": HybridMeshShape(ici_mesh_shape=(4, 1, 16), dcn_mesh_shape=(2, 2, 1)),
+            "expected": ValueError("Product of DCN"),
+        },
+        # Test a case where we infer -1 in ICI mesh.
+        {
+            "logical_mesh": HybridMeshShape(ici_mesh_shape=(1, 2, -1), dcn_mesh_shape=(8, 1, 1)),
+            "expected": (8, 2, 32),
+        },
+        # Test a case where we infer -1 in DCN mesh.
+        {
+            "logical_mesh": HybridMeshShape(ici_mesh_shape=(1, 4, 16), dcn_mesh_shape=(-1, 1, 1)),
+            "expected": (8, 4, 16),
+        },
+        # Test a case where we infer -1 in both ICI and DCN mesh.
+        {
+            "logical_mesh": HybridMeshShape(ici_mesh_shape=(1, -1, 16), dcn_mesh_shape=(-1, 1, 1)),
+            "expected": (8, 4, 16),
+        },
+    )
+    def test_create_device_mesh_neuron(
+        self,
+        logical_mesh: Union[MeshShape, HybridMeshShape],
+        expected: Optional[Union[MeshShape, Exception]] = None,
+    ):
+        num_devices_per_process = 64
+        num_granules = 8
+        devices = [
+            DummyDevice(
+                platform="neuron",
+                device_kind="NC_v3d",
+                process_index=(num_devices_per_process * granule_index + ix)
+                // num_devices_per_process,
+            )
+            for ix in range(num_devices_per_process)
+            for granule_index in range(num_granules)
+        ]
+        if isinstance(expected, Exception):
+            with self.assertRaisesRegex(type(expected), str(expected)):
+                create_device_mesh(mesh_shape=logical_mesh, devices=devices)
+        else:
+            # Check that the constructed mesh has the expected shape.
+            device_mesh = create_device_mesh(mesh_shape=logical_mesh, devices=devices)
+            self.assertEqual(expected or logical_mesh, device_mesh.shape)
+
 
 class InferMeshShapeTest(TestCase):
     """Tests infer_mesh_shape."""

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1-flash.txt
@@ -225,9 +225,9 @@ mesh_rules[6][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModif
 mesh_rules[7][0]: 'neuron-(trn2|trn2n).48xlarge-64'
 mesh_rules[7][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
 mesh_rules[7][1].config_modifiers[0].mesh_shape[0]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: 1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: -1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[2]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: -1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: 128
 mesh_rules[7][1].config_modifiers[0].mesh_shape[4]: 1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[5]: 4
 mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modifier.RematSpecModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1.txt
@@ -225,9 +225,9 @@ mesh_rules[6][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModif
 mesh_rules[7][0]: 'neuron-(trn2|trn2n).48xlarge-64'
 mesh_rules[7][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
 mesh_rules[7][1].config_modifiers[0].mesh_shape[0]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: 1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: -1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[2]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: -1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: 128
 mesh_rules[7][1].config_modifiers[0].mesh_shape[4]: 1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[5]: 4
 mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modifier.RematSpecModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2-flash.txt
@@ -225,9 +225,9 @@ mesh_rules[6][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModif
 mesh_rules[7][0]: 'neuron-(trn2|trn2n).48xlarge-64'
 mesh_rules[7][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
 mesh_rules[7][1].config_modifiers[0].mesh_shape[0]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: 1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: -1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[2]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: -1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: 128
 mesh_rules[7][1].config_modifiers[0].mesh_shape[4]: 1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[5]: 4
 mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modifier.RematSpecModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2.txt
@@ -225,9 +225,9 @@ mesh_rules[6][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModif
 mesh_rules[7][0]: 'neuron-(trn2|trn2n).48xlarge-64'
 mesh_rules[7][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
 mesh_rules[7][1].config_modifiers[0].mesh_shape[0]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: 1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: -1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[2]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: -1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: 128
 mesh_rules[7][1].config_modifiers[0].mesh_shape[4]: 1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[5]: 4
 mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modifier.RematSpecModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-flash.txt
@@ -225,9 +225,9 @@ mesh_rules[6][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModif
 mesh_rules[7][0]: 'neuron-(trn2|trn2n).48xlarge-64'
 mesh_rules[7][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
 mesh_rules[7][1].config_modifiers[0].mesh_shape[0]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: 1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: -1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[2]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: -1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: 128
 mesh_rules[7][1].config_modifiers[0].mesh_shape[4]: 1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[5]: 4
 mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modifier.RematSpecModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken-flash.txt
@@ -225,9 +225,9 @@ mesh_rules[6][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModif
 mesh_rules[7][0]: 'neuron-(trn2|trn2n).48xlarge-64'
 mesh_rules[7][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
 mesh_rules[7][1].config_modifiers[0].mesh_shape[0]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: 1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: -1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[2]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: -1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: 128
 mesh_rules[7][1].config_modifiers[0].mesh_shape[4]: 1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[5]: 4
 mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modifier.RematSpecModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken.txt
@@ -225,9 +225,9 @@ mesh_rules[6][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModif
 mesh_rules[7][0]: 'neuron-(trn2|trn2n).48xlarge-64'
 mesh_rules[7][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
 mesh_rules[7][1].config_modifiers[0].mesh_shape[0]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: 1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: -1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[2]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: -1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: 128
 mesh_rules[7][1].config_modifiers[0].mesh_shape[4]: 1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[5]: 4
 mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modifier.RematSpecModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3.txt
@@ -225,9 +225,9 @@ mesh_rules[6][1].klass: 'axlearn.common.trainer_config_modifier.ChainConfigModif
 mesh_rules[7][0]: 'neuron-(trn2|trn2n).48xlarge-64'
 mesh_rules[7][1].config_modifiers[0].klass: 'axlearn.common.trainer_config_modifier.MeshShapeModifier'
 mesh_rules[7][1].config_modifiers[0].mesh_shape[0]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: 1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[1]: -1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[2]: 1
-mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: -1
+mesh_rules[7][1].config_modifiers[0].mesh_shape[3]: 128
 mesh_rules[7][1].config_modifiers[0].mesh_shape[4]: 1
 mesh_rules[7][1].config_modifiers[0].mesh_shape[5]: 4
 mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modifier.RematSpecModifier'

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -796,9 +796,10 @@ def get_trainer_kwargs(
                     ChainConfigModifier.default_config().set(
                         config_modifiers=[
                             MeshShapeModifier.default_config().set(
-                                # TP within the chip, FSDP across chips.
+                                # TP within the chip, FSDP across 8 nodes and Data parallel
+                                # replication across replicas.
                                 # Each TRN2 chip has 4 XLA cores.
-                                mesh_shape=mesh_shape_from_axes(fsdp=-1, model=4)
+                                mesh_shape=mesh_shape_from_axes(data=-1, fsdp=128, model=4)
                             ),
                             RematSpecModifier.default_config().set(
                                 remat_policies={


### PR DESCRIPTION
Allow fallback to standard mesh for multi-granule mesh as such a mesh provides better performance on TRN2 
- Added corresponding tests for fallback and mesh creation for TRN2.
- Switch to a new mesh for neuron-(trn2|trn2n).48xlarge-64 on for 70B-FujiV2 as it provides better scale-out performance.