### PR TITLE
[UPDATE JAX API] Update `trainer_test` `_normalized_spec`

### DIFF
--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -1090,8 +1090,8 @@ class TrainerTest(test_utils.TestCase):
                 jax.debug.inspect_array_sharding(
                     x,
                     callback=lambda sharding: self.assertEqual(
-                        partition_spec._normalized_spec(x.ndim),
-                        sharding.spec._normalized_spec(x.ndim),
+                        partition_spec._normalized_spec_for_aval(x.ndim),
+                        sharding.spec._normalized_spec_for_aval(x.ndim),
                         msg=f"{path=}, {sharding=}",
                     ),
                 )


### PR DESCRIPTION
By running unittests: 
```bash 
XLA_FLAGS='--xla_force_host_platform_device_count=8' pytest --durations=100 -v   -n auto -v -m "for_8_devices" --dist worksteal ${UNQUOTED_PYTEST_FILES}

E             File "/opt/axlearn/axlearn/common/trainer_test.py", line 1093, in <lambda>
E           AttributeError: 'PartitionSpec' object has no attribute '_normalized_spec'
```
```
The internal API for `PartitionSpec` has been updated, so `_normalized_spec` is now `_normalized_spec_for_aval` ( [reference](https://github.com/jax-ml/jax/blob/609fb7f6085b52861f65c7aa3b339c40dfd207fa/jax/_src/partition_spec.py#L166) )
@matthew-e-hopkins for visibility