### PR TITLE
Use lambda instead of functools.partial to create single-host config maker

### DIFF
--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -1011,7 +1011,6 @@ def trainer_configs(
                 return cfg
 
             # Make single-host config
-            make_single_host_config_func = functools.partial(make_single_host_config, config_name)
-            config_map[f"{config_name}-single-host"] = make_single_host_config_func
+            config_map[f"{config_name}-single-host"] = lambda: make_single_host_config(config_name)
 
     return config_map


### PR DESCRIPTION
Fixes #1151 

An alternative solution is to use `functools.wraps` but that requires a custom config validator:
```
axlearn.common.config.InvalidConfigValueError: Invalid config value type <class 'functools.partial'> for value "functools.partial(<function trainer_configs.<locals>.make_single_host_config at 0x722900936160>, 'fuji-3B-v3-flash')". Consider registering a custom validator with `register_validator`.
```
