### PR TITLE
[aot] Discard unsupported XLA options in AOT compilation

### DIFF
--- a/axlearn/experiments/run_aot_compilation.py
+++ b/axlearn/experiments/run_aot_compilation.py
@@ -74,6 +74,18 @@ def _compile_and_dump_programs(
         )
     else:
         xla_options = None
+
+    # Remove XLA options that are not supported by JAX 0.4.38.
+    # TODO(kelvin-zou): Remove this when we upgrade JAX.
+    if xla_options is not None:
+        xla_options.pop("megascale_graph_within_launch_hang_threshold", None)
+        xla_options.pop("megascale_graph_hang_threshold", None)
+        xla_options.pop("megascale_grpc_enable_xor_tracer", None)
+        xla_options.pop("megascale_error_reporter_abort_on_hang", None)
+        xla_options.pop("xla_sc_disjoint_spmem", None)
+        xla_options.pop("megascale_grpc_premap_memory_bytes", None)
+        xla_options.pop("megascale_error_reporter_abort_on_error", None)
+
     programs = aot_compilation.compile_trainer_programs(
         trainer_config,
         topology=compile_topology,


### PR DESCRIPTION
This fixes the AOT compilation for multi-slice topology.