### PR TITLE
Introduce safe_not() for ~paddings instead of 1 - paddings.

### DIFF
--- a/axlearn/audio/decoder_asr.py
+++ b/axlearn/audio/decoder_asr.py
@@ -8,6 +8,7 @@
 
 from typing import Callable, Optional, Union
 
+import chex
 import jax
 import jax.numpy as jnp
 import optax
@@ -37,7 +38,7 @@ from axlearn.common.metrics import WeightedScalar
 from axlearn.common.module import Module, child_context
 from axlearn.common.rnn import BaseRNNCell, LSTMCell
 from axlearn.common.transducer import Transducer, log_probs_from_blank_and_tokens
-from axlearn.common.utils import Nested, Tensor, vectorized_tree_map
+from axlearn.common.utils import Nested, Tensor, safe_not, vectorized_tree_map
 
 
 def _is_valid_ctc_seq(
@@ -311,9 +312,9 @@ class CTCDecoderModel(BaseASRDecoderModel):
             we have not subtracted the log-partition function.
         """
         inputs = input_batch["inputs"]
-        paddings = input_batch["paddings"]
+        paddings: Tensor = input_batch["paddings"]
         logits = self.lm_head(inputs)
-        return logits * (1 - paddings[..., None])
+        return logits * safe_not(paddings)[..., None]
 
     def _loss_summaries(
         self,
@@ -441,7 +442,7 @@ class CTCDecoderModel(BaseASRDecoderModel):
         # Add a dummy EOS token:
         # eos_log_probs[b, t, :] = 0 if paddings_extended[b, t] else NEG_INF.
         paddings_extended = jnp.pad(paddings, ((0, 0), (0, 1)), constant_values=1)
-        eos_log_probs = (1 - paddings_extended[:, :, None]) * NEG_INF
+        eos_log_probs = safe_not(paddings_extended)[:, :, None] * NEG_INF
         # [batch_size, num_frames + 1, vocab_size + 1].
         log_probs = jnp.concatenate([log_probs, eos_log_probs], axis=-1)
         # Apply logits modifier after (e.g. if applying top-k, don't factor in padding scores).
@@ -590,7 +591,7 @@ class CTCDecoderModel(BaseASRDecoderModel):
         # [batch, num_frames, 1].
         scores = jnp.take_along_axis(log_probs, sequences[:, 0, :, None], axis=-1)
         # [batch, 1].
-        scores = jnp.sum(jnp.squeeze(scores, axis=-1) * (1 - paddings), axis=1, keepdims=True)
+        scores = jnp.sum(jnp.squeeze(scores, axis=-1) * safe_not(paddings), axis=1, keepdims=True)
 
         return DecodeOutputs(
             raw_sequences=sequences,
@@ -601,7 +602,7 @@ class CTCDecoderModel(BaseASRDecoderModel):
 
     def _postprocess_outputs(self, *, sequences: Tensor, paddings: Tensor, scores: Tensor):
         cfg: CTCDecoderModel.Config = self.config
-        live_mask = 1 - paddings[:, None, :]
+        live_mask = safe_not(paddings)[:, None, :]
         # Drop dummy decode position and mask outputs corresponding to padding frames.
         sequences = sequences[..., :-1] * live_mask
         # If given per-token scores, sum non-padding scores along sequence dim.
@@ -664,7 +665,7 @@ def _map_label_sequences(
         jnp.cumsum(indicators, axis=-1) * indicators - 1, max_decode_len, dtype=inputs.dtype
     )
     sequences = jnp.einsum("...nm,...n->...m", dispatch, inputs)
-    paddings = (jnp.arange(max_decode_len) >= lens).astype(inputs.dtype)
+    paddings = jnp.arange(max_decode_len) >= lens
     if pad_id != 0:
         sequences = jnp.where(paddings, pad_id, sequences)
     return dict(sequences=sequences, paddings=paddings, lengths=lens)
@@ -831,6 +832,7 @@ class TransducerDecoderModel(BaseASRDecoderModel):
         # [batch, src_max_len, joint_dim].
         am_data = self.am_proj(input_batch["inputs"])
         am_paddings: Tensor = input_batch["paddings"]
+        chex.assert_type(am_paddings, jnp.bool)
         target_labels: Tensor = input_batch["target_labels"]
         target_paddings: Tensor = _compute_target_paddings(target_labels, vocab_size=cfg.vocab_size)
 
@@ -1254,7 +1256,7 @@ class LASDecoderModel(BaseASRDecoderModel):
                 eos_id=dec_cfg.eos_token_id,
             )
             # Drop dummy decode position and mask outputs corresponding to padding.
-            sequences = beam_search_outputs.sequences * (1 - paddings)
+            sequences = beam_search_outputs.sequences * safe_not(paddings)
         return DecodeOutputs(
             raw_sequences=beam_search_outputs.sequences,
             sequences=sequences,
@@ -1306,9 +1308,9 @@ class LASDecoderModel(BaseASRDecoderModel):
             )
 
             # Drop dummy decode position and mask outputs corresponding to padding.
-            sequences = sample_decode_outputs.sequences * (1 - paddings)
+            sequences = sample_decode_outputs.sequences * safe_not(paddings)
             # [batch_size, num_decodes].
-            scores = jnp.sum(sample_decode_outputs.token_scores * (1 - paddings), axis=-1)
+            scores = jnp.sum(sample_decode_outputs.token_scores * safe_not(paddings), axis=-1)
         return DecodeOutputs(
             raw_sequences=sample_decode_outputs.sequences,
             sequences=sequences,

--- a/axlearn/audio/decoder_asr_test.py
+++ b/axlearn/audio/decoder_asr_test.py
@@ -34,7 +34,7 @@ from axlearn.common.module import functional as F
 from axlearn.common.param_converter import as_torch_tensor
 from axlearn.common.rnn import BaseRNNCell, IdentityCell, LSTMCell
 from axlearn.common.test_utils import TestCase, assert_allclose, set_threefry_partitionable
-from axlearn.common.utils import Nested, NestedTensor, Tensor, shapes
+from axlearn.common.utils import Nested, NestedTensor, Tensor, safe_not, shapes
 
 _NEG_INF = -1.0e7
 
@@ -59,7 +59,7 @@ class UtilsTest(TestCase):
                     [
                         [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
                     ]
-                ),
+                ).astype(jnp.bool),
                 lengths=jnp.asarray([[4]]),
             ),
             blank_id=0,
@@ -85,7 +85,7 @@ class UtilsTest(TestCase):
                         [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
                         [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
                     ]
-                ),
+                ).astype(jnp.bool),
                 lengths=jnp.asarray([[4], [4]]),
             ),
             blank_id=0,
@@ -111,7 +111,7 @@ class UtilsTest(TestCase):
                         [[0, 0, 0, 0, 0, 0, 0, 1, 1, 1], [0, 0, 0, 1, 1, 1, 1, 1, 1, 1]],
                         [[0, 0, 0, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]],
                     ]
-                ),
+                ).astype(jnp.bool),
                 lengths=jnp.asarray([[[7], [3]], [[3], [0]]]),
             ),
             blank_id=0,
@@ -137,7 +137,7 @@ class UtilsTest(TestCase):
                         [[0, 0, 0, 0, 0, 0, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0, 1, 1, 1, 1]],
                         [[0, 0, 0, 0, 0, 0, 1, 1, 1, 1], [0, 0, 0, 1, 1, 1, 1, 1, 1, 1]],
                     ]
-                ),
+                ).astype(jnp.bool),
                 lengths=jnp.asarray([[[6], [6]], [[6], [3]]]),
             ),
             blank_id=3,
@@ -170,7 +170,7 @@ class ValidCtcSeqTest(TestCase):
         logits = jax.random.normal(
             prng_key, (batch_size, input_lengths, vocab_size), dtype=jnp.float32
         )
-        paddings = jnp.zeros((batch_size, input_lengths), dtype=np.int32)
+        paddings = jnp.zeros((batch_size, input_lengths), dtype=jnp.bool)
         target_labels = jax.random.randint(
             prng_key,
             shape=(batch_size, target_lengths),
@@ -178,7 +178,7 @@ class ValidCtcSeqTest(TestCase):
             maxval=vocab_size - 1,
             dtype=jnp.int32,
         )
-        target_paddings = jnp.zeros(shape=(batch_size, target_lengths), dtype=jnp.int32)
+        target_paddings = jnp.zeros(shape=(batch_size, target_lengths), dtype=jnp.bool)
         return logits, paddings, target_labels, target_paddings
 
     def test_label_longer_than_input(self):
@@ -406,7 +406,7 @@ class CTCDecoderModelTest(TestCase):
             [batch_size, 1, 1],
         )
         # [batch_size, max_seq_len].
-        paddings = (jnp.arange(max_seq_len) >= seq_len[:, None]).astype(inputs.dtype)
+        paddings = jnp.arange(max_seq_len) >= seq_len[:, None]
 
         # Generate different padding data.
         padding_data = jax.random.normal(
@@ -466,7 +466,7 @@ class CTCDecoderModelTest(TestCase):
             target_key, [batch_size, max_seq_len], minval=0, maxval=vocab_size
         )
         # [batch_size, max_seq_len].
-        paddings = (jnp.arange(max_seq_len) >= input_lengths[:, None]).astype(target_labels.dtype)
+        paddings = jnp.arange(max_seq_len) >= input_lengths[:, None]
         # Map padding targets out-of-vocab.
         target_labels = jnp.where(
             jnp.arange(max_seq_len) >= target_lengths[:, None], -1, target_labels
@@ -552,12 +552,12 @@ class CTCDecoderModelTest(TestCase):
             target_key, [batch_size, max_seq_len], minval=0, maxval=vocab_size
         )
         # [batch_size, max_seq_len].
-        paddings = (jnp.arange(max_seq_len) >= input_lengths[:, None]).astype(target_labels.dtype)
+        paddings = jnp.arange(max_seq_len) >= input_lengths[:, None]
         # Map padding targets out-of-vocab.
         target_labels = jnp.where(
             jnp.arange(max_seq_len) >= target_lengths[:, None], -1, target_labels
         )
-        target_paddings = jnp.where(target_labels == -1, 1, 0)
+        target_paddings = target_labels == -1
         input_batch = dict(inputs=inputs, paddings=paddings, target_labels=target_labels)
         _, output_collections = F(
             layer,
@@ -572,8 +572,8 @@ class CTCDecoderModelTest(TestCase):
         self._check_summary(summaries, "loss/ctc_loss", WeightedScalar(6972.1353, 6))
         self._check_summary(summaries, "loss/invalid_seq_percent", 0.25)
         total_ctc_loss = summaries["loss/ctc_loss"].weight * summaries["loss/ctc_loss"].mean
-        num_valid_frames = jnp.sum((1 - paddings) * per_example_weight[:, None])
-        num_valid_labels = jnp.sum((1 - target_paddings) * per_example_weight[:, None])
+        num_valid_frames = jnp.sum(safe_not(paddings) * per_example_weight[:, None])
+        num_valid_labels = jnp.sum(safe_not(target_paddings) * per_example_weight[:, None])
         num_valid_examples = jnp.sum(per_example_weight)
         self._check_summary(
             summaries,
@@ -634,7 +634,7 @@ class CTCDecoderModelTest(TestCase):
         # [batch_size, max_seq_len, dim].
         inputs = jax.random.normal(input_key, [batch_size, max_seq_len, cfg.input_dim]) * 1000
         # [batch_size, max_seq_len].
-        paddings = (jnp.arange(max_seq_len) >= seq_len[:, None]).astype(jnp.int32)
+        paddings = jnp.arange(max_seq_len) >= seq_len[:, None]
 
         @functools.partial(jax.jit, static_argnames=("method", "modify_logits", "num_decodes"))
         def jit_method(inputs, prng_key, method, modify_logits=False, num_decodes=None):
@@ -677,7 +677,7 @@ class CTCDecoderModelTest(TestCase):
         log_probs += paddings[..., None] * NEG_INF
         log_probs = jnp.pad(log_probs, ((0, 0), (0, 1), (0, 0)), constant_values=NEG_INF)
         paddings_extended = jnp.pad(paddings, ((0, 0), (0, 1)), constant_values=1)
-        eos_log_probs = (1 - paddings_extended[:, :, None]) * NEG_INF
+        eos_log_probs = safe_not(paddings_extended)[:, :, None] * NEG_INF
         ref_log_probs = jnp.concatenate([log_probs, eos_log_probs], axis=-1)
 
         # Sequences have shape [batch_size, max_seq_len].
@@ -700,7 +700,7 @@ class CTCDecoderModelTest(TestCase):
         ref_scores = ref_scores[..., :-1, :]
 
         # Aggregate scores [batch_size].
-        ref_scores = jnp.squeeze(ref_scores, axis=-1) * (1 - paddings)
+        ref_scores = jnp.squeeze(ref_scores, axis=-1) * safe_not(paddings)
         ref_scores = jnp.sum(ref_scores, axis=-1)
 
         # Sample decode top decode should match.
@@ -739,7 +739,7 @@ class CTCDecoderModelTest(TestCase):
         # [batch_size, max_seq_len, dim].
         inputs = jax.random.normal(input_key, [batch_size, max_seq_len, cfg.input_dim]) * 1000
         # [batch_size, max_seq_len].
-        paddings = (jnp.arange(max_seq_len) >= seq_len[:, None]).astype(jnp.int32)
+        paddings = jnp.arange(max_seq_len) >= seq_len[:, None]
 
         @functools.partial(jax.jit, static_argnames=("method", "logits_modifier", "num_decodes"))
         def jit_method(inputs, prng_key, method, logits_modifier=None, num_decodes=None):
@@ -805,7 +805,7 @@ class CTCDecoderModelTest(TestCase):
         # [batch_size, max_seq_len, dim].
         inputs = jax.random.normal(input_key, [batch_size, max_seq_len, input_dim]) * 1000
         # [batch_size, max_seq_len].
-        paddings = (jnp.arange(max_seq_len) >= seq_len[:, None]).astype(jnp.int32)
+        paddings = jnp.arange(max_seq_len) >= seq_len[:, None]
 
         @functools.partial(jax.jit, static_argnames=("method", "prefix_merger", "num_decodes"))
         def jit_method(inputs, prng_key, method, prefix_merger=None, num_decodes=None):
@@ -947,7 +947,7 @@ class CTCDecoderModelTest(TestCase):
                 [0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
                 [0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
             ]
-        )
+        ).astype(jnp.bool)
         scores = jnp.array(
             [
                 [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]],
@@ -993,7 +993,7 @@ class CTCDecoderModelTest(TestCase):
                     [[0, 0, 0, 0, 1, 1, 1, 1, 1, 1], [0, 0, 0, 0, 1, 1, 1, 1, 1, 1]],
                     [[0, 0, 0, 0, 0, 1, 1, 1, 1, 1], [0, 0, 0, 0, 1, 1, 1, 1, 1, 1]],
                 ]
-            ),
+            ).astype(jnp.bool),
         )
         self.assertNestedEqual(outputs.scores, jnp.array([[28, 28], [36, 36]]))
 
@@ -1279,7 +1279,7 @@ class TransducerDecoderModelTest(TestCase):
                     ],
                 ]
             )
-            am_paddings = (jnp.arange(max_src_len)[None, :] >= src_len[:, None]).astype(jnp.int32)
+            am_paddings = jnp.arange(max_src_len)[None, :] >= src_len[:, None]
             expected_decodes = dict(
                 raw_sequences=jnp.array(
                     [
@@ -1336,7 +1336,7 @@ class TransducerDecoderModelTest(TestCase):
                             [0, 0, 0, 1, 1, 1, 1],
                         ],
                     ]
-                ),
+                ).astype(jnp.bool),
                 probabilities=jnp.array(
                     [
                         [1, 0, 0, 0],
@@ -1352,7 +1352,7 @@ class TransducerDecoderModelTest(TestCase):
             src_len = jnp.array([3, 4])
             # [batch_size, max_src_len, am_dim].
             am_data = jnp.zeros([batch_size, max_src_len, am_dim])
-            am_paddings = (jnp.arange(max_src_len)[None, :] >= src_len[:, None]).astype(jnp.int32)
+            am_paddings = jnp.arange(max_src_len)[None, :] >= src_len[:, None]
             expected_decodes = dict(
                 raw_sequences=jnp.array(
                     [
@@ -1385,7 +1385,7 @@ class TransducerDecoderModelTest(TestCase):
                             [0, 1, 1, 1, 1, 1, 1],
                         ],
                     ]
-                ),
+                ).astype(jnp.bool),
                 probabilities=jnp.array(
                     [
                         [0.8**3, 0.2, 0.8 * 0.2, 0.8**2 * 0.2],
@@ -1398,7 +1398,7 @@ class TransducerDecoderModelTest(TestCase):
             src_len = jnp.array([3, 4])
             # [batch_size, max_src_len, am_dim].
             am_data = jnp.zeros([batch_size, max_src_len, am_dim])
-            am_paddings = (jnp.arange(max_src_len)[None, :] >= src_len[:, None]).astype(jnp.int32)
+            am_paddings = jnp.arange(max_src_len)[None, :] >= src_len[:, None]
             expected_decodes = dict(
                 raw_sequences=jnp.array(
                     [
@@ -1411,7 +1411,7 @@ class TransducerDecoderModelTest(TestCase):
                         [[1, 1, 1, 1, 1], [0, 0, 0, 0, 1], [0, 0, 1, 1, 1], [0, 0, 0, 1, 1]],
                         [[1, 1, 1, 1, 1], [0, 1, 1, 1, 1], [0, 0, 0, 0, 1], [0, 0, 1, 1, 1]],
                     ]
-                ),
+                ).astype(jnp.bool),
                 probabilities=jnp.array(
                     [
                         [
@@ -1501,7 +1501,7 @@ class TransducerDecoderModelTest(TestCase):
         src_len = jnp.array([2, 5, 0])
         # [batch_size, src_len, am_dim].
         am_data = jax.random.normal(jax.random.PRNGKey(312), [batch_size, max_src_len, am_dim])
-        am_paddings = (jnp.arange(max_src_len)[None, :] >= src_len[:, None]).astype(jnp.int32)
+        am_paddings = jnp.arange(max_src_len)[None, :] >= src_len[:, None]
         # Test beam_search_decode.
         beam_search_outputs, _ = F(
             layer,
@@ -1518,7 +1518,7 @@ class TransducerDecoderModelTest(TestCase):
         # src_len = 0 for the 3rd example.
         self.assertNestedEqual(
             beam_search_outputs.paddings[2],
-            jnp.ones((num_decodes, max_decode_len), dtype=jnp.int32),
+            jnp.ones((num_decodes, max_decode_len), dtype=jnp.bool),
         )
         # The decoding finishes with the eos token.
         self.assertNestedEqual(
@@ -1647,7 +1647,7 @@ class LASDecoderModelTest(TestCase):
         # [batch_size, max_seq_len, dim].
         inputs = jax.random.normal(input_key, [batch_size, max_src_len, cfg.input_dim]) * 1000
         # [batch_size, max_seq_len].
-        paddings = (jnp.arange(max_src_len) >= src_len[:, None]).astype(jnp.int32)
+        paddings = jnp.arange(max_src_len) >= src_len[:, None]
         prefix = jax.random.randint(
             prefix_key,
             shape=[batch_size, max_tgt_len],

--- a/axlearn/audio/encoder_asr.py
+++ b/axlearn/audio/encoder_asr.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 from math import prod
 from typing import Any, Optional
 
+import chex
 import jax.numpy as jnp
 
 from axlearn.audio.frontend import LogMelFrontend
@@ -22,7 +23,7 @@ from axlearn.common.conformer import RepeatedConformerLayer
 from axlearn.common.ein_ops import rearrange
 from axlearn.common.layers import Dropout, Linear
 from axlearn.common.module import Module
-from axlearn.common.utils import Tensor
+from axlearn.common.utils import Tensor, safe_not
 
 
 class SpeechFeatureLayer(BaseLayer):
@@ -81,6 +82,7 @@ class SpeechFeatureLayer(BaseLayer):
                 [batch_size, subsampled_frames, subsampled_freq, output_dim].
             - paddings: A 0/1 Tensor of shape [batch_size, subsampled_frames].
         """
+        chex.assert_type(paddings, jnp.bool)
         # Compute frontend features.
         features = self.frontend(inputs=inputs, paddings=paddings)
         self.add_module_output("spectrogram", features)
@@ -173,7 +175,7 @@ class SpeechContextNetwork(BaseLayer):
             activations=x,
             activation_paddings=paddings,
         )
-        return dict(outputs=x * (1 - paddings[..., None]), paddings=paddings)
+        return dict(outputs=x * safe_not(paddings)[..., None], paddings=paddings)
 
 
 class ASREncoder(BaseLayer):

--- a/axlearn/audio/model_asr_test.py
+++ b/axlearn/audio/model_asr_test.py
@@ -62,7 +62,7 @@ def _fake_input_batch(prng_key: Tensor, *, pad_id: int, eos_id: int):
         prng_key, minval=-(2**15), maxval=2**15, shape=[batch_size, max_src_len]
     )
     src_length = jnp.array([0, 3000, 4000, 4500])
-    src_paddings = (jnp.arange(max_src_len)[None, :] >= src_length[:, None]).astype(jnp.int32)
+    src_paddings = jnp.arange(max_src_len)[None, :] >= src_length[:, None]
     input_ids = jnp.array(
         [
             [1, eos_id, pad_id, pad_id, pad_id],

--- a/axlearn/audio/spectrum_augmenter.py
+++ b/axlearn/audio/spectrum_augmenter.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 from axlearn.common.base_layer import BaseLayer
 from axlearn.common.config import config_class
 from axlearn.common.module import Module
-from axlearn.common.utils import Tensor
+from axlearn.common.utils import Tensor, safe_not
 
 
 class MaskSampler(BaseLayer):
@@ -166,7 +166,7 @@ class SpectrumAugmenter(BaseLayer):
         )
         # [batch_size, num_frames].
         time_masks = self.time_mask_sampler(
-            input_lengths=jnp.sum(1 - paddings, axis=1),
+            input_lengths=jnp.sum(safe_not(paddings), axis=1),
             max_length=num_frames,
         )
 

--- a/axlearn/common/attention_bias.py
+++ b/axlearn/common/attention_bias.py
@@ -39,7 +39,7 @@ from jax.sharding import PartitionSpec
 
 from axlearn.common import struct
 from axlearn.common.config import ClassConfigBase, ConfigOr, config_for_class, maybe_instantiate
-from axlearn.common.utils import Tensor
+from axlearn.common.utils import Tensor, safe_not
 
 NEG_INF = -1e15
 
@@ -786,7 +786,7 @@ def bool_to_bias(mask: OpT) -> OpT:
         return None
     if mask.dtype != jnp.bool:
         raise ValueError("mask must be a Boolean tensor.")
-    return (~mask) * NEG_INF
+    return safe_not(mask) * NEG_INF
 
 
 def _make_bool_segment_mask(*, source_segments: Tensor, target_segments: Tensor) -> Tensor:

--- a/axlearn/common/base_layer_test.py
+++ b/axlearn/common/base_layer_test.py
@@ -42,6 +42,7 @@ from axlearn.common.param_init import (
     WeightInitializer,
 )
 from axlearn.common.test_utils import TestCase, assert_allclose, set_threefry_partitionable
+from axlearn.common.utils import safe_not
 
 
 class TestLayer(BaseLayer):
@@ -450,14 +451,14 @@ class BaseLayerTest(TestCase):
                 output_collections.summaries["activations/inputs_norm"].weight, batch_size
             )
         else:
-            num_frames = jnp.sum(1 - paddings)
+            num_frames = jnp.sum(safe_not(paddings))
             self.assertEqual(
                 output_collections.summaries["activations/inputs_mean"].weight, num_frames
             )
             self.assertEqual(
                 output_collections.summaries["activations/inputs_norm"].weight, num_frames
             )
-            inputs_with_padding = inputs * (1 - paddings)[:, :, None, None]
+            inputs_with_padding = inputs * safe_not(paddings)[:, :, None, None]
             expected_mean = jnp.sum(inputs_with_padding) / jnp.maximum(1, num_frames) / (2 * 4)
             inputs_norm = jnp.sqrt(jnp.sum(inputs_with_padding**2, axis=(2, 3)) / (2 * 4))
             expected_norm = jnp.sum(inputs_norm) / jnp.maximum(1, num_frames)

--- a/axlearn/common/convolution_test.py
+++ b/axlearn/common/convolution_test.py
@@ -27,7 +27,7 @@ from axlearn.common.convolution import (
 from axlearn.common.module import functional as F
 from axlearn.common.param_converter import as_torch_tensor
 from axlearn.common.test_utils import TestCase, assert_allclose
-from axlearn.common.utils import shapes
+from axlearn.common.utils import safe_not, shapes
 
 
 def _copy(src: jnp.ndarray, dst: torch.nn.Parameter):
@@ -93,7 +93,10 @@ class ConvTest(TestCase):
         # https://github.com/tensorflow/lingvo/blob/master/lingvo/core/conv_layers_with_time_padding_test.py#L157.
         window = 3
         out_paddings = compute_conv_paddings(
-            jnp.array([input_paddings]), window=window, stride=stride, conv_padding=padding_cfg
+            jnp.array([input_paddings], jnp.bool),
+            window=window,
+            stride=stride,
+            conv_padding=padding_cfg,
         )
         assert_allclose(out_paddings[0], expected_paddings)
 
@@ -222,7 +225,7 @@ class ConvTest(TestCase):
         """Tests conv_output_shape() with explicit padding cfg."""
         batch_size = 5
         seq_len = 5
-        paddings = jnp.triu(jnp.ones((batch_size, seq_len)), k=1)
+        paddings = jnp.triu(jnp.ones((batch_size, seq_len)), k=1).astype(jnp.bool)
 
         explicit_padding = convolution.conv_explicit_padding(
             window=(window,), strides=(stride,), padding=ref_padding, dilation=(1,)
@@ -251,7 +254,7 @@ class ConvTest(TestCase):
         """Tests compute_conv_paddings() as described in conv_explicit_padding()."""
         window, stride = 5, 2
         out_paddings = compute_conv_paddings(
-            jnp.array([paddings]),
+            jnp.array([paddings], jnp.bool),
             window=window,
             stride=stride,
             conv_padding=padding,
@@ -285,7 +288,7 @@ class ConvTest(TestCase):
         input_paddings = [0, 0, 0, 1, 1, 1]
         try:
             out_paddings = compute_conv_paddings(
-                jnp.array([input_paddings]),
+                jnp.array([input_paddings], jnp.bool),
                 window=window,
                 stride=1,
                 conv_padding=padding,
@@ -1876,7 +1879,7 @@ class ConvTransposeTest(TestCase):
         prng_key, input_key = jax.random.split(prng_key)
         width, height = 12, 13
         inputs = jax.random.normal(input_key, [2, width, height, input_dim])
-        paddings = jnp.zeros([2, width], dtype=inputs.dtype).at[:, -2:].set(1)
+        paddings = jnp.zeros([2, width], dtype=jnp.bool).at[:, -2:].set(1)
         # Compute layer outputs.
         (ref_outputs, ref_paddings), _ = F(
             ref_layer,
@@ -2028,7 +2031,7 @@ class ConvTransposeTest(TestCase):
         prng_key, input_key = jax.random.split(prng_key)
         inputs = jax.random.normal(input_key, [batch_size, max_seq_len, input_dim])
         # The 10 sequences have length 1 to 10.
-        paddings = jnp.triu(jnp.ones((batch_size, max_seq_len)), k=1)
+        paddings = jnp.triu(jnp.ones((batch_size, max_seq_len)), k=1).astype(jnp.bool)
 
         (test_outputs, test_paddings), _ = F(
             test_layer,
@@ -2079,7 +2082,7 @@ class StackOverTimeTest(TestCase):
             [[[1, 1], [2, 2], [3, 3], [4, 4], [5, 5]], [[7, 7], [8, 8], [0, 0], [0, 0], [0, 0]]],
             dtype=jnp.float32,
         )
-        paddings = jnp.array([[0, 0, 0, 0, 0], [0, 0, 1, 1, 1]])
+        paddings = jnp.array([[0, 0, 0, 0, 0], [0, 0, 1, 1, 1]], jnp.bool)
         layer: StackOverTime = (
             StackOverTime.default_config()
             .set(
@@ -2106,10 +2109,10 @@ class StackOverTimeTest(TestCase):
         """Tests that the stacked outputs is masked with the output paddings."""
         np.random.seed(500)
         inputs = np.random.normal(size=[2, 21, 16])
-        paddings = np.ones([2, 21], dtype=np.float32)
+        paddings = np.ones([2, 21], dtype=np.bool_)
         paddings[0, :9] = 0
         paddings[1, :14] = 0
-        inputs = inputs * (1 - paddings)[:, :, None]
+        inputs = inputs * safe_not(paddings)[:, :, None]
 
         layer: StackOverTime = (
             StackOverTime.default_config()

--- a/axlearn/common/poolings_test.py
+++ b/axlearn/common/poolings_test.py
@@ -101,7 +101,7 @@ class PoolingTest(TestCase):
         # test w/ mask
         paddings = jnp.hstack(
             [jnp.zeros((inputs.shape[0], inputs.shape[1] - 1)), jnp.ones((inputs.shape[0], 1))]
-        )
+        ).astype(jnp.bool)
 
         outputs, _ = F(
             pooler,
@@ -180,7 +180,7 @@ class PoolingTest(TestCase):
         # test w/ mask
         paddings = jnp.hstack(
             [jnp.zeros((inputs.shape[0], inputs.shape[1] - 1)), jnp.ones((inputs.shape[0], 1))]
-        )
+        ).astype(jnp.bool)
 
         outputs, _ = F(
             pooler,
@@ -230,7 +230,7 @@ class PoolingTest(TestCase):
         # Test w/ mask.
         paddings = jnp.hstack(
             [jnp.zeros((inputs.shape[0], inputs.shape[1] - 1)), jnp.ones((inputs.shape[0], 1))]
-        )
+        ).astype(jnp.bool)
 
         outputs, _ = F(
             pooler,
@@ -250,7 +250,7 @@ class PoolingTest(TestCase):
         assert_allclose(outputs, outputs_expected, atol=atol)
 
         # Test w/ all zero masks.
-        paddings = jnp.ones((inputs.shape[0], inputs.shape[1]))
+        paddings = jnp.ones((inputs.shape[0], inputs.shape[1]), jnp.bool)
 
         outputs, _ = F(
             pooler,
@@ -300,7 +300,7 @@ class PoolingTest(TestCase):
         # Test w/ mask.
         paddings = jnp.hstack(
             [jnp.zeros((inputs.shape[0], inputs.shape[1] - 1)), jnp.ones((inputs.shape[0], 1))]
-        )
+        ).astype(jnp.bool)
 
         outputs, _ = F(
             pooler,
@@ -316,7 +316,7 @@ class PoolingTest(TestCase):
 
         # Test w/ specific mask.
         inputs = jax.random.normal(input_key, [3, 3, input_dim])
-        paddings = jnp.asarray([[0, 0, 1], [0, 0, 1], [0, 0, 0]], dtype=jnp.int32)
+        paddings = jnp.asarray([[0, 0, 1], [0, 0, 1], [0, 0, 0]], dtype=jnp.bool)
         outputs, _ = F(
             pooler,
             inputs=utils.cast_floats((inputs, paddings), dtype),
@@ -332,7 +332,7 @@ class PoolingTest(TestCase):
         inputs = jnp.asarray(
             [[[0.1, 0.2, 0.3], [0.2, 0.3, 0.4]], [[0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]]
         )
-        paddings = jnp.asarray([[0, 1], [0, 0]], dtype=jnp.int32)
+        paddings = jnp.asarray([[0, 1], [0, 0]], dtype=jnp.bool)
 
         outputs, _ = F(
             pooler,
@@ -409,7 +409,7 @@ class PoolingTest(TestCase):
         # Test w/ mask.
         paddings = jnp.hstack(
             [jnp.zeros((inputs.shape[0], inputs.shape[1] - 1)), jnp.ones((inputs.shape[0], 1))]
-        )
+        ).astype(jnp.bool)
 
         outputs, _ = F(
             pooler,
@@ -424,7 +424,7 @@ class PoolingTest(TestCase):
         self.assertEqual(outputs.dtype, dtype)
 
         # Test w/ all zero masks.
-        paddings = jnp.ones((inputs.shape[0], inputs.shape[1]))
+        paddings = jnp.ones((inputs.shape[0], inputs.shape[1]), jnp.bool)
 
         outputs, _ = F(
             pooler,

--- a/axlearn/common/quantizer.py
+++ b/axlearn/common/quantizer.py
@@ -29,6 +29,7 @@ https://github.com/facebookresearch/fairseq/blob/d871f6169f8185837d1c11fb28da56a
 from enum import Enum, unique
 from typing import NamedTuple, Optional
 
+import chex
 import jax.nn
 import jax.numpy as jnp
 
@@ -46,7 +47,7 @@ from axlearn.common.param_init import (
     constant_initializer,
 )
 from axlearn.common.schedule import as_schedule_fn
-from axlearn.common.utils import Nested, NestedTensor, Tensor
+from axlearn.common.utils import Nested, NestedTensor, Tensor, safe_not
 
 _einsum_dims = "abcdefwxyz"
 
@@ -61,7 +62,7 @@ def compute_code_histogram(onehots: Tensor, paddings: Tensor) -> Tensor:
     Returns:
         Histogram of the quantized codes of shape [num_codebooks, codebook_size].
     """
-    onehots = onehots * (1 - paddings)[..., None, None]
+    onehots = onehots * safe_not(paddings)[..., None, None]
     # [num_codebooks, codebook_size].
     histogram = jnp.sum(onehots, axis=tuple(range(onehots.ndim - 2)))
     return histogram
@@ -70,7 +71,7 @@ def compute_code_histogram(onehots: Tensor, paddings: Tensor) -> Tensor:
 def compute_code_pplx(onehots: Tensor, paddings: Tensor) -> tuple[Tensor, Tensor]:
     """Computes pplx and entropy of the quantized codes distribution."""
     histogram = compute_code_histogram(onehots, paddings)
-    normalizer = jnp.sum(1 - paddings)
+    normalizer = jnp.sum(safe_not(paddings))
     # [num_codebooks, codebook_size].
     probs = histogram / jnp.maximum(normalizer, 1.0)
     log_probs = jnp.log(jnp.maximum(1.0e-30, probs))
@@ -254,11 +255,11 @@ def _apply_paddings(*, outputs: BaseQuantizer.Output, paddings: Tensor) -> BaseQ
     Returns:
         padded_outputs: BaseQuantizer.Output.
     """
-
+    chex.assert_type(paddings, jnp.bool)
     # ids are padded with -1.
-    ids_paddings = paddings[:, :, None].astype(outputs.ids.dtype)
+    ids_paddings = paddings[:, :, None]
     ids = outputs.ids * (1 - ids_paddings) + (-1) * ids_paddings
-    quantized_vectors = outputs.quantized_vectors * (1 - paddings)[:, :, None, None]
+    quantized_vectors = outputs.quantized_vectors * safe_not(paddings)[:, :, None, None]
     return BaseQuantizer.Output(
         ids=ids,
         quantized_vectors=quantized_vectors,
@@ -286,7 +287,7 @@ def _add_codebook_summaries(*, context: InvocationContext, onehots: Tensor, padd
     pplx, entropy = compute_code_pplx(onehots=onehots, paddings=paddings)
     batch_size = paddings.shape[0]
 
-    num_frames = jnp.sum(1 - paddings)
+    num_frames = jnp.sum(safe_not(paddings))
     context.add_summary(
         "codebook/num_frames",
         WeightedScalar(num_frames.astype(jnp.float32) / batch_size, batch_size),
@@ -504,7 +505,7 @@ class KmeansVectorQuantizer(BaseQuantizer):
 
         # Compute mean squared errors between q_vecs and inputs on non-padded frames.
         # Number of valid frames * input_dim.
-        num_frames = jnp.sum(1 - paddings)
+        num_frames = jnp.sum(safe_not(paddings))
         denominator = jnp.maximum(num_frames * input_dim, 1)
         # Eq.3 of VQ-VAE paper https://arxiv.org/pdf/1711.00937.pdf.
         # The codebook is optimized by kmeans_loss only.
@@ -515,14 +516,16 @@ class KmeansVectorQuantizer(BaseQuantizer):
         )
         kmeans_loss = (
             jnp.sum(
-                (q_vecs - jax.lax.stop_gradient(inputs_to_loss)) ** 2 * (1 - paddings)[:, :, None]
+                (q_vecs - jax.lax.stop_gradient(inputs_to_loss)) ** 2
+                * safe_not(paddings)[:, :, None]
             )
             / denominator
         )
         # The inputs receive gradients from commitment_loss.
         commitment_loss = (
             jnp.sum(
-                (inputs_to_loss - jax.lax.stop_gradient(q_vecs)) ** 2 * (1 - paddings)[:, :, None]
+                (inputs_to_loss - jax.lax.stop_gradient(q_vecs)) ** 2
+                * safe_not(paddings)[:, :, None]
             )
             / denominator
         )
@@ -535,7 +538,7 @@ class KmeansVectorQuantizer(BaseQuantizer):
         # Note that gradient on quantized_vectors is not propagated to the codebook.
         quantized_vectors = inputs + jax.lax.stop_gradient(q_vecs - inputs)
         # We need this to stop gradients on the padded inputs.
-        quantized_vectors = quantized_vectors * (1 - paddings)[:, :, None]
+        quantized_vectors = quantized_vectors * safe_not(paddings)[:, :, None]
 
         outputs = self.Output(
             # [batch_size, seq_len, num_codebooks].
@@ -638,13 +641,12 @@ class GumbelSoftmaxVectorQuantizer(BaseQuantizer):
             outputs = _apply_paddings(outputs=outputs, paddings=paddings)
         else:
             # [batch_size, seq_len, 1].
-            mask = (1 - paddings)[:, :, None].astype(ids.dtype)
-            ids = ids * mask + (-1) * (1 - mask)
+            mask = safe_not(paddings)[:, :, None]
+            ids = ids * mask + (-1) * safe_not(mask)
             # TODO(dhwang2): optimize memory by scan for long context training.
             # [batch_size, seq_len, num_codebooks, vocab_size].
             onehots = _ids_to_onehots(ids, codebook_size=cfg.codebook_size, dtype=inputs.dtype)
             # We need this to stop gradients on the padded frames.
-            mask = mask.astype(inputs.dtype)
             onehots = onehots * mask[:, :, :, None]
             # [batch_size, seq_len, num_codebooks, vocab_size].
             y_soft = jax.nn.softmax(logits, axis=-1)

--- a/axlearn/common/quantizer_test.py
+++ b/axlearn/common/quantizer_test.py
@@ -40,7 +40,7 @@ from axlearn.common.test_utils import (
     prng_impl,
     set_threefry_partitionable,
 )
-from axlearn.common.utils import Tensor, shapes
+from axlearn.common.utils import Tensor, safe_not, shapes
 
 testdata_dir = os.path.join(os.path.dirname(__file__), "../experiments/testdata")
 
@@ -83,7 +83,7 @@ class HelpersTest(TestCase):
             np.random.rand(batch_size, seq_len, num_groups, codebook_dim).astype(np.float32)
             + input_mean
         )
-        paddings = jnp.zeros([batch_size, seq_len])
+        paddings = jnp.zeros([batch_size, seq_len], jnp.bool)
         if metric not in (SimilarityMetric.L2_DISTANCE, SimilarityMetric.DOT_PRODUCT):
             with self.assertRaisesRegex(ValueError, "Expect DOT_PRODUCT metric"):
                 quantize_by_nearest_neighbor(inputs=inputs, codebook=codebook, metric=metric)
@@ -123,7 +123,7 @@ class HelpersTest(TestCase):
             )
             assert_allclose(
                 expected_outputs[num_groups][input_mean][1],
-                np.sum(q_outputs.ids * (1 - paddings[:, :, None])),
+                np.sum(q_outputs.ids * safe_not(paddings)[:, :, None]),
                 rtol=1e-06,
                 atol=1e-06,
             )
@@ -146,7 +146,7 @@ class HelpersTest(TestCase):
                 [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [0, 0]],
             ]
         )
-        paddings = jnp.array([[0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 1]])
+        paddings = jnp.array([[0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 1]], jnp.bool)
 
         pplx, entropy = compute_code_pplx(
             onehots=jax.nn.one_hot(codes, num_classes=vocab_size, axis=-1), paddings=paddings
@@ -327,7 +327,7 @@ class RandomVectorQuantizerTest(TestCase):
 
         np.random.seed(2022)
         inputs = np.random.rand(batch_size, seq_len, input_dim).astype(np.float32)
-        paddings = np.zeros((batch_size, seq_len)).astype(np.float32)
+        paddings = np.zeros((batch_size, seq_len)).astype(np.bool_)
         q_outputs, output_collections = F(
             layer,
             inputs=dict(inputs=inputs, paddings=paddings),
@@ -351,14 +351,14 @@ class RandomVectorQuantizerTest(TestCase):
             rtol=1e-6,
         )
         assert_allclose(
-            np.sum(q_outputs.ids * (1 - paddings[:, :, None])),
+            np.sum(q_outputs.ids * safe_not(paddings)[:, :, None]),
             expected_values[batch_size][normalize_codebook]["ids"],
             atol=1e-6,
             rtol=1e-6,
         )
         self.assertEqual(
             output_collections.summaries["codebook/num_frames"].mean,
-            jnp.sum(1 - paddings) / batch_size,
+            jnp.sum(safe_not(paddings)) / batch_size,
         )
         assert_allclose(
             output_collections.summaries["codebook/coverage"].mean,
@@ -411,7 +411,7 @@ class RandomVectorQuantizerTest(TestCase):
             )
 
         inputs = jax.random.uniform(jax.random.PRNGKey(1), (batch_size, seq_len, input_dim))
-        paddings = jnp.zeros((batch_size, seq_len))
+        paddings = jnp.zeros((batch_size, seq_len), jnp.bool)
 
         _, (grad_params, grad_inputs) = jax.value_and_grad(_loss, argnums=(0, 1), has_aux=False)(
             layer_params, jnp.asarray(inputs), jnp.asarray(paddings)
@@ -432,7 +432,7 @@ class RandomVectorQuantizerTest(TestCase):
         layer: RandomVectorQuantizer = cfg.instantiate(parent=None)
         layer_params = layer.initialize_parameters_recursively(prng_key=jax.random.PRNGKey(1))
         inputs = jax.random.uniform(jax.random.PRNGKey(1), (batch_size, seq_len, input_dim))
-        paddings = jnp.zeros((batch_size, seq_len))
+        paddings = jnp.zeros((batch_size, seq_len), jnp.bool)
         outputs, _ = F(
             layer,
             inputs=dict(inputs=inputs, paddings=paddings),
@@ -451,7 +451,7 @@ class RandomVectorQuantizerTest(TestCase):
             state=layer_params,
             method="lookup",
         )
-        quantized_vectors = lookup_outputs.quantized_vectors * (1 - paddings)[:, :, None, None]
+        quantized_vectors = lookup_outputs.quantized_vectors * safe_not(paddings)[:, :, None, None]
         self.assertNestedAllClose(quantized_vectors, outputs.quantized_vectors)
 
 
@@ -483,7 +483,7 @@ class KmeansVectorQuantizerTest(TestCase):
             + input_mean
         )
         paddings = jnp.arange(seq_len)[None, :] >= jnp.array([2, 3])[:, None]
-        inputs = inputs * (1 - paddings)[:, :, None]
+        inputs = inputs * safe_not(paddings)[:, :, None]
         outputs, output_collections = F(
             layer,
             inputs=dict(inputs=inputs, paddings=paddings),
@@ -517,7 +517,7 @@ class KmeansVectorQuantizerTest(TestCase):
         )
         assert_allclose(
             expected_outputs[num_groups][input_mean][1],
-            np.sum(outputs.ids * (1 - paddings[:, :, None])),
+            np.sum(outputs.ids * safe_not(paddings)[:, :, None]),
             atol=1e-6,
             rtol=1e-6,
         )
@@ -595,7 +595,7 @@ class KmeansVectorQuantizerTest(TestCase):
             jax.random.PRNGKey(1), shape=(batch_size, seq_len, dim_from_all_codebooks)
         )
         paddings = jnp.arange(seq_len)[None, :] >= jnp.array([2, 3])[:, None]
-        inputs = inputs * (1 - paddings)[:, :, None]
+        inputs = inputs * safe_not(paddings)[:, :, None]
         F(
             layer,
             inputs=dict(inputs=inputs, paddings=paddings),
@@ -665,7 +665,7 @@ class KmeansVectorQuantizerTest(TestCase):
         np.random.seed(2000)
         inputs = np.random.rand(batch_size, seq_len, dim_from_all_codebooks).astype(np.float32)
         paddings = np.arange(seq_len)[None, :] >= np.array([5, 6, 3, 4])[:, None]
-        inputs = inputs * (1 - paddings)[:, :, None]
+        inputs = inputs * safe_not(paddings)[:, :, None]
 
         (_, outputs), (grad_params, grad_inputs) = jax.value_and_grad(
             _loss, argnums=(0, 1), has_aux=True
@@ -684,8 +684,8 @@ class KmeansVectorQuantizerTest(TestCase):
             rtol=1e-6,
         )
 
-        num_frames = jnp.sum(1 - paddings)
-        mask = (1 - paddings)[:, :, None]
+        num_frames = jnp.sum(safe_not(paddings))
+        mask = safe_not(paddings)[:, :, None]
         reshape_quantized_vectors = jnp.reshape(
             outputs.quantized_vectors, [batch_size, seq_len, -1]
         )
@@ -734,7 +734,7 @@ class KmeansVectorQuantizerTest(TestCase):
             + input_mean
         )
         paddings = jnp.arange(seq_len)[None, :] >= jnp.array([2, 3])[:, None]
-        inputs = inputs * (1 - paddings)[:, :, None]
+        inputs = inputs * safe_not(paddings)[:, :, None]
         outputs, _ = F(
             layer,
             inputs=dict(inputs=inputs, paddings=paddings),
@@ -754,7 +754,7 @@ class KmeansVectorQuantizerTest(TestCase):
             state=layer_params,
             method="lookup",
         )
-        quantized_vectors = lookup_outputs.quantized_vectors * (1 - paddings)[:, :, None, None]
+        quantized_vectors = lookup_outputs.quantized_vectors * safe_not(paddings)[:, :, None, None]
         self.assertNestedAllClose(quantized_vectors, outputs.quantized_vectors)
 
 
@@ -788,10 +788,8 @@ class GumbelSoftmaxVectorQuantizerTest(TestCase):
         batch_size, seq_len = 2, 4
         np.random.seed(2021)
         inputs = np.random.rand(batch_size, seq_len, input_dim).astype(np.float32)
-        paddings = np.array(
-            np.arange(seq_len)[None, :] >= np.array([2, 3])[:, None], dtype=np.float32
-        )
-        inputs = inputs * (1 - paddings)[:, :, None]
+        paddings = np.arange(seq_len)[None, :] >= np.array([2, 3])[:, None]
+        inputs = inputs * safe_not(paddings)[:, :, None]
 
         outputs, output_collections = F(
             layer,
@@ -849,7 +847,7 @@ class GumbelSoftmaxVectorQuantizerTest(TestCase):
             allow_pickle=True,
         ).item()
         ref_outputs = testcase["outputs"]
-        paddings = testcase["paddings"]
+        paddings = testcase["paddings"].astype(jnp.bool)
         outputs, output_collections = F(
             layer,
             inputs=dict(inputs=testcase["inputs"], paddings=paddings),
@@ -873,7 +871,7 @@ class GumbelSoftmaxVectorQuantizerTest(TestCase):
         )
         assert_allclose(
             ref_outputs["targets"].detach().numpy(),
-            outputs.ids * (1 - paddings[:, :, None]),
+            outputs.ids * safe_not(paddings)[:, :, None],
             atol=1e-6,
             rtol=1e-6,
         )
@@ -913,7 +911,7 @@ class GumbelSoftmaxVectorQuantizerTest(TestCase):
         np.random.seed(2000)
         inputs = np.random.rand(batch_size, seq_len, input_dim).astype(np.float32)
         paddings = np.arange(seq_len)[None, :] >= np.array([5, 6, 3, 4])[:, None]
-        inputs = inputs * (1 - paddings)[:, :, None]
+        inputs = inputs * safe_not(paddings)[:, :, None]
 
         (_, (outputs, side_outputs)), (grad_params, grad_inputs) = jax.value_and_grad(
             _loss, argnums=(0, 1), has_aux=True
@@ -925,7 +923,7 @@ class GumbelSoftmaxVectorQuantizerTest(TestCase):
         # Computes gradient w.r.t inputs using Gumbel softmax trick and chain rule.
         grad_onehots = jnp.einsum(
             "btgh,vgh->btgv",
-            grad_q_vecs * (1 - paddings)[:, :, None, None],
+            grad_q_vecs * safe_not(paddings)[:, :, None, None],
             layer_params["codebook"],
         )
         # [batch_size, seq_len, num_groups, vocab_size, vocab_size].
@@ -976,10 +974,8 @@ class GumbelSoftmaxVectorQuantizerTest(TestCase):
         batch_size, seq_len = 2, 4
         np.random.seed(2021)
         inputs = np.random.rand(batch_size, seq_len, input_dim).astype(np.float32)
-        paddings = np.array(
-            np.arange(seq_len)[None, :] >= np.array([2, 3])[:, None], dtype=np.float32
-        )
-        inputs = inputs * (1 - paddings)[:, :, None]
+        paddings = np.arange(seq_len)[None, :] >= np.array([2, 3])[:, None]
+        inputs = inputs * safe_not(paddings)[:, :, None]
         outputs, _ = F(
             layer,
             inputs=dict(inputs=inputs, paddings=paddings),
@@ -999,7 +995,7 @@ class GumbelSoftmaxVectorQuantizerTest(TestCase):
             state=layer_params,
             method="lookup",
         )
-        quantized_vectors = lookup_outputs.quantized_vectors * (1 - paddings)[:, :, None, None]
+        quantized_vectors = lookup_outputs.quantized_vectors * safe_not(paddings)[:, :, None, None]
         self.assertNestedAllClose(quantized_vectors, outputs.quantized_vectors)
 
 

--- a/axlearn/common/splade.py
+++ b/axlearn/common/splade.py
@@ -14,7 +14,7 @@ from axlearn.common.config import config_class
 from axlearn.common.layers import BaseClassificationHead, RedirectToSharedModule, get_activation_fn
 from axlearn.common.module import Module
 from axlearn.common.poolings import BasePoolingLayer
-from axlearn.common.utils import Tensor
+from axlearn.common.utils import Tensor, safe_not
 
 
 class SpladePooling(BasePoolingLayer):
@@ -91,6 +91,6 @@ class SpladePooling(BasePoolingLayer):
             splade_output = jnp.log1p(get_activation_fn(cfg.splade_activation_fn)(x))
         elif cfg.splade_mode == "sum":
             splade_output = jnp.log1p(get_activation_fn(cfg.splade_activation_fn)(x))
-            splade_output *= 1 - paddings  # Set padded values to 0.
+            splade_output *= safe_not(paddings)  # Set padded values to 0.
             splade_output = jnp.sum(splade_output, axis=1, keepdims=True)
         return splade_output

--- a/axlearn/common/splade_test.py
+++ b/axlearn/common/splade_test.py
@@ -26,7 +26,7 @@ from axlearn.common.poolings import BasePoolingLayer
 from axlearn.common.splade import SpladePooling
 from axlearn.common.test_utils import TestCase, assert_allclose
 from axlearn.common.torch_utils import parameters_from_torch_layer
-from axlearn.common.utils import Tensor
+from axlearn.common.utils import Tensor, safe_not
 
 
 class SpladePoolingParentLayer(BaseLayer):
@@ -98,7 +98,7 @@ class SpladePoolingTest(TestCase):
         else:
             torch_paddings = torch.from_numpy(paddings.astype(float))
             # axlearn_paddings = True means padded tokens.
-            axlearn_paddings = jnp.asarray((1 - paddings).astype(bool))
+            axlearn_paddings = safe_not(paddings)
 
         # Reference output.
         ref_output, ref_model_params = self.ref_splade_implementation(

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -1969,6 +1969,20 @@ def sequence_mask(*, lengths: Tensor, max_len: int, dtype: jnp.dtype = jnp.bool)
     return (sequence < lengths).astype(dtype)
 
 
+def safe_not(mask: Tensor) -> Tensor:
+    """Inverts a boolean mask.
+
+    Commonly used to switch between paddings and mask.
+
+    Args:
+        mask: A boolean tensor.
+
+    Returns:
+        A boolean tensor of the same shape.
+    """
+    return ~(mask.astype(jnp.bool))
+
+
 def validate_contains_paths(x: Nested[Tensor], paths: Sequence[str]):
     """Raises ValueError if any of the given `paths` are not present in `x`."""
     for path in paths:

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -945,6 +945,18 @@ class TreeUtilsTest(TestCase):
         expected = jnp.array(expected).astype(dtype)
         self.assertNestedAllClose(mask, expected)
 
+    @parameterized.parameters(
+        dict(mask=[True, False], expected=[False, True]),
+        dict(mask=[[False, True], [True, False]], expected=[[True, False], [False, True]]),
+        dict(mask=[1, 0], expected=[False, True]),
+        dict(mask=[10, 0], expected=[False, True]),
+        dict(mask=[1.0, 0.0], expected=[False, True]),
+    )
+    def test_safe_not(self, mask, expected):
+        inverted_mask = utils.safe_not(jnp.array(mask))
+        self.assertEqual(inverted_mask.dtype, jnp.bool)
+        self.assertEqual(inverted_mask.tolist(), expected)
+
     def test_prune_empty_state(self):
         state = {
             "state": {

--- a/axlearn/vision/beit_image_tokenizer.py
+++ b/axlearn/vision/beit_image_tokenizer.py
@@ -182,7 +182,7 @@ class BEiTImageVQKD(BaseLayer):
         # encoded_outputs shape [batch_size, seq_len, codebook_dim]
         encoded_outputs = self.output_proj(encoded_features)
         encoded_outputs = self.l2norm(encoded_outputs)
-        paddings = jnp.zeros(encoded_outputs.shape[:2])
+        paddings = jnp.zeros(encoded_outputs.shape[:2], jnp.bool)
         quantized_output = self.quantizer(inputs=encoded_outputs, paddings=paddings)
         # quantized_output.quantized_vectors shape [batch_size, seq_len, 1, codebook_dim]
         # quantized_output.ids in shape [batch_size, seq_len, 1]

--- a/axlearn/vision/retinanet.py
+++ b/axlearn/vision/retinanet.py
@@ -26,7 +26,7 @@ from axlearn.common.config import (
 from axlearn.common.convolution import Conv2D
 from axlearn.common.layers import BatchNorm, get_activation_fn
 from axlearn.common.loss import ReductionMethod, focal_loss, huber_loss
-from axlearn.common.module import Module, NestedTensor, Tensor, child_context
+from axlearn.common.module import Module, child_context
 from axlearn.common.param_init import (
     PARAM_REGEXP_BIAS,
     PARAM_REGEXP_WEIGHT,
@@ -34,6 +34,7 @@ from axlearn.common.param_init import (
     DefaultInitializer,
     WeightInitializer,
 )
+from axlearn.common.utils import NestedTensor, Tensor, safe_not
 from axlearn.vision.anchor import AnchorGenerator, AnchorLabeler
 from axlearn.vision.box_coder import BoxCoder
 from axlearn.vision.detection_generator import MultilevelDetectionGenerator
@@ -498,8 +499,8 @@ class RetinaNetModel(BaseLayer):
                 ),
                 "box_targets": anchor_labels.groundtruth_boxes,
                 "class_targets": anchor_labels.groundtruth_classes,
-                "box_weights": ~anchor_labels.box_paddings,
-                "class_weights": ~anchor_labels.class_paddings,
+                "box_weights": safe_not(anchor_labels.box_paddings),
+                "class_weights": safe_not(anchor_labels.class_paddings),
                 # TODO(pdufter) move self._generate_anchors to anchor_labeler and only pass
                 # anchor_labels to metrics
                 "anchor_boxes_tiled": self._generate_anchors(

--- a/axlearn/vision/samplers.py
+++ b/axlearn/vision/samplers.py
@@ -7,7 +7,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from axlearn.common.module import Tensor
+from axlearn.common.utils import Tensor, safe_not
 
 
 def sample(*, is_candidate: Tensor, size: Tensor, prng_key: Tensor) -> Tensor:
@@ -89,7 +89,7 @@ class LabelSampler:
         """
         prng_key1, prng_key2 = jax.random.split(prng_key, num=2)
         foreground_candidates = (
-            ~paddings & (labels != self.ignore_label) & (labels != self.background_label)
+            safe_not(paddings) & (labels != self.ignore_label) & (labels != self.background_label)
         )
         num_foreground = jnp.minimum(jnp.sum(foreground_candidates, axis=-1), self.num_foreground)
         foreground_samples = sample(
@@ -97,7 +97,7 @@ class LabelSampler:
             size=num_foreground,
             prng_key=prng_key1,
         )
-        background_candidates = ~paddings & (labels == self.background_label)
+        background_candidates = safe_not(paddings) & (labels == self.background_label)
         num_background = self.size - num_foreground
         background_samples = sample(
             is_candidate=background_candidates,


### PR DESCRIPTION
Now all of paddings.dtype are bool (1bit), after
https://github.com/apple/axlearn/pull/1133

This PR is unifying coding style between ~paddings and 1 - paddings used inconsistently across the codebase. I’d like to standardize on ~paddings, because A 1-bit flip is cheaper than a subtraction.

In detail, the common operation `x * (1 - paddings)` involves 4 steps:

1. Cast `paddings` to `int32` to perform `1 - paddings`
2. Perform the subtraction: `1 - paddings`
3. Cast the result to `float32` to match `x`
4. Perform the float multiplication: `x * (1 - paddings)`

This introduces an unnecessary cast to `int32`.
In contrast, `x * ~paddings` only requires 3 steps:

1. Bitwise NOT (`~paddings`) — a cheap bit flip
2. Cast the result to `float32` to match `x`
3. Multiply `x * (~paddings)`

Also, `float * bool` (2 and 3 steps) may (will) be specially optimized in XLA or hardware, making this path potentially more efficient, while `float * int` is hard to be optimized as internal value matters.