### PR TITLE
Remove obsolete jax_spmd_mode config

### DIFF
--- a/axlearn/common/utils_spmd.py
+++ b/axlearn/common/utils_spmd.py
@@ -43,8 +43,6 @@ def setup(
     """
     # Use a GSPMD-friendly PRNG implementation.
     jax.config.update("jax_default_prng_impl", "rbg")
-    # This allows replicated jax.Arrays to be used for computation on the host.
-    jax.config.update("jax_spmd_mode", "allow_all")
 
     global _jax_distributed_initialized  # pylint: disable=global-statement
     if not _jax_distributed_initialized:


### PR DESCRIPTION
Upstream removed the `jax_spmd_mode` option on Apr 17: https://github.com/jax-ml/jax/commit/7634230cdcd2d3cb42d1093f6ab255f47f9869d5. Keeping it would cause the following error:
```
  File "/opt/axlearn/axlearn/common/launch.py", line 115, in setup
    setup_spmd(
  File "/opt/axlearn/axlearn/common/utils_spmd.py", line 47, in setup
    jax.config.update("jax_spmd_mode", "allow_all")
  File "/opt/jax/jax/_src/config.py", line 111, in update
    raise AttributeError(f"Unrecognized config option: {name}")
AttributeError: Unrecognized config option: jax_spmd_mode
```