### PR TITLE
More efficient `rmtree` & `listdir` for buckets with hierarchical namespace enabled

### DIFF
--- a/axlearn/common/file_system.py
+++ b/axlearn/common/file_system.py
@@ -9,6 +9,8 @@ This module provides a common interface between these options.
 """
 # TODO(markblee): Consider supporting a pathlib-like interface.
 
+import concurrent
+import concurrent.futures
 import contextlib
 import functools
 import os
@@ -86,6 +88,20 @@ def _gs_client():
     return storage.Client(project=gcp_settings("project"), credentials=get_credentials())
 
 
+@functools.cache
+def _gs_control_client():
+    """Creates or retrieves the google cloud storage control client.
+    Different from `_gs_client`, it provides metadata-specific and control plane operations .
+    """
+    # pylint: disable=import-outside-toplevel
+    # Avoid introducing a global dependency on `gcp`.
+    from google.cloud import storage_control_v2  # pytype: disable=import-error
+
+    from axlearn.cloud.gcp.utils import get_credentials
+
+    return storage_control_v2.StorageControlClient(credentials=get_credentials())
+
+
 @_wrap_tf_errors
 def isdir(path: str) -> bool:
     """Analogous to tf.io.gfile.isdir."""
@@ -95,6 +111,25 @@ def isdir(path: str) -> bool:
 @_wrap_tf_errors
 def listdir(path: str) -> list[str]:
     """Analogous to tf.io.gfile.listdir."""
+    parsed = urlparse(path)
+    if parsed.scheme == "gs":
+        bucket_name = parsed.netloc
+        prefix = parsed.path
+        if _is_hierarchical_namespace_enabled(bucket_name):
+            client = _gs_client()
+            blobs = client.list_blobs(
+                bucket_name,
+                prefix=prefix.strip("/") + "/",
+                delimiter="/",
+                include_folders_as_prefixes=True,
+            )
+            # objects
+            results = [os.path.basename(b.name) for b in blobs if not b.name.endswith("/")]
+            # folders
+            for p in blobs.prefixes:
+                results.append(os.path.basename(p.rstrip("/")) + "/")
+            return results
+
     return tf.io.gfile.listdir(path)
 
 
@@ -173,7 +208,59 @@ def makedirs(path: str):
     return tf.io.gfile.makedirs(path)
 
 
+@functools.cache
+def _is_hierarchical_namespace_enabled(bucket_name: str) -> bool:
+    """Return whether hierarchical namespace is enabled."""
+    client = _gs_client()
+    bucket = client.get_bucket(bucket_name)
+    return bucket.hierarchical_namespace_enabled
+
+
+def _rm_empty_folders(bucket: str, prefix: str):
+    """For a hierarchical namespace bucket, delete empty folders recursively."""
+    # pylint: disable=import-outside-toplevel
+    from google.cloud import storage_control_v2
+
+    client = _gs_control_client()
+    project_path = client.common_project_path("_")
+    bucket_path = f"{project_path}/buckets/{bucket}"
+    folders = set(
+        folder.name  # Format: "projects/{project}/buckets/{bucket}/folders/{folder}"
+        for folder in client.list_folders(
+            request=storage_control_v2.ListFoldersRequest(
+                parent=bucket_path, prefix=prefix.strip("/") + "/"
+            )
+        )
+    )
+
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        # Delete empty folders first, otherwise GCS will complain:
+        # FailedPrecondition: 400 The folder you tried to delete is not empty.
+        while len(folders) > 0:
+            parents = set(os.path.dirname(x.rstrip("/")) + "/" for x in folders)
+            leaves = folders - parents
+            res = list(
+                pool.map(
+                    client.delete_folder,
+                    [storage_control_v2.DeleteFolderRequest(name=f) for f in leaves],
+                )
+            )
+            folders = folders - leaves
+            logging.info(
+                "Deleted %s folders, %s remaining. [%s][%s]", len(res), len(folders), bucket, prefix
+            )
+
+
 @_wrap_tf_errors
 def rmtree(path: str):
-    """Analogous to tf.io.gfile.rmtree."""
-    return tf.io.gfile.rmtree(path)
+    """Analogous to tf.io.gfile.rmtree.
+    For a hierarchical namespace bucket, all the folders will also be removed."""
+    tf.io.gfile.rmtree(path)
+
+    # For HNS enabled bucket, we also need to delete folders recursively.
+    parsed = urlparse(path)
+    if parsed.scheme == "gs":
+        bucket_name = parsed.netloc
+        prefix = parsed.path
+        if _is_hierarchical_namespace_enabled(bucket_name):
+            _rm_empty_folders(bucket_name, prefix)

--- a/axlearn/common/file_system.py
+++ b/axlearn/common/file_system.py
@@ -254,8 +254,12 @@ def _rm_empty_folders(bucket: str, prefix: str):
 @_wrap_tf_errors
 def rmtree(path: str):
     """Analogous to tf.io.gfile.rmtree.
-    
-    For a hierarchical namespace bucket, all the folders will also be removed.
+
+    For a hierarchical namespace bucket, (until tensorflow@v2.19)
+    `tf.io.gfile.rmtree` only removes objects, leaving all the empty parent
+    folders intact. Here we manually delete the empty folders recursively with
+    [google-cloud-storage-control]
+    (https://cloud.google.com/python/docs/reference/google-cloud-storage-control/latest).
     """
     tf.io.gfile.rmtree(path)
 

--- a/axlearn/common/file_system.py
+++ b/axlearn/common/file_system.py
@@ -119,7 +119,7 @@ def listdir(path: str) -> list[str]:
             client = _gs_client()
             blobs = client.list_blobs(
                 bucket_name,
-                prefix=prefix.strip("/") + "/",
+                prefix=(prefix.rstrip("/") + "/").lstrip("/"),
                 delimiter="/",
                 include_folders_as_prefixes=True,
             )

--- a/axlearn/common/file_system.py
+++ b/axlearn/common/file_system.py
@@ -254,7 +254,9 @@ def _rm_empty_folders(bucket: str, prefix: str):
 @_wrap_tf_errors
 def rmtree(path: str):
     """Analogous to tf.io.gfile.rmtree.
-    For a hierarchical namespace bucket, all the folders will also be removed."""
+    
+    For a hierarchical namespace bucket, all the folders will also be removed.
+    """
     tf.io.gfile.rmtree(path)
 
     # For HNS enabled bucket, we also need to delete folders recursively.

--- a/axlearn/common/file_system.py
+++ b/axlearn/common/file_system.py
@@ -91,7 +91,7 @@ def _gs_client():
 @functools.cache
 def _gs_control_client():
     """Creates or retrieves the google cloud storage control client.
-    Different from `_gs_client`, it provides metadata-specific and control plane operations .
+    Different from `_gs_client`, it provides metadata-specific and control plane operations.
     """
     # pylint: disable=import-outside-toplevel
     # Avoid introducing a global dependency on `gcp`.

--- a/axlearn/common/file_system_test.py
+++ b/axlearn/common/file_system_test.py
@@ -262,6 +262,46 @@ class GsTest(TestWithTemporaryCWD):
         ):
             fs.glob(f"gs://{bucket_name}/dummy")
 
+    def test_rmtree_mocked(self):
+        dummy_folder = {
+            "tmp/foo/",
+            "tmp/foo/index",
+            "tmp/foo/bar/",
+            "tmp/foo/bar/x/",
+            "tmp/foo/bar/x/x.txt",
+            "tmp/foo/bar/y/",
+            "tmp/foo/bar/y/y.txt",
+            "tmp/foo/baz/",
+            "tmp/foo/baz/z/",
+            "tmp/foo/baz/z/z.txt",
+        }
+
+        def tf_rmtree_mock(path):
+            self.assertEndsWith(path.rstrip("/"), "tmp/foo")
+            objects = [x for x in dummy_folder if not x.endswith("/")]
+            for x in objects:
+                dummy_folder.remove(x)
+
+        def create_mock_folder(name_value):
+            m = mock.Mock()
+            m.name = name_value
+            return m
+
+        mock_client = mock.Mock()
+        mock_client.list_folders.side_effect = lambda request: [
+            create_mock_folder(folder_name) for folder_name in dummy_folder
+        ]
+        mock_client.delete_folder.side_effect = lambda req: dummy_folder.remove(req.name)
+        mock_client.common_project_path.return_value = "projects/_"
+
+        with (
+            mock.patch("tensorflow.io.gfile.rmtree", side_effect=tf_rmtree_mock),
+            mock.patch(f"{fs.__name__}._is_hierarchical_namespace_enabled", return_value=True),
+            mock.patch(f"{fs.__name__}._gs_control_client", return_value=mock_client),
+        ):
+            fs.rmtree("gs://dummy/tmp/foo")
+            self.assertEmpty(dummy_folder)
+
     @pytest.mark.gs_login
     def test_glob(self):
         self.assertCountEqual(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,8 @@ gcp = [
     "google-api-python-client==2.109.0",
     "google-auth==2.29.0",
     "google-auth[pyopenssl]",  # Ensures that we have compatible pyopenssl/cryptography pins.
-    "google-cloud-storage==2.16.0",
+    "google-cloud-storage==2.19.0",
+    "google-cloud-storage-control==1.4.0",
     "google-cloud-compute==1.19.2", # Needed for region discovery for CloudBuild API access.
     "google-cloud-core==2.3.3",
     "google-cloud-build==3.24.1",
@@ -120,7 +121,7 @@ vertexai_tensorboard = [
     "setuptools==65.7.0",
     # Pin version to fix Tensorboard uploader TypeError: can only concatenate str (not "NoneType") to str
     # https://github.com/googleapis/python-aiplatform/commit/4f982ab254b05fe44a9d2ed959fca2793961b56c
-    "google-cloud-aiplatform[tensorboard]==1.61.0",
+    "google-cloud-aiplatform[tensorboard]==1.92.0",
     "tensorboard",
 ]
 # Dataflow dependencies.


### PR DESCRIPTION
1. Updated the version of `google-cloud-storage` to recognize buckets with hierarchical namespace enabled. `google-cloud-aiplatform` is also updated correspondingly.
2. Added dependency of `google-cloud-storage-control` to list and remove empty folders buckets with hierarchical namespace enabled.
3. Added a mock unit test.