### PR TITLE
Add remat point for input

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -3418,6 +3418,7 @@ class TransformerLayer(BaseTransformerLayer):
         """
         if isinstance(data, Tensor):
             self.vlog(3, "transformer.input=%s", data.sum())  # pytype: disable=attribute-error
+            data = self._remat_name(data, "input")
         self_attention_return_aux = set()
         cross_attention_return_aux = set()
         if return_aux:


### PR DESCRIPTION
This is useful to train large models on accelerators where HBM is limited. This input can be offloaded to CPU to save more HBM. 
