### PR TITLE
[UPDATE JAX API] update `jax.tree_leaves` to `jax.tree_util.tree_leaves`

### DIFF
--- a/axlearn/common/gradient_accumulation.py
+++ b/axlearn/common/gradient_accumulation.py
@@ -33,7 +33,7 @@ def _compute_minibatch_size(input_batch: Nested[Tensor], *, steps: int) -> int:
     if steps <= 0:
         raise ValueError("Accumulation steps need to be a positive integer.")
 
-    input_batch_sizes = jax.tree_leaves(jax.tree.map(lambda x: x.shape[0], input_batch))
+    input_batch_sizes = jax.tree_util.tree_leaves(jax.tree.map(lambda x: x.shape[0], input_batch))
 
     if len(input_batch_sizes) == 0:
         raise ValueError("Input batch is empty.")

--- a/axlearn/experiments/text/gpt/common_test.py
+++ b/axlearn/experiments/text/gpt/common_test.py
@@ -52,7 +52,9 @@ class TrainerConfigTest(TestCase):
         # axis for multiple dims.
         for v in cfg.input.input_partitioner.path_rank_to_partition.values():
             visited = set()
-            for axis in jax.tree_leaves(tuple(v)):  # Cast to tuple since PartitionSpec is a leaf.
+            for axis in jax.tree_util.tree_leaves(
+                tuple(v)
+            ):  # Cast to tuple since PartitionSpec is a leaf.
                 self.assertNotIn(axis, visited)
                 visited.add(axis)
             self.assertGreater(len(visited), 0)


### PR DESCRIPTION
Similar to #1199 here we have a depreaction of `jax.tree_leaves`
[For reference](https://github.com/jax-ml/jax/blob/eb1220374c066d429a20488a3557a813f078a734/jax/__init__.py#L189)
@matthew-e-hopkins for visibility