### PR TITLE
CausalLM: Metrics now return `WeightedScalar` instead of plain scalars.

### DIFF
--- a/axlearn/common/encoder_decoder_test.py
+++ b/axlearn/common/encoder_decoder_test.py
@@ -9,7 +9,7 @@ from unittest import mock
 import jax
 import numpy as np
 import torch
-from absl.testing import parameterized
+from absl.testing import absltest, parameterized
 from jax import numpy as jnp
 from transformers import BertConfig, BertModel, EncoderDecoderConfig
 from transformers import EncoderDecoderModel as HFEncoderDecoderModel
@@ -528,7 +528,7 @@ class TestAgainstHF(TestCase):
         test_name = f"{source_padding_type}:{target_padding_type}"
 
         # We occasionally observe rounding errors.
-        assert_allclose(test_logits, ref_logits, atol=5e-6, err_msg=test_name)
+        assert_allclose(test_logits, ref_logits, atol=1e-5, err_msg=test_name)
         assert_allclose(loss, utils.as_tensor(ref_outputs.loss), err_msg=test_name)
 
 
@@ -585,3 +585,7 @@ class TestAgainstT5X(TestCase):
         ref_outputs = utils.as_tensor(testcase["outputs"])
         mask = testcase["padding_mask"][..., None]
         self.assertNestedAllClose(test_outputs * mask, ref_outputs * mask)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/axlearn/common/loss_metrics.py
+++ b/axlearn/common/loss_metrics.py
@@ -3,6 +3,7 @@
 """Layers for computing training time metrics."""
 
 from axlearn.common.base_layer import BaseLayer
+from axlearn.common.metrics import WeightedScalar
 from axlearn.common.utils import Nested, Tensor
 
 
@@ -18,7 +19,7 @@ class BaseLossMetrics(BaseLayer):
         *,
         predict_outputs: Nested[Tensor],
         module_outputs: Nested[Tensor],
-    ) -> tuple[Tensor, Nested[Tensor]]:
+    ) -> tuple[WeightedScalar, dict[str, WeightedScalar | Tensor]]:
         """Computes metrics from inputs and predictions.
 
         Args:
@@ -28,5 +29,7 @@ class BaseLossMetrics(BaseLayer):
 
         Returns:
             A tuple (loss, metrics).
+                loss: A WeightedScalar loss. Callers should call loss.value() for gradient.
+                metrics: A dict containing auxiliary losses and metrics.
         """
         raise NotImplementedError(type(self))


### PR DESCRIPTION
This is because, in multimodal training, it's often unclear how to assign a common weight to all losses. By returning the loss weight alongside the value, we enable proper loss aggregation downstream.