### PR TITLE
Save O_PROJ on Fuji 70B-v2 for TRN2

### DIFF
--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1-flash.txt
@@ -234,7 +234,7 @@ mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modif
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['prevent_cse']: True
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].fn: 'axlearn.common.utils.save_and_offload_only_these_names_regex'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_offloaded: None
-mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*linear1_[01]'
+mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*o_proj|.*linear1_[01]'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: None
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: None
 mesh_rules[7][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.ModuleConfigModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v1.txt
@@ -234,7 +234,7 @@ mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modif
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['prevent_cse']: True
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].fn: 'axlearn.common.utils.save_and_offload_only_these_names_regex'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_offloaded: None
-mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*linear1_[01]'
+mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*o_proj|.*linear1_[01]'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: None
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: None
 mesh_rules[7][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.ModuleConfigModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2-flash.txt
@@ -234,7 +234,7 @@ mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modif
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['prevent_cse']: True
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].fn: 'axlearn.common.utils.save_and_offload_only_these_names_regex'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_offloaded: None
-mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*linear1_[01]'
+mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*o_proj|.*linear1_[01]'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: None
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: None
 mesh_rules[7][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.ModuleConfigModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v2.txt
@@ -234,7 +234,7 @@ mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modif
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['prevent_cse']: True
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].fn: 'axlearn.common.utils.save_and_offload_only_these_names_regex'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_offloaded: None
-mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*linear1_[01]'
+mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*o_proj|.*linear1_[01]'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: None
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: None
 mesh_rules[7][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.ModuleConfigModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-flash.txt
@@ -234,7 +234,7 @@ mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modif
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['prevent_cse']: True
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].fn: 'axlearn.common.utils.save_and_offload_only_these_names_regex'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_offloaded: None
-mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*linear1_[01]'
+mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*o_proj|.*linear1_[01]'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: None
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: None
 mesh_rules[7][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.ModuleConfigModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken-flash.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken-flash.txt
@@ -234,7 +234,7 @@ mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modif
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['prevent_cse']: True
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].fn: 'axlearn.common.utils.save_and_offload_only_these_names_regex'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_offloaded: None
-mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*linear1_[01]'
+mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*o_proj|.*linear1_[01]'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: None
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: None
 mesh_rules[7][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.ModuleConfigModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3-tiktoken.txt
@@ -234,7 +234,7 @@ mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modif
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['prevent_cse']: True
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].fn: 'axlearn.common.utils.save_and_offload_only_these_names_regex'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_offloaded: None
-mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*linear1_[01]'
+mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*o_proj|.*linear1_[01]'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: None
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: None
 mesh_rules[7][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.ModuleConfigModifier'

--- a/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3.txt
+++ b/axlearn/experiments/testdata/axlearn.experiments.text.gpt.c4_trainer/fuji-70B-v3.txt
@@ -234,7 +234,7 @@ mesh_rules[7][1].config_modifiers[1].klass: 'axlearn.common.trainer_config_modif
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['prevent_cse']: True
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].fn: 'axlearn.common.utils.save_and_offload_only_these_names_regex'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_offloaded: None
-mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*linear1_[01]'
+mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].names_which_can_be_saved: '.*[kqv]_proj|.*o_proj|.*linear1_[01]'
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_dst: None
 mesh_rules[7][1].config_modifiers[1].remat_policies['model.decoder.transformer.layer']['policy'].offload_src: None
 mesh_rules[7][1].config_modifiers[2].klass: 'axlearn.common.trainer_config_modifier.ModuleConfigModifier'

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -810,6 +810,7 @@ def get_trainer_kwargs(
                                             names_which_can_be_saved="|".join(
                                                 [
                                                     RematRegexSavePatterns.QKV_PROJ.value,
+                                                    RematRegexSavePatterns.O_PROJ.value,
                                                     RematRegexSavePatterns.LINEAR1_X.value,
                                                 ]
                                             ),


### PR DESCRIPTION
Saving out-projection improves training throughput while still fitting in the mesh defined by `neuron-(trn2|trn2n).48xlarge-64`.