### PR TITLE
Add max_len arg to fake_speech_source().

### DIFF
--- a/axlearn/audio/spectrum_augmenter_test.py
+++ b/axlearn/audio/spectrum_augmenter_test.py
@@ -217,7 +217,7 @@ class SpectrumAugmenterTest(TestCase):
             dict(inputs=inputs, paddings=paddings), is_training=True, **kwargs
         )
         # pylint: disable-next=import-outside-toplevel
-        import matplotlib.pyplot as plt
+        import matplotlib.pyplot as plt  # pytype: disable=import-error
 
         _, plots = plt.subplots(outputs.shape[0], 1)
         for plot, output in zip(plots, outputs):

--- a/axlearn/common/input_fake.py
+++ b/axlearn/common/input_fake.py
@@ -418,6 +418,7 @@ def fake_classification_source_instruct_lm(
 def fake_speech_source(
     *,
     is_training: bool,
+    max_len: int = 100,
     num_examples: int = 100,
     speech_key: str = "speech",
     shuffle_buffer_size: Optional[int] = None,
@@ -426,7 +427,9 @@ def fake_speech_source(
 
     Args:
         is_training: A boolean indicating whether it is in the training mode.
+        max_len: Maximum sequence length (in samples) for generated speech data.
         num_examples: Integer of number of examples in the dataset.
+        speech_key: Key name for the audio field in each example dict.
         shuffle_buffer_size: Shuffle buffer size used for training.
 
     Returns:
@@ -441,7 +444,7 @@ def fake_speech_source(
                     jax.random.PRNGKey(ix),
                     minval=-(2**15),
                     maxval=2**15,
-                    shape=[ix % 100 + 1],
+                    shape=[min(max_len // 2 + ix, max_len)],
                 ),
             }
             for ix in range(num_examples)

--- a/axlearn/experiments/audio/conformer/common_test.py
+++ b/axlearn/experiments/audio/conformer/common_test.py
@@ -7,7 +7,7 @@ import os
 import pytest
 import seqio
 import tensorflow as tf
-from absl.testing import parameterized
+from absl.testing import absltest, parameterized
 
 from axlearn.audio.encoder_asr import SpeechFeatureLayer
 from axlearn.common.config import config_for_class
@@ -46,7 +46,7 @@ class ConfigTest(TestCase):
         # Dropping all text.
         dict(max_source_len=5, max_target_len=5, expect_count=0),
         # Dropping some speech and pad text.
-        dict(max_source_len=4, max_target_len=8, expect_count=4),
+        dict(max_source_len=4, max_target_len=8, expect_count=3),
     )
     @pytest.mark.skipif(not os.path.exists(_bpe_vocab_file), reason="Missing testdata.")
     def test_asr_input(self, max_source_len: int, max_target_len: int, expect_count: int):
@@ -63,7 +63,7 @@ class ConfigTest(TestCase):
         )
 
         def source():
-            speech_ds = fake_speech_source(is_training=False, num_examples=5)()
+            speech_ds = fake_speech_source(is_training=False, num_examples=5, max_len=5)()
             text_ds = fake_text_source(is_training=False, batch_size=5)()
             return tf.data.Dataset.zip((speech_ds, text_ds)).map(lambda s, t: {**s, **t})
 
@@ -98,3 +98,7 @@ class ConfigTest(TestCase):
                 tf.reduce_all(ex["target"]["input_ids"][1:] == ex["target_labels"][:-1])
             )
         self.assertEqual(expect_count, actual_count)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/axlearn/experiments/audio/conformer/librispeech_trainer.py
+++ b/axlearn/experiments/audio/conformer/librispeech_trainer.py
@@ -63,12 +63,15 @@ from axlearn.experiments.audio.conformer.common import (
 from axlearn.experiments.trainer_config_utils import TrainerConfigFn
 
 
-def source_config(is_training: bool, split: str) -> InstantiableConfig[BuildDatasetFn]:
+def source_config(
+    is_training: bool, split: str, max_source_len: int
+) -> InstantiableConfig[BuildDatasetFn]:
     """Builds a source dataset config for librispeech.
 
     Args:
         is_training: Whether source is for training.
         split: Dataset split.
+        max_source_len: Max speech length.
 
     Returns:
         A config that instantiates to a data source.
@@ -78,7 +81,7 @@ def source_config(is_training: bool, split: str) -> InstantiableConfig[BuildData
         def fake_asr_source(is_training: bool):
             def fn():
                 text_ds = fake_text_source(is_training=is_training)()
-                speech_ds = fake_speech_source(is_training=is_training)()
+                speech_ds = fake_speech_source(is_training=is_training, max_len=max_source_len)()
                 return tf.data.Dataset.zip((speech_ds, text_ds)).map(lambda s, t: {**s, **t})
 
             return fn
@@ -317,7 +320,7 @@ def _input_fn(is_training: bool, split: str, eos_id: Optional[int] = None) -> In
         global_batch_size = 2048 if is_training else 512
 
     return Input.default_config().set(
-        source=source_config(is_training=is_training, split=split),
+        source=source_config(is_training=is_training, split=split, max_source_len=max_source_len),
         processor=config_for_function(asr_input).set(
             max_source_len=max_source_len,
             max_target_len=max_target_len,


### PR DESCRIPTION
fake_speech_source() generates extremely short fake audio samples (lengths like 1, 2, 3 and so on), which causes gradients to be zero in gradient unit tests.