### PR TITLE
Add support for bf16 KV and fp32 Q in SplashAttention

### DIFF
--- a/axlearn/common/flash_attention/test_utils.py
+++ b/axlearn/common/flash_attention/test_utils.py
@@ -80,6 +80,7 @@ def generate_attention_data(
     attention_bias_type: Literal[None, "2d", "4d"] = None,
     with_segment_ids: bool = False,
     dtype=jnp.bfloat16,
+    kv_dtype=None,
     query_offset: int = 0,
 ) -> tuple[Tensor, Tensor, Tensor, CompositeAttentionBias]:
     """Generates QKV and Bias for unit test purposes."""
@@ -92,9 +93,11 @@ def generate_attention_data(
     kv_len = kv_len or query_len
     if kv_len != query_len and with_segment_ids:
         pytest.skip(reason="segment ids require kv_seq_len == q_seq_len")
+    if kv_dtype is None:
+        kv_dtype = dtype
     q = jax.random.normal(k1, (batch_size, query_len, num_heads, per_head_dim), dtype=dtype)
-    k = jax.random.normal(k2, (batch_size, kv_len, num_kv_heads, per_head_dim), dtype=dtype)
-    v = jax.random.normal(k3, (batch_size, kv_len, num_kv_heads, per_head_dim), dtype=dtype)
+    k = jax.random.normal(k2, (batch_size, kv_len, num_kv_heads, per_head_dim), dtype=kv_dtype)
+    v = jax.random.normal(k3, (batch_size, kv_len, num_kv_heads, per_head_dim), dtype=kv_dtype)
     attention_bias = None
     if attention_bias_type == "2d":
         attention_bias = jax.random.normal(k4, (1, 1, query_len, kv_len), dtype=dtype)

--- a/axlearn/common/flash_attention/test_utils.py
+++ b/axlearn/common/flash_attention/test_utils.py
@@ -39,18 +39,18 @@ def generate_paged_attention_data(
 ) -> tuple[Tensor, Tensor, Tensor, Tensor, CompositeAttentionBias]:
     """Generates query, key value pages, and page tables for paged attention testing."""
     bias = generate_attention_data(
-        batch_size,
-        query_len,
-        kv_len,
-        num_heads,
-        per_head_dim,
-        num_kv_heads,
-        mask_fn,
-        sliding_window_sz,
-        attention_bias_type,
-        with_segment_ids,
-        dtype,
-        query_offset,
+        batch_size=batch_size,
+        query_len=query_len,
+        kv_len=kv_len,
+        num_heads=num_heads,
+        per_head_dim=per_head_dim,
+        num_kv_heads=num_kv_heads,
+        mask_fn=mask_fn,
+        sliding_window_sz=sliding_window_sz,
+        attention_bias_type=attention_bias_type,
+        with_segment_ids=with_segment_ids,
+        dtype=dtype,
+        query_offset=query_offset,
     )[3]
     assert kv_len % page_size == 0
     k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(0), 4)

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -975,8 +975,8 @@ class LegacyTPUFlashAttention(TPUFlashAttention):
         """See `BaseFlashAttention.is_supported`."""
         if not super().is_supported(input_batch):
             return False
-        query: Tensor = input_batch["query"].dtype
-        key: Tensor = input_batch["key"].dtype
+        query: Tensor = input_batch["query"]
+        key: Tensor = input_batch["key"]
         if query.dtype != key.dtype:
             return self._log_unsupported(f"{query.dtype=} != {key.dtype=}")
         logging.info("Using %s.", self.name())

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -876,7 +876,9 @@ class TPUFlashAttention(BaseFlashAttention):
             return self._log_unsupported("dropout is not supported.")
         query: Tensor = input_batch["query"]
         if jax.config.jax_default_matmul_precision == "highest" and query.dtype == jnp.bfloat16:
-            raise RuntimeError(
+            # Pallas is having some trouble compiling bfloat with precision default is the highest
+            # precision.
+            raise ValueError(
                 "TPU FlashAttention doesn't support default_matmul_precision=='highest' "
                 "when the query dtype is bfloat16!"
             )

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -969,6 +969,10 @@ class LegacyTPUFlashAttention(TPUFlashAttention):
         """See `BaseFlashAttention.is_supported`."""
         if not super().is_supported(input_batch):
             return False
+        query_dtype = input_batch["query"].dtype
+        key_dtype = input_batch["key"].dtype
+        if query_dtype != key_dtype:
+            return self._log_unsupported(f"{query_dtype=} != {key_dtype=}")
         logging.info("Using %s.", self.name())
         return True
 

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -874,6 +874,14 @@ class TPUFlashAttention(BaseFlashAttention):
             return False
         if self.cfg.dropout_rate != 0.0:
             return self._log_unsupported("dropout is not supported.")
+        if (
+            jax.config.jax_default_matmul_precision == "highest"
+            and input_batch["query"].dtype == jnp.bfloat16
+        ):
+            raise RuntimeError(
+                "TPU FlashAttention doesn't support default_matmul_precision=='highest' "
+                "when the query dtype is bfloat16!"
+            )
         return True
 
 

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -874,10 +874,8 @@ class TPUFlashAttention(BaseFlashAttention):
             return False
         if self.cfg.dropout_rate != 0.0:
             return self._log_unsupported("dropout is not supported.")
-        if (
-            jax.config.jax_default_matmul_precision == "highest"
-            and input_batch["query"].dtype == jnp.bfloat16
-        ):
+        query: Tensor = input_batch["query"]
+        if jax.config.jax_default_matmul_precision == "highest" and query.dtype == jnp.bfloat16:
             raise RuntimeError(
                 "TPU FlashAttention doesn't support default_matmul_precision=='highest' "
                 "when the query dtype is bfloat16!"
@@ -977,10 +975,10 @@ class LegacyTPUFlashAttention(TPUFlashAttention):
         """See `BaseFlashAttention.is_supported`."""
         if not super().is_supported(input_batch):
             return False
-        query_dtype = input_batch["query"].dtype
-        key_dtype = input_batch["key"].dtype
-        if query_dtype != key_dtype:
-            return self._log_unsupported(f"{query_dtype=} != {key_dtype=}")
+        query: Tensor = input_batch["query"].dtype
+        key: Tensor = input_batch["key"].dtype
+        if query.dtype != key.dtype:
+            return self._log_unsupported(f"{query.dtype=} != {key.dtype=}")
         logging.info("Using %s.", self.name())
         return True
 

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -3,6 +3,8 @@
 """Tests TPU FlashAttention kernels."""
 from __future__ import annotations
 
+from contextlib import nullcontext
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -123,7 +125,9 @@ class TestFlashAttention(TestCase):
         mask=[None, causal_mask, jax_fn_mask(5)],
         attention_bias_type=[None, "2d", "4d"],
         with_segment_ids=[False, True],
-        per_head_dim=[32, 64, 128, 256],
+        per_head_dim=[32, 64, 128],
+        q_dtype=[jnp.float32, jnp.bfloat16],
+        kv_dtype=[jnp.float32, jnp.bfloat16],
     )
     def test_forward_and_backward(
         self,
@@ -135,12 +139,17 @@ class TestFlashAttention(TestCase):
         mask,
         attention_bias_type,
         with_segment_ids,
+        q_dtype,
+        kv_dtype,
     ):
         if jax.default_backend() == "cpu":
             # TODO(dhwang2): this has been broken for a while on CPU.
             pytest.skip(reason="Backward path is broken on CPU")
         if mask not in (None, causal_mask) and query_length_multiplier > 1:
             pytest.skip(reason="Sliding window attention does not make sense when q_len != kv_len.")
+        # KV should not have a higher precision than Q.
+        if kv_dtype == jnp.float32 and q_dtype == jnp.bfloat16:
+            return
         # pylint: disable=protected-access
         fallback_to_legacy = per_head_dim % 128 != 0 or (attention_bias_type is not None)
         q, k, v, bias = generate_attention_data(
@@ -152,6 +161,8 @@ class TestFlashAttention(TestCase):
             mask_fn=mask,
             attention_bias_type=attention_bias_type,
             with_segment_ids=with_segment_ids,
+            dtype=q_dtype,
+            kv_dtype=kv_dtype,
         )
         cfg = dict(
             interpret=jax.default_backend() == "cpu",
@@ -170,23 +181,28 @@ class TestFlashAttention(TestCase):
             # Check splash attention is used when it should be.
             self.assertEqual(fallback_to_legacy, True)
             fn = tpu_attention.LegacyTPUFlashAttention.default_config().set(**cfg).instantiate()
-            self.assertEqual(fn.is_supported(input_batch=input_batch), True)
+            legacy_supported = fn.is_supported(input_batch=input_batch)
+            if q_dtype != kv_dtype:
+                self.assertEqual(legacy_supported, False)
+                return
+            self.assertEqual(legacy_supported, True)
 
-        # Compare outputs.
-        out = fn(input_batch)
-        ref_out = ref_fn(input_batch)
-        self.assertNestedAllClose(out, ref_out, atol=0.05)
+        with jax.default_matmul_precision("highest") if q_dtype == jnp.float32 else nullcontext():
+            # Compare outputs.
+            out = fn(input_batch)
+            ref_out = ref_fn(input_batch)
+            self.assertNestedAllClose(out, ref_out, atol=0.05)
 
-        # Compare grads.
-        def grad_fn(float_inputs, aux_inputs, f):
-            full_batch = {**float_inputs, **aux_inputs}
-            return f(full_batch).mean()
+            # Compare grads.
+            def grad_fn(float_inputs, aux_inputs, f):
+                full_batch = {**float_inputs, **aux_inputs}
+                return f(full_batch).mean()
 
-        float_inputs = dict(query=q, key=k, value=v)
-        aux_inputs = dict(bias=bias)
-        grad_out = jax.grad(grad_fn, argnums=0)(float_inputs, aux_inputs, fn)
-        ref_grad_out = jax.grad(grad_fn, argnums=0)(float_inputs, aux_inputs, ref_fn)
-        self.assertNestedAllClose(grad_out, ref_grad_out, atol=0.05)
+            float_inputs = dict(query=q, key=k, value=v)
+            aux_inputs = dict(bias=bias)
+            grad_out = jax.grad(grad_fn, argnums=0)(float_inputs, aux_inputs, fn)
+            ref_grad_out = jax.grad(grad_fn, argnums=0)(float_inputs, aux_inputs, ref_fn)
+            self.assertNestedAllClose(grad_out, ref_grad_out, atol=0.05)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fix is similar to https://github.com/apple/axlearn/pull/1049. Some models are using BF16 KV cache even when the inference type is float32. Pallas is having trouble compiling the splash kernel when KV is in BF16 and compute type is FP32 and matmul precision is highest (which is needed for some eval to achieve parity with external numbers). This PR fixed this issue.

Note that legacy kernels don't support this. Added a check in legacy kernels.

Also added a check that `JAX_DEFAULT_MATMUL_PRECISION=highest` shouldn't be used with bf16 flash attention.