### PR TITLE
apply tolerance values to assertAlmostEqual

### DIFF
--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -239,7 +239,8 @@ class TestCase(parameterized.TestCase):
                 self.assertEqual(a_value.shape, b_value.shape, msg=f"{a_name}")
                 assert_allclose(a_value, b_value, atol=atol, rtol=rtol, err_msg=f"{a_name}")
             else:
-                self.assertAlmostEqual(a_value, b_value, msg=f"{a_name}")
+                delta = atol + rtol * abs(b_value)
+                self.assertAlmostEqual(a_value, b_value, msg=f"{a_name}", delta=delta)
 
     def assertNestedEqual(self, a, b):
         a_kv = flatten_items(a)


### PR DESCRIPTION
`atol` and `rtol` are not really used when it goes to `assertAlmostEqual`. It will keep using 1e-7 as delta.