### PR TITLE
Update pathways image to jax 0.5.3

### DIFF
--- a/axlearn/cloud/gcp/pathways_utils.py
+++ b/axlearn/cloud/gcp/pathways_utils.py
@@ -36,7 +36,7 @@ _PATHWAYS_WORKER_PORT = 29001
 # Pin to specific pathways image version for stable release.
 # Oldest available is jax-0.5.1, although axlearn is using jax-0.4.38.
 # Verified the backwards compatibility works.
-_PATHWAYS_IMAGE_TAG = "jax-0.5.1"
+_PATHWAYS_IMAGE_TAG = "jax-0.5.3"
 # The docker image used by pathways proxy container.
 _PATHWAYS_PROXY_IMAGE = (
     f"us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:{_PATHWAYS_IMAGE_TAG}"

--- a/axlearn/cloud/gcp/pathways_utils.py
+++ b/axlearn/cloud/gcp/pathways_utils.py
@@ -34,7 +34,6 @@ _PATHWAYS_RESOURCE_MANAGER_PORT = 29001
 # The specific value is not important, as long as clients and servers use the same port.
 _PATHWAYS_WORKER_PORT = 29001
 # Pin to specific pathways image version for stable release.
-# Oldest available is jax-0.5.1, although axlearn is using jax-0.4.38.
 # Verified the backwards compatibility works.
 _PATHWAYS_IMAGE_TAG = "jax-0.5.3"
 # The docker image used by pathways proxy container.


### PR DESCRIPTION
This will fix the serialization issue on pathways with large kv sequences (64k).

https://github.com/apple/axlearn/pull/1182 should be merged before this PR goes in.