### PR TITLE
[UPDATE JAX API] update to `jax.tree_structure` to `jax.tree_util.tree_structure`

### DIFF
--- a/axlearn/common/causal_lm.py
+++ b/axlearn/common/causal_lm.py
@@ -199,7 +199,7 @@ class AuxLossMetrics(BaseLossMetrics):
         live_targets = target_labels >= 0
         num_targets = live_targets.sum()
 
-        logging.info("Module outputs: %s", jax.tree_structure(module_outputs))
+        logging.info("Module outputs: %s", jax.tree_util.tree_structure(module_outputs))
         accumulation = []
         for k, v in flatten_items(module_outputs):
             if re.fullmatch(regex, k):

--- a/axlearn/common/utils.py
+++ b/axlearn/common/utils.py
@@ -1991,7 +1991,7 @@ def validate_contains_paths(x: Nested[Tensor], paths: Sequence[str]):
         except KeyError as e:
             raise ValueError(
                 f"Input is expected to contain '{path}'; "
-                f"instead, it contains: '{jax.tree_structure(x)}'."
+                f"instead, it contains: '{jax.tree_util.tree_structure(x)}'."
             ) from e
 
 


### PR DESCRIPTION
This is a small change, the newer version of JAX is deprecating `jax.tree_structure`. This is substituted almost in all parts of the code with `jax.tree_util.tree_structure` except in `causal_lm.py` and `utils.py`. 
[For reference](https://github.com/jax-ml/jax/blob/eb1220374c066d429a20488a3557a813f078a734/jax/__init__.py#L195C71-L196C58).
I provided to substitute the missing instances. 
@matthew-e-hopkins for visibility