### PR TITLE
Logmel: use jnp.fft.rfft instead of jnp.fft.fft.

### DIFF
--- a/axlearn/audio/frontend_utils.py
+++ b/axlearn/audio/frontend_utils.py
@@ -293,15 +293,13 @@ def magnitude_spectrogram(ffts: Tensor, *, dtype: jnp.dtype) -> Tensor:
     """Computes magnitude of the spectrogram from the FFT matrix.
 
     Args:
-        ffts: FFT of input audio frames of shape `[..., num_frames, fft_size]`.
+        ffts: FFT of input audio frames of shape `[..., num_frames, fft_size // 2 + 1]`.
         dtype: dtype of output tensor.
 
     Returns:
-        A spectrogram of shape `[..., num_frames, num_spectrogram_bins=fft_size // 2 + 1]`.
+        A spectrogram of shape `[..., num_frames, fft_size // 2 + 1]`.
     """
     out = jnp.abs(ffts)
-    fft_size = ffts.shape[-1]
-    out = out[..., : fft_size // 2 + 1]
     return out.astype(dtype)
 
 
@@ -406,7 +404,7 @@ def sharded_fft(n: int, partition_spec: PartitionSpec) -> Callable[[Tensor], Ten
         A callable that computes FFT.
     """
     return shard_map(
-        partial(jnp.fft.fft, n=n),
+        partial(jnp.fft.rfft, n=n),
         mesh=thread_resources.env.physical_mesh,
         in_specs=partition_spec,
         out_specs=partition_spec,

--- a/axlearn/audio/frontend_utils_test.py
+++ b/axlearn/audio/frontend_utils_test.py
@@ -40,7 +40,7 @@ from axlearn.common.utils import as_tensor
 
 
 def _magnitude_spectrogram_from_audio(x, fft_size):
-    return magnitude_spectrogram(jnp.fft.fft(x, n=fft_size), dtype=x.dtype)
+    return magnitude_spectrogram(jnp.fft.rfft(x, n=fft_size), dtype=x.dtype)
 
 
 class FrameTest(parameterized.TestCase, tf.test.TestCase):
@@ -414,7 +414,7 @@ class ShardedFftTest(TestCase):
             fft_fn = jax.jit(
                 sharded_fft(n=fft_size, partition_spec=PartitionSpec("data", None, None))
             )
-            ref_ffts = jax.jit(jnp.fft.fft, static_argnames="n")(inputs, n=fft_size)
+            ref_ffts = jax.jit(jnp.fft.rfft, static_argnames="n")(inputs, n=fft_size)
             test_ffts = fft_fn(inputs)
 
         assert_allclose(ref_ffts, test_ffts)


### PR DESCRIPTION
Audio samples are always real-valued, which is why the more efficient `rfft` can be used.

Currently, the logmel frontend uses `fft` and manually slices the output tensor to `fft_size // 2 + 1`. In contrast, `rfft` directly returns a tensor of shape `fft_size // 2 + 1` because, when the input is real, half of the FFT output consists of conjugate complex values, essentially redundant information.