### PR TITLE
Implemented sliding window KV cache to maintain the window size KV cache to enable infinite decoding.

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -99,6 +99,7 @@ from axlearn.common.attention_bias import (
     CausalAttentionBias,
     MaskFnAttentionBias,
     SegmentIdAttentionBias,
+    SlidingWindowAttentionBias,
     as_attention_bias,
     causal_mask,
     make_segment_mask,
@@ -154,6 +155,7 @@ from axlearn.common.utils import (
     flatten_items,
     get_or_none,
     save_and_offload_only_these_names_regex,
+    sequence_mask,
     shapes,
     split_prng_key,
 )
@@ -257,7 +259,7 @@ class BaseKVCache(BaseLayer):
             cached_states: A `Nested[Tensor]` object containing KV cache such as key and value.
             k_proj: A Tensor of shape [batch, step_length, num_kv_heads, per_head_dim].
             v_proj: A Tensor of shape [batch, step_length, num_kv_heads, per_head_dim].
-            key_positions: An optional Tensor of shape [batch, step_length].
+            key_positions: An optional Tensor of shape [1|batch, step_length].
             live_step_len: An optional Tensor of shape [batch]. Please refer to ``On live_step_len``
                 in the file docstring for details.
 
@@ -360,6 +362,107 @@ class KVCache(BaseKVCache):
         # and this part is filtered out by the causal mask through key_positions.
         key_positions = jnp.arange(k_proj.shape[1])[None]  # [1, source_length]
         return updated_state, self.Output(k_proj=k_proj, v_proj=v_proj, key_positions=key_positions)
+
+
+class SlidingWindowKVCache(BaseKVCache):
+    """KV cache for sliding window attention.
+
+    Manages a fixed cached_kv_length kv_cache using a FIFO approach.
+    """
+
+    @config_class
+    class Config(BaseKVCache.Config):
+        """Configures SlidingWindowKVCache."""
+
+        # Specifies the size of the key-value cache. `init_states()` ignores `shape[1]`.
+        cached_kv_length: Required[int] = REQUIRED
+
+    def _invaild_position(self) -> int:
+        # Out of window position.
+        return -(self.config.cached_kv_length + 1)
+
+    def init_states(self, shape: BaseKVCache.Shape, *, dtype: jnp.dtype) -> Nested[Tensor]:
+        cfg = self.config
+        shape = (shape.batch_size, cfg.cached_kv_length, shape.num_kv_heads, shape.per_head_dim)
+        return dict(
+            key=jnp.zeros(shape=shape, dtype=self._cache_dtype(dtype)),
+            value=jnp.zeros(shape=shape, dtype=self._cache_dtype(dtype)),
+            key_positions=jnp.full(
+                shape=shape[:2], fill_value=self._invaild_position(), dtype=jnp.int32
+            ),
+        )
+
+    def extend_step(
+        self,
+        cached_states: Nested[Tensor],
+        *,
+        k_proj: Tensor,
+        v_proj: Tensor,
+        key_positions: Tensor,
+        live_step_len: Optional[Tensor] = None,
+    ) -> tuple[Nested[Tensor], BaseKVCache.Output]:
+        """Updates the sliding window KV cache per extend step.
+
+        Args:
+            cached_states: A `Nested[Tensor]` object containing KV cache such as key and value.
+            k_proj: A Tensor of shape [batch, step_length, num_kv_heads, per_head_dim].
+            v_proj: A Tensor of shape [batch, step_length, num_kv_heads, per_head_dim].
+            key_positions: An optional Tensor of shape [1|batch, step_length].
+            live_step_len: An optional Tensor of shape [batch]. Please refer to ``On live_step_len``
+                in the file docstring for details.
+
+        Returns:
+            A tuple (updated_state, output):
+            * updated_state: A `Nested[Tensor]` object containing KV cache such as key and value.
+            * output: The output k_proj, v_proj, and key_positions, which are merged with
+                KV cache, resulting in a length of `cached_kv_length + step_size`.
+        """
+        cfg = self.config
+        cached_key: Tensor = cached_states["key"]
+        cached_value: Tensor = cached_states["value"]
+        cached_positions: Tensor = cached_states["key_positions"]
+        batch, step_len = k_proj.shape[:2]
+        chex.assert_shape(cached_key, (batch, cfg.cached_kv_length, *k_proj.shape[2:]))
+
+        # [1|batch, step_length] -> [batch, step_length]
+        key_positions = jnp.broadcast_to(key_positions, (batch, step_len))
+        if live_step_len is not None:
+            if live_step_len.shape[0] != batch:
+                raise ValueError(f"{live_step_len.shape=} must be [{batch}].")
+            steps = live_step_len
+            seq_mask = sequence_mask(lengths=steps, max_len=step_len, dtype=key_positions.dtype)
+            # update_single rolls key_positions, so mark invalid positions.
+            key_positions = jnp.where(seq_mask, key_positions, self._invaild_position())
+        else:
+            steps = jnp.full([batch], fill_value=step_len)
+
+        # Ensure that we accumulate using the original dtype.
+        k_proj = k_proj.astype(cached_key.dtype)
+        v_proj = v_proj.astype(cached_value.dtype)
+
+        # Function to update the cache for a single batch element.
+        def update_single(cached_kv_slice, kv_proj_slice, steps_slice):
+            new_kv_slice = jnp.concatenate((cached_kv_slice, kv_proj_slice), axis=0)  # [T, N, H]
+            shift = kv_proj_slice.shape[0] - steps_slice
+            new_kv_slice = jnp.roll(new_kv_slice, shift, axis=0)
+            return new_kv_slice
+
+        # Use jax.vmap to vectorize over the batch dimension.
+        vmap_update = jax.vmap(update_single)
+        # [B, Lc, N, H], [B, S, N, H] -> [B, Lc+S, N, H]
+        new_key = vmap_update(cached_key, k_proj, steps)
+        new_value = vmap_update(cached_value, v_proj, steps)
+        new_key_positions = vmap_update(cached_positions, key_positions, steps)  # [batch, Lc+S]
+        updated_state = dict(
+            key=new_key[:, step_len:],
+            value=new_value[:, step_len:],
+            key_positions=new_key_positions[:, step_len:],
+        )
+        chex.assert_equal_shape((updated_state["key"], cached_key))
+        chex.assert_equal_shape((updated_state["value"], cached_value))
+        return updated_state, self.Output(
+            k_proj=new_key, v_proj=new_value, key_positions=new_key_positions
+        )
 
 
 class BaseTransformerLayer(BaseLayer):
@@ -1831,8 +1934,15 @@ class MultiheadAttention(BaseLayer):
                         key_positions=query_positions,
                         live_step_len=live_step_len,
                     )
-                k_proj, v_proj, key_positions = kv_cache_output
-                kv_state = KVState(*kv_cache_output)
+                if mode == ForwardMode.EXTEND_STEP:
+                    k_proj, v_proj, key_positions = kv_cache_output
+                    kv_state = KVState(*kv_cache_output)
+                else:
+                    # During prefill, q/k/v_proj are the same as in the forward pass.
+                    # kv_cache.extend_step() was called to update the kv_cache.
+                    assert mode == ForwardMode.INIT_STATES
+                    key_positions = query_positions
+                    kv_state = KVState(k_proj, v_proj, key_positions)
             else:
                 # KV sharing branch.
                 k_proj, v_proj, key_positions = kv_state
@@ -2153,6 +2263,31 @@ class MultiheadAttention(BaseLayer):
         """The config for the default function used to compute the key scale."""
 
         return config_for_function(constant_scale_fn).set(value=1)
+
+
+def enable_sliding_window_attention(
+    cfg: MultiheadAttention.Config, sliding_window_size: int
+) -> MultiheadAttention.Config:
+    """Enable sliding window attention.
+
+    Args:
+        cfg: MultiheadAttention Config.
+        sliding_window_size: Sliding window size.
+
+    Returns:
+        The in-place modified MultiheadAttention Config with sliding window attention enabled.
+    """
+    if cfg.kv_cache is not None:
+        cache_dtype = cfg.kv_cache.cache_dtype
+    else:
+        cache_dtype = None
+    cfg.set(
+        kv_cache=SlidingWindowKVCache.default_config().set(
+            cache_dtype=cache_dtype, cached_kv_length=sliding_window_size
+        ),
+        mask=SlidingWindowAttentionBias.default_config(sliding_window_size=sliding_window_size),
+    )
+    return cfg
 
 
 def compute_gqa_logits(q_proj: Tensor, k_proj: Tensor) -> Tensor:

--- a/axlearn/common/attention_bias_test.py
+++ b/axlearn/common/attention_bias_test.py
@@ -36,6 +36,20 @@ class MaskTest(test_utils.TestCase):
         out_mask = bool_mask.astype(jnp.int32)
         self.assertEqual(out_mask.tolist(), expected)
 
+    @parameterized.parameters(
+        [0, [[1, 0, 0, 0, 0], [1, 1, 0, 0, 0], [1, 1, 1, 0, 0]]],
+        [2, [[1, 1, 1, 0, 0], [0, 1, 1, 1, 0], [0, 0, 1, 1, 1]]],
+        [4, [[0, 0, 1, 1, 1], [0, 0, 0, 1, 1], [0, 0, 0, 0, 1]]],
+    )
+    def test_sliding_window_mask_with_time_step(self, time_step, expected):
+        mask_fn = sliding_window_causal_mask(sliding_window_size=2)
+        target_len, source_len = 3, 5
+        target_positions = jnp.arange(target_len)[:, None] + time_step
+        source_positions = jnp.arange(source_len)[None, :]
+        bool_mask = mask_fn(target_positions, source_positions)
+        out_mask = bool_mask.astype(jnp.int32)
+        self.assertEqual(out_mask.tolist(), expected)
+
 
 class AttentionBiasTest(test_utils.TestCase):
     @parameterized.parameters(

--- a/axlearn/common/dit_test.py
+++ b/axlearn/common/dit_test.py
@@ -21,7 +21,8 @@ from absl.testing import absltest, parameterized
 from timm.models.vision_transformer import Attention, Mlp, PatchEmbed
 from torch import nn
 
-from axlearn.common.attention_bias import NEG_INF, CausalAttentionBias, SlidingWindowAttentionBias
+from axlearn.common.attention import CausalAttentionBias, enable_sliding_window_attention
+from axlearn.common.attention_bias import NEG_INF
 from axlearn.common.dit import (
     AdaptiveLayerNormModulation,
     DiTAttentionLayer,
@@ -663,8 +664,8 @@ class TestDiTAttn(parameterized.TestCase):
         if causal_type == "causal":
             layer_cfg.attention.mask = CausalAttentionBias.default_config()
         elif causal_type == "sliding_window":
-            layer_cfg.attention.mask = SlidingWindowAttentionBias.default_config(
-                sliding_window_size=10
+            layer_cfg.attention = enable_sliding_window_attention(
+                layer_cfg.attention, sliding_window_size=10
             )
 
         layer = layer_cfg.instantiate(parent=None)
@@ -775,8 +776,8 @@ class TestDiTBlock(parameterized.TestCase):
         if causal_type == "causal":
             layer_cfg.attention.attention.mask = CausalAttentionBias.default_config()
         elif causal_type == "sliding_window":
-            layer_cfg.attention.attention.mask = SlidingWindowAttentionBias.default_config(
-                sliding_window_size=10
+            layer_cfg.attention.attention = enable_sliding_window_attention(
+                layer_cfg.attention.attention, sliding_window_size=10
             )
 
         layer = layer_cfg.instantiate(parent=None)


### PR DESCRIPTION
Currently, when using `MultiheadAttention` or `GroupedQueryAttention` for sliding window attention, the KV cache is kept for the full sequence length (`seq_len`) instead of the window length (`window_len`).

For example, a model with `window_len=1k` and `seq_len=2M` keeps a KV cache for the full 2M tokens. It then biases 1999k invalid KV tokens before calculating attention, resulting in a computational complexity of **O(2M²)** instead of the desired **O(1k²)**.

This issue persists even when using flash attention. Flash attention uses the KV cache allocated in HBM as its input. While unnecessary blocks are discarded during computation, the KV cache still occupies HBM inefficiently for the full 2M tokens.

To address this, when `MultiheadAttention` detects a sliding window mask, it stores the key-value (KV) cache in a ring buffer inside the input linear layer. As a result, downstream projects using `MultiheadAttention` automatically benefit from efficient KV cache handling in `init_states` and `extend_step`.

This PR actually moves from downstream speech/streaming/sliding_window_attention.py

**TODO**: TPU/GPU flash decoding now supports sliding window KV cache. **Note**: During FORWARD and PREFILL, its behavior is identical to vanilla KV cache. Therefore, both Splash Attention and GPU Flash Attention already cover this path in TPU and GPU.
**Note**: `enable_sliding_window_attention` is currently only used in unittests,
 so no model behavior has changed yet.