### PR TITLE
Pathways headless mode

### DIFF
--- a/axlearn/common/compiler_options.py
+++ b/axlearn/common/compiler_options.py
@@ -163,6 +163,18 @@ def default_xla_options(
     return options
 
 
+def get_megascale_options(
+    xla_options: dict[str, Union[str, bool, int]]
+) -> dict[str, Union[str, bool, int]]:
+    return {k: v for k, v in xla_options.items() if k.startswith("megascale")}
+
+
+def get_xla_options(
+    xla_options: dict[str, Union[str, bool, int]]
+) -> dict[str, Union[str, bool, int]]:
+    return {k: v for k, v in xla_options.items() if not k.startswith("megascale")}
+
+
 def xla_flags_from_options(xla_options: dict[str, Union[str, bool, int]]) -> str:
     """Convert an XLA options dict suitable for
     `jitted_fn.lower(...).compile(compiler_options=xla_options)`

--- a/axlearn/common/compiler_options.py
+++ b/axlearn/common/compiler_options.py
@@ -171,7 +171,7 @@ def get_megascale_options(
 def get_xla_options(
     xla_options: dict[str, Union[str, bool, int]]
 ) -> dict[str, Union[str, bool, int]]:
-    return {k: v for k, v in xla_options.items() if not k.startswith("xla")}
+    return {k: v for k, v in xla_options.items() if k.startswith("xla")}
 
 
 def xla_flags_from_options(xla_options: dict[str, Union[str, bool, int]]) -> str:

--- a/axlearn/common/compiler_options.py
+++ b/axlearn/common/compiler_options.py
@@ -123,7 +123,6 @@ def default_xla_options(
             xla_should_allow_loop_variant_parameter_in_chain="true",
             xla_should_add_loop_invariant_op_in_chain="true",
             xla_tpu_use_enhanced_launch_barrier="true",
-            tpu_use_continuations="true",
             # TODO(kelvinzou): temporary workaround to avoid memory leak in megascale.
             megascale_grpc_enable_xor_tracer="false",
         )
@@ -172,7 +171,7 @@ def get_megascale_options(
 def get_xla_options(
     xla_options: dict[str, Union[str, bool, int]]
 ) -> dict[str, Union[str, bool, int]]:
-    return {k: v for k, v in xla_options.items() if not k.startswith("megascale")}
+    return {k: v for k, v in xla_options.items() if not k.startswith("xla")}
 
 
 def xla_flags_from_options(xla_options: dict[str, Union[str, bool, int]]) -> str:

--- a/axlearn/common/compiler_options.py
+++ b/axlearn/common/compiler_options.py
@@ -165,12 +165,29 @@ def default_xla_options(
 def get_megascale_options(
     xla_options: dict[str, Union[str, bool, int]]
 ) -> dict[str, Union[str, bool, int]]:
+    """Filters XLA options for those pertaining to Megascale.
+
+    Args:
+        xla_options: A dictionary of XLA options.
+
+    Returns:
+        A dictionary containing only Megascale-related XLA options
+        (those starting with 'megascale').
+    """
     return {k: v for k, v in xla_options.items() if k.startswith("megascale")}
 
 
 def get_xla_options(
     xla_options: dict[str, Union[str, bool, int]]
 ) -> dict[str, Union[str, bool, int]]:
+    """Filters XLA options for those starting with 'xla_'.
+
+    Args:
+        xla_options: A dictionary of XLA options.
+
+    Returns:
+        A dictionary containing only XLA-specific options (those starting with 'xla').
+    """
     return {k: v for k, v in xla_options.items() if k.startswith("xla")}
 
 

--- a/axlearn/common/compiler_options_test.py
+++ b/axlearn/common/compiler_options_test.py
@@ -56,6 +56,14 @@ class CompilerOptionsTest(test_utils.TestCase):
     def test_tpu_version_alias(self, tpu_type: str, expected: str):
         self.assertEqual(expected, compiler_options.infer_tpu_version(tpu_type))
 
+    def test_v6e_default_options_split_megascale_and_xla(self):
+        default_options = compiler_options.default_xla_options(
+            instance_type="tpu-v6e-512", num_slices=2, backend="tpu"
+        )
+        megascale_options = compiler_options.get_megascale_options(default_options)
+        xla_options = compiler_options.get_xla_options(default_options)
+        self.assertEqual(len(megascale_options) + len(xla_options), len(default_options))
+
     def test_xla_performance_flags(self):
         self.assertEqual(
             {},

--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -19,6 +19,8 @@ num_tpu_slices = int(os.environ.get("NUM_TPU_SLICES", 1))
 # Set LIBTPU_INIT_ARGS before importing jax!
 tpu_flags_exc = None
 try:
+    # This does NOT work for Pathways. XLA flags are set on the pathways-proxy.
+    # Megascale flags have to be set on the pathways-workers as arguments.
     libtpu_init_options = compiler_options.default_xla_options(
         instance_type=instance_type, num_slices=num_tpu_slices, backend="tpu"
     )


### PR DESCRIPTION
this pr depends on #1163 

Introduces a new --pathways_headless flag:
```
axlearn gcp launch run --cluster=$CLUSTER \
        --runner_name gke_tpu_pathways --pathways_headless \
        --name=$USER \
        --instance_type=tpu-v6e-16 \
        --num_replicas=1 \
        --bundler_spec=allow_dirty=True \
        --bundler_type=artifactregistry --bundler_spec=image=tpu \
        --bundler_spec=dockerfile=Dockerfile --bundler_spec=target=tpu
```