### PR TITLE
Compute SpecAug in jnp.bool (1 byte), not jnp.int32.

### DIFF
--- a/axlearn/audio/spectrum_augmenter.py
+++ b/axlearn/audio/spectrum_augmenter.py
@@ -12,6 +12,7 @@
 
 from typing import Optional
 
+import chex
 import jax
 import jax.numpy as jnp
 
@@ -119,7 +120,9 @@ class MaskSampler(BaseLayer):
             masks = masks * (jnp.arange(max_num_masks) < num_masks)[..., None]
 
         # Reduce over max_num_masks axis.
-        return jnp.max(masks, axis=1)
+        masks = jnp.max(masks, axis=1)
+        chex.assert_type(masks, jnp.bool)
+        return masks
 
 
 class SpectrumAugmenter(BaseLayer):
@@ -171,8 +174,8 @@ class SpectrumAugmenter(BaseLayer):
         )
 
         # [batch_size, 1, num_freq, 1].
-        freq_keep = 1 - freq_masks[:, None, :, None]
+        freq_keep = safe_not(freq_masks)[:, None, :, None]
         # [batch_size, num_frames, 1, 1].
-        time_keep = 1 - time_masks[:, :, None, None]
+        time_keep = safe_not(time_masks)[:, :, None, None]
 
         return inputs * freq_keep * time_keep

--- a/axlearn/audio/spectrum_augmenter_test.py
+++ b/axlearn/audio/spectrum_augmenter_test.py
@@ -10,12 +10,12 @@ from typing import Optional
 import jax
 import jax.numpy as jnp
 import pytest
-from absl.testing import parameterized
+from absl.testing import absltest, parameterized
 
 from axlearn.audio.spectrum_augmenter import MaskSampler, SpectrumAugmenter
 from axlearn.common.module import functional as F
 from axlearn.common.test_utils import TestCase, dummy_padding_mask
-from axlearn.common.utils import Tensor
+from axlearn.common.utils import Tensor, safe_not
 
 
 class MaskSamplerTest(TestCase):
@@ -180,7 +180,9 @@ class SpectrumAugmenterTest(TestCase):
             inputs = jnp.ones(input_shape)
         else:
             inputs = jax.random.normal(jax.random.PRNGKey(123), input_shape)
-        paddings = 1 - dummy_padding_mask(batch_size=inputs.shape[0], max_seq_len=inputs.shape[1])
+        paddings = safe_not(
+            dummy_padding_mask(batch_size=inputs.shape[0], max_seq_len=inputs.shape[1])
+        )
         outputs = self._generate_masks(
             dict(inputs=inputs, paddings=paddings), is_training=is_training, **kwargs
         )
@@ -210,7 +212,7 @@ class SpectrumAugmenterTest(TestCase):
     @pytest.mark.skip(reason="Comment out to run manually.")
     def test_visualize(self, input_shape: Sequence[int], **kwargs):
         inputs = jnp.ones(input_shape)
-        paddings = jnp.zeros([input_shape[0], input_shape[1]])
+        paddings = jnp.zeros([input_shape[0], input_shape[1]], jnp.bool)
         outputs = self._generate_masks(
             dict(inputs=inputs, paddings=paddings), is_training=True, **kwargs
         )
@@ -222,3 +224,7 @@ class SpectrumAugmenterTest(TestCase):
             # Show time on x axis and freq on y.
             plot.imshow(jnp.moveaxis(output, 0, 1), cmap=plt.cm.gray)
         plt.show()
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -664,7 +664,7 @@ def dummy_padding_mask(*, batch_size: int, max_seq_len: int) -> Tensor:
     input_len = jax.random.randint(
         jax.random.PRNGKey(123), shape=(batch_size,), minval=0, maxval=max_seq_len
     )
-    return lower_diag[input_len].astype(jnp.int32)
+    return lower_diag[input_len].astype(jnp.bool)
 
 
 # TODO(markblee): Update to take prng_key explicitly.


### PR DESCRIPTION
It saves the temp memory for a [batch, time, freq] mask.