### PR TITLE
Use `remat` in `scan_in_context`

### DIFF
--- a/axlearn/common/base_layer.py
+++ b/axlearn/common/base_layer.py
@@ -338,7 +338,7 @@ class BaseLayer(Module):
             # pylint: disable-next=protected-access
             module._remat_methods.append(method_fn.__name__)
             # Pass both outputs and output_collection through remat(...) to avoid leaking tracers.
-            outputs, output_collection = jax.ad_checkpoint.remat(
+            outputs, output_collection = jax.checkpoint(
                 fn,
                 **{k: maybe_instantiate(v) for k, v in dataclasses.asdict(cfg.remat_spec).items()},
             )(*args, **tracer_kwargs)

--- a/axlearn/common/module_test.py
+++ b/axlearn/common/module_test.py
@@ -993,6 +993,29 @@ class ScanInContextTest(TestWithTemporaryCWD):
                 ctx.output_collection.module_outputs[child_name_prefix]["nested"],
             )
 
+    def test_remat(self):
+        num_iters = 3
+
+        with self._dummy_context():
+            ref_carry, ref_ys = self._invoke(num_iters=num_iters, xs={})
+
+        with self._dummy_context():
+            test_carry, test_ys = self._invoke(
+                num_iters=num_iters,
+                xs={},
+                remat_kwargs=dict(policy=jax.checkpoint_policies.everything_saveable),
+            )
+        self.assertNestedEqual(ref_carry, test_carry)
+        self.assertNestedEqual(ref_ys, test_ys)
+
+        # prevent_cse=True raises ValueError.
+        with self._dummy_context(), self.assertRaises(ValueError):
+            _ = self._invoke(
+                num_iters=num_iters,
+                xs={},
+                remat_kwargs=dict(prevent_cse=True),
+            )
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/axlearn/common/repeat_test.py
+++ b/axlearn/common/repeat_test.py
@@ -152,17 +152,27 @@ class RepeatTest(TestCase):
 
     @parameterized.product(
         dtype=(jnp.float32, jnp.bfloat16),
-        remat_spec=(None, RematSpec(prevent_cse=False)),
+        remat_in_scan=(False, True),
+        remat_spec=(
+            None,
+            RematSpec(prevent_cse=False),
+            RematSpec(policy=jax.checkpoint_policies.everything_saveable),
+        ),
         drop_output=(None, config_for_function(_drop_by_regex).set(rules=["module_outputs.*"])),
         num_layers_total=(4, 6),
         unroll=(True, False, 1, 2),
     )
-    def test_repeat(self, dtype, remat_spec, drop_output, num_layers_total, unroll):
+    def test_repeat(self, dtype, remat_in_scan, remat_spec, drop_output, num_layers_total, unroll):
         batch_size, num_layers = 14, 4
         cfg = TestEnsemble.default_config().set(
             name="test", num_layers=num_layers_total, dtype=dtype
         )
-        cfg.repeat_layer.set(remat_spec=remat_spec, drop_output=drop_output, unroll=unroll)
+        cfg.repeat_layer.set(
+            remat_spec=remat_spec,
+            drop_output=drop_output,
+            unroll=unroll,
+            remat_in_scan=remat_in_scan,
+        )
         layer: TestEnsemble = cfg.instantiate(parent=None)
         self.assertEqual(
             PartitionSpec(None),
@@ -344,9 +354,14 @@ class RepeatTest(TestCase):
 
     @parameterized.product(
         dtype=[jnp.float32, jnp.bfloat16],
-        remat_spec=[None, RematSpec(prevent_cse=False)],
+        remat_in_scan=(False, True),
+        remat_spec=(
+            None,
+            RematSpec(prevent_cse=False),
+            RematSpec(policy=jax.checkpoint_policies.everything_saveable),
+        ),
     )
-    def test_shared_module(self, dtype, remat_spec):
+    def test_shared_module(self, dtype, remat_in_scan, remat_spec):
         """Test repeat with shared modules."""
         batch_size, num_layers = 14, 4
 
@@ -361,6 +376,7 @@ class RepeatTest(TestCase):
                         remat_spec=remat_spec,
                     ),
                     num_layers=num_layers,
+                    remat_in_scan=remat_in_scan,
                 ),
                 # Test nested repeat to a shared module.
                 nested=ParentLayer.default_config().set(


### PR DESCRIPTION
Applying `scan(remat(scan_fn))` is a well-known JAX idiom. It enables gradient checkpointing at scan function boundaries, which significantly reduces memory usage during training.

We measured the impact on a 2.8B model (using `RepeatedTransformer`). The change saved a substantial amount of memory with minimal effect on training speed:

* **Before (as-is)**
  * `train_step`: 19,558.35 MiB, 1112 ms
  * `forward`: 8,433.40 MiB, 295 ms

![image](https://github.com/user-attachments/assets/2e961d72-e9f8-42ef-a8fc-2634e40e93a9)

* **After (with remat)**
  * `train_step`: 15,695.13 MiB, 1128 ms
  * `forward`: 8,433.40 MiB, 295 ms

![image](https://github.com/user-attachments/assets/cfcacfcb-1f30-4d25-bee9-e9dee32188d7)

Note: The relationship between BaseLayer's remat, and Repeat's scan(remat(fn))
can be described as: remat(scan(remat(fn)), policy)

Until now, the inner scan was opaque to remat, so the remat policy wasn’t properly applied inside it (e.g., in RepeatedTransformerLayer). This PR applies the remat policy inside the scan as well: remat(scan(remat(fn, policy)), policy)