### PR TITLE
Quick fix Axlearn CI due to transformers and torch version conflict.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dev = [
     "timm==0.6.12",  # DiT Dependency test-only
     "torch>=1.12.1",  # test-only
     "torchvision==0.16.1",  # test-only
-    "transformers>=4.51.3",  # test-only
+    "transformers==4.51.3",  # test-only
     "wandb",  # test-only
     "wrapt",  # implied by tensorflow-datasets, but also used in config tests.
 ]
@@ -148,7 +148,7 @@ mmau = [
     "plotly==5.22.0",
     "nbconvert==7.16.4",
     "google-cloud-aiplatform==1.50.0",
-    "transformers>=4.51.3",
+    "transformers==4.51.3",
     "huggingface-hub==0.24.6",
 ]
 # Orbax checkpointing.


### PR DESCRIPTION
transformers>=4.51.3 installs the latest version and conflict with the outdated torch. Before proper torch upgrade, this PR ceases the fire.