### PR TITLE
[JAX API Update] Remove jax_spmd_mode from config

### DIFF
--- a/axlearn/common/utils_spmd.py
+++ b/axlearn/common/utils_spmd.py
@@ -43,8 +43,6 @@ def setup(
     """
     # Use a GSPMD-friendly PRNG implementation.
     jax.config.update("jax_default_prng_impl", "rbg")
-    # This allows replicated jax.Arrays to be used for computation on the host.
-    jax.config.update("jax_spmd_mode", "allow_all")
 
     global _jax_distributed_initialized  # pylint: disable=global-statement
     if not _jax_distributed_initialized:


### PR DESCRIPTION
This PR removes `jax_spmd_config` from `utils_spmd.py` given the recent changes [in JAX API](https://github.com/jax-ml/jax/commit/7634230cdcd2d3cb42d1093f6ab255f47f9869d5). Re #1160, there was an error in merging this PR. 
@matthew-e-hopkins for visibility

thank you :) 