### PR TITLE
Differentiate the configs for MultiheadInputLinear and MultiheadOutputLinear

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -822,6 +822,12 @@ class BaseMultiheadLinear(DenseGeneralBaseLayer):
 class MultiheadInputLinear(BaseMultiheadLinear):
     """Multi-head input linear layer."""
 
+    @config_class
+    class Config(BaseMultiheadLinear.Config):
+        # Explicitly define MultiheadInputLinear.Config so that config parsing
+        # functions can distinguish it from MultiheadOutputLinear.Config.
+        pass
+
     @property
     def _einsum_expr(self):
         return "btd,dnh->btnh"
@@ -844,6 +850,12 @@ class MultiheadInputLinear(BaseMultiheadLinear):
 
 class MultiheadOutputLinear(BaseMultiheadLinear):
     """Multi-head output linear layer."""
+
+    @config_class
+    class Config(BaseMultiheadLinear.Config):
+        # Explicitly define MultiheadOutputLinear.Config so that config parsing
+        # functions can distinguish it from MultiheadInputLinear.Config.
+        pass
 
     @property
     def _einsum_expr(self):

--- a/axlearn/common/attention_test.py
+++ b/axlearn/common/attention_test.py
@@ -822,7 +822,7 @@ class RoFormerSinusoidalPositionalEmbeddingTest(TestCase):
         ref_layer = hf_roformer.RoFormerSinusoidalPositionalEmbedding(max_len, dim)
         # In recent transformers API, PE's `_init_weight` is called recursively by parent module.
         # Since we only initialize the PE layer here, we need to manually call it.
-        ref_layer._init_weight()  # pylint: disable=protected-access
+        ref_layer._init_weight()  # pylint: disable=protected-access, no-value-for-parameter
         ref_output = ref_layer(as_torch_tensor(token_ids).shape)
         # Set up the RoPE AXLearn configs.
         test_layer = (
@@ -1321,6 +1321,14 @@ class RoFormerSinusoidalPositionalEmbeddingAgainstLLaMATest(TestCase):
 
 class MultiheadLinearInitTest(TestCase):
     """Tests MultiheadLinear initialization."""
+
+    def test_unique_config_classes(self):
+        self.assertFalse(
+            isinstance(MultiheadInputLinear.default_config(), MultiheadOutputLinear.Config)
+        )
+        self.assertFalse(
+            isinstance(MultiheadOutputLinear.default_config(), MultiheadInputLinear.Config)
+        )
 
     @parameterized.parameters(
         (


### PR DESCRIPTION
This is useful to allow config parsing functions to distinguish between the two classes.