### PR TITLE
Goodput Monitoring | Add support for custom badput events

### DIFF
--- a/axlearn/cloud/gcp/measurement.py
+++ b/axlearn/cloud/gcp/measurement.py
@@ -97,6 +97,10 @@ class GoodputRecorder(measurement.Recorder):
             self._recorder.record_data_loading_start_time(*args, **kwargs)
         elif event == measurement.Event.END_DATA_LOADING:
             self._recorder.record_data_loading_end_time(*args, **kwargs)
+        elif event == measurement.Event.START_CUSTOM_BADPUT_EVENT:
+            self._recorder.record_custom_badput_event_start_time(*args, **kwargs)
+        elif event == measurement.Event.END_CUSTOM_BADPUT_EVENT:
+            self._recorder.record_custom_badput_event_end_time(*args, **kwargs)
         else:
             logging.log_first_n(
                 logging.WARNING,

--- a/axlearn/common/measurement.py
+++ b/axlearn/common/measurement.py
@@ -24,6 +24,8 @@ class Event(enum.Enum):
         END_TRAINING_PREPARATION: End of training preparation.
         START_DATA_LOADING: Start of data loading.
         END_DATA_LOADING: End of data loading.
+        START_CUSTOM_BADPUT_EVENT: Start of custom badput event.
+        END_CUSTOM_BADPUT_EVENT: End of custom badput event.
     """
 
     START_JOB = "START_JOB"
@@ -35,6 +37,8 @@ class Event(enum.Enum):
     END_TRAINING_PREPARATION = "END_TRAINING_PREPARATION"
     START_DATA_LOADING = "START_DATA_LOADING"
     END_DATA_LOADING = "END_DATA_LOADING"
+    START_CUSTOM_BADPUT_EVENT = "START_CUSTOM_BADPUT_EVENT"
+    END_CUSTOM_BADPUT_EVENT = "END_CUSTOM_BADPUT_EVENT"
 
 
 class Recorder(Configurable):

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -1037,14 +1037,23 @@ class SpmdTrainer(Module):
             mesh_shape=cfg.mesh_shape, mesh_axis_names=cfg.mesh_axis_names, device_kind=device_kind
         )
         if not with_xsc:
+            self._maybe_record_event(
+                measurement.Event.START_CUSTOM_BADPUT_EVENT,
+                custom_badput_event_type="COMPILATION_NO_XSC",
+            )
             self._compiled_train_step = self.compile_train_step(
                 trainer_state=trainer_state, input_batch=input_batch, compiler_options=options
+            )
+            self._maybe_record_event(
+                measurement.Event.END_CUSTOM_BADPUT_EVENT,
+                custom_badput_event_type="COMPILATION_NO_XSC",
             )
             return self._compiled_train_step
         logging.log_first_n(logging.INFO, "Compiling XSC train step.", 1)
 
         self._maybe_record_event(
-            measurement.Event.START_CUSTOM_BADPUT_EVENT, custom_badput_event_type="SDC_COMPILATION"
+            measurement.Event.START_CUSTOM_BADPUT_EVENT,
+            custom_badput_event_type="COMPILATION_WITH_XSC",
         )
         compiled_jit_train_step_fn = self.compile_train_step(
             trainer_state=trainer_state,
@@ -1055,7 +1064,8 @@ class SpmdTrainer(Module):
             ),
         )
         self._maybe_record_event(
-            measurement.Event.END_CUSTOM_BADPUT_EVENT, custom_badput_event_type="SDC_COMPILATION"
+            measurement.Event.END_CUSTOM_BADPUT_EVENT,
+            custom_badput_event_type="COMPILATION_WITH_XSC",
         )
         return compiled_jit_train_step_fn
 

--- a/axlearn/common/trainer.py
+++ b/axlearn/common/trainer.py
@@ -1044,7 +1044,7 @@ class SpmdTrainer(Module):
         logging.log_first_n(logging.INFO, "Compiling XSC train step.", 1)
 
         self._maybe_record_event(
-            measurement.Event.START_CUSTOM_BADPUT_EVENT, custom_badput_event_type="SDC_CHECK"
+            measurement.Event.START_CUSTOM_BADPUT_EVENT, custom_badput_event_type="SDC_COMPILATION"
         )
         compiled_jit_train_step_fn = self.compile_train_step(
             trainer_state=trainer_state,
@@ -1055,7 +1055,7 @@ class SpmdTrainer(Module):
             ),
         )
         self._maybe_record_event(
-            measurement.Event.END_CUSTOM_BADPUT_EVENT, custom_badput_event_type="SDC_CHECK"
+            measurement.Event.END_CUSTOM_BADPUT_EVENT, custom_badput_event_type="SDC_COMPILATION"
         )
         return compiled_jit_train_step_fn
 


### PR DESCRIPTION
- Goodput monitoring supports custom badput types that are synchronous and overlapping.
- Axlearn can now monitor two custom badput events (SDC_CHECK and EVAL) 