### PR TITLE
Fix CI pre-commit check failure.

### DIFF
--- a/.github/scripts/monitor_memory.sh
+++ b/.github/scripts/monitor_memory.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Simple memory monitor that prints to console every minute
+# Designed for GitHub Actions monitoring
+
+INFO="\033[90m"
+RESET="\033[0m"
+
+echo -e "${INFO}====== Starting memory monitor at $(date) ======${RESET}"
+
+while true; do
+  # Get current timestamp
+  timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+  echo ""
+  echo -e "${INFO}=== Memory Check: $timestamp ===${RESET}"
+
+  # Print simplified memory stats.
+  free -h | grep "Mem:" | awk "{printf \"${INFO}Memory: %s used, %s free, %s total\n${RESET}\", \$3, \$4, \$2}"
+
+  # Print memory usage percentage.
+  mem_total=$(free | grep Mem | awk '{print $2}')
+  mem_used=$(free | grep Mem | awk '{print $3}')
+  mem_percent=$(awk "BEGIN {printf \"%.1f\", $mem_used/$mem_total*100}")
+  echo -e "${INFO}Memory usage: $mem_percent%${RESET}"
+
+  # Sleep for 30 seconds
+  sleep 30
+done

--- a/.github/scripts/monitor_memory.sh
+++ b/.github/scripts/monitor_memory.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Simple memory monitor that prints to console every minute
-# Designed for GitHub Actions monitoring
+# Simple memory monitor that prints to console periodically.
+# Designed for GitHub Actions monitoring.
 
 INFO="\033[90m"
 RESET="\033[0m"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,5 +16,18 @@ jobs:
       # TODO(markblee): Remove gcp,vertexai_tensorboard from CI. (needed by pytype)
       - run: pip install '.[core,dev,grain,gcp,vertexai_tensorboard,open_api]'
       # pylint uses approx 12GB of memory during this run, look into split to decrease?
-      - run: pre-commit run --all-files
+      - run: |
+          .github/scripts/monitor_memory.sh &
+          MONITOR_PID=$!
+          # A short sleep to wait for monitor process start running.
+          sleep 1
+
+          echo "====== Starting pre-commit... ======"
+          pre-commit run --all-files
+          echo "====== pre-commi complted. ======"
+
+          if kill -0 $MONITOR_PID 2>/dev/null; then
+            echo "Manually stopping monitor..."
+            kill $MONITOR_PID
+          fi
       - run: pytype -j auto .

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,7 +26,7 @@ jobs:
           # Start pre-commit check.
           echo "====== Starting pre-commit... ======"
           pre-commit run --all-files
-          echo "====== pre-commi complted. ======"
+          echo "====== pre-commit completed. ======"
 
           # Clean up memory monitor process.
           if kill -0 $MONITOR_PID 2>/dev/null; then

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,17 +17,20 @@ jobs:
       - run: pip install '.[core,dev,grain,gcp,vertexai_tensorboard,open_api]'
       # pylint uses approx 12GB of memory during this run, look into split to decrease?
       - run: |
+          # Start memory monitor as a background process.
           .github/scripts/monitor_memory.sh &
           MONITOR_PID=$!
-          # A short sleep to wait for monitor process start running.
+          # A short sleep to wait for monitor process to start.
           sleep 1
 
+          # Start pre-commit check.
           echo "====== Starting pre-commit... ======"
           pre-commit run --all-files
           echo "====== pre-commi complted. ======"
 
+          # Clean up memory monitor process.
           if kill -0 $MONITOR_PID 2>/dev/null; then
-            echo "Manually stopping monitor..."
+            echo "Manually stopping monitor process..."
             kill $MONITOR_PID
           fi
       - run: pytype -j auto .

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
       # pylint uses approx 12GB of memory during this run, look into split to decrease?
       - run: |
           # Start memory monitor as a background process.
-          .github/scripts/monitor_memory.sh &
+          { .github/scripts/monitor_memory.sh & } || true
           MONITOR_PID=$!
           # A short sleep to wait for monitor process to start.
           sleep 1
@@ -31,6 +31,6 @@ jobs:
           # Clean up memory monitor process.
           if kill -0 $MONITOR_PID 2>/dev/null; then
             echo "Manually stopping monitor process..."
-            kill $MONITOR_PID
+            kill $MONITOR_PID || true
           fi
       - run: pytype -j auto .

--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,7 @@ persistent=no
 # load-plugins=pylint.extensions.docparams
 
 # Use multiple processes to speed up Pylint.
-jobs=4
+jobs=1
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.


### PR DESCRIPTION
Started to see consistent CI failure starting from last night.

The error is a sigterm with pylint
```
pylint...................................................................
Error: Process completed with exit code 143.
```

**Cause**
Initially, I thought it might be worker machine preemption, but it fails consistently across many machines, so preemption shouldn't be the reason.

Then I tried to see if OOM could be the reason, and was able to prove my assumption.
1. I first kept decreasing parallelism by changing `jobs=` in `.pylintrc`. Was able to get it working occasionally with 2 and consistently with 1.
2. Then I added a monitor process, we can see that even with 1 process, the peak memory usage is around 75%.

Thus, I was able to identify the cause.

**Implication of reduced parallelism**
While the memory impact is very obvious as I decrease the parallelism, speed is not really impacted that much.
The most recent successful run from yesterday (https://github.com/apple/axlearn/actions/runs/15127200091/job/42521313140) finished pre-commit stage in 5min and 6second, my test runs can finish within 5mins 30 seconds.

**Root cause**
I was not able to identify what triggered this change. One guess I have is that, maybe we were using a more powerful CI instances.
Since there is not much CI speed regression, I think we can prioritize getting CI fixed first.