### PR TITLE
Do not materialize full text/image/speech logits (10GB for 16k seq text).

### DIFF
--- a/axlearn/common/adapter_torch_test.py
+++ b/axlearn/common/adapter_torch_test.py
@@ -980,12 +980,18 @@ class DecoderTest(TestCase):
             is_training=False,
             method="forward",
         )[0]
+        axlearn_logits = F(
+            axlearn_layer,
+            jax.random.PRNGKey(0),
+            state=axlearn_layer_state,
+            inputs=dict(forward_outputs=axlearn_outputs),
+            is_training=False,
+            method="compute_logits",
+        )[0]
         self.assertNestedAllClose(
             torch_outputs["hidden_states"].detach().numpy(), axlearn_outputs["hidden_states"]
         )
-        self.assertNestedAllClose(
-            torch_outputs["logits"].detach().numpy(), axlearn_outputs["logits"]
-        )
+        self.assertNestedAllClose(torch_outputs["logits"].detach().numpy(), axlearn_logits)
         # Also test extend.
         for chunk_size in [1, 6]:
             extend_logits: torch.Tensor = None
@@ -1245,12 +1251,18 @@ class CausalLmModelModulesTest(TestCase):
             torch_input_ids, target_labels=torch.as_tensor(target_labels)
         )
         self.assertNestedAllClose(
-            torch_predictions["logits"].detach().numpy(), axlearn_predictions["logits"]
-        )
-        self.assertNestedAllClose(
             torch_predictions["hidden_states"].detach().numpy(),
             axlearn_predictions["hidden_states"],
         )
+        axlearn_logits = F(
+            axlearn_model,
+            jax.random.PRNGKey(0),
+            state=axlearn_model_state,
+            inputs=dict(predictions=axlearn_predictions),
+            is_training=False,
+            method="compute_logits",
+        )[0]
+        self.assertNestedAllClose(torch_predictions["logits"].detach().numpy(), axlearn_logits)
         # Also test iterative decoding.
         extend_logits: torch.Tensor = None
         extend_hidden_states: torch.Tensor = None
@@ -1322,12 +1334,18 @@ class AdapterCausalLmModelModulesTest(TestCase):
             torch_input_ids, target_labels=torch.as_tensor(target_labels)
         )
         self.assertNestedAllClose(
-            torch_predictions["logits"].detach().numpy(), axlearn_predictions["logits"]
-        )
-        self.assertNestedAllClose(
             torch_predictions["hidden_states"].detach().numpy(),
             axlearn_predictions["hidden_states"],
         )
+        axlearn_logits = F(
+            axlearn_model,
+            jax.random.PRNGKey(0),
+            state=axlearn_model_state,
+            inputs=dict(predictions=axlearn_predictions),
+            is_training=False,
+            method="compute_logits",
+        )[0]
+        self.assertNestedAllClose(torch_predictions["logits"].detach().numpy(), axlearn_logits)
         # Also test iterative decoding.
         extend_logits: torch.Tensor = None
         extend_hidden_states: torch.Tensor = None

--- a/axlearn/common/causal_lm.py
+++ b/axlearn/common/causal_lm.py
@@ -21,7 +21,7 @@ from axlearn.common.attention import (
 )
 from axlearn.common.base_layer import RematSpec
 from axlearn.common.base_model import BaseModel
-from axlearn.common.config import REQUIRED, ConfigOr, Required, config_class
+from axlearn.common.config import REQUIRED, ConfigOr, Required, config_class, maybe_instantiate
 from axlearn.common.decoder import Decoder
 from axlearn.common.decoding import (
     BeamSearchOutputs,
@@ -29,13 +29,14 @@ from axlearn.common.decoding import (
     StopDecodingCondition,
     brevity_penalty_fn,
 )
+from axlearn.common.ein_ops import rearrange, repeat
 from axlearn.common.embedding import TransformerTextEmbeddings
 from axlearn.common.layers import LayerNorm
 from axlearn.common.logit_modifiers import LogitsToLogitsFn
 from axlearn.common.loss import cross_entropy
 from axlearn.common.loss_metrics import BaseLossMetrics
 from axlearn.common.metrics import WeightedScalar
-from axlearn.common.module import Module, NestedTensor, Tensor, child_context
+from axlearn.common.module import Module, NestedTensor, Tensor, child_context, scan_in_context
 from axlearn.common.param_init import PARAM_REGEXP_WEIGHT, DefaultInitializer, WeightInitializer
 from axlearn.common.utils import (
     Nested,
@@ -101,6 +102,8 @@ class CrossEntropyLossMetrics(BaseLossMetrics):
                     live_targets: A bool Tensor of same shape as `target_labels`. False indicates
                         ignored targets.
                     num_targets: A scalar int Tensor corresponding to number of live targets.
+                    predicted_ids: Token IDs from greedy sampling (argmax over logits).
+
         """
         del module_outputs
         validate_contains_paths(input_batch, paths=["target_labels"])
@@ -138,11 +141,13 @@ class CrossEntropyLossMetrics(BaseLossMetrics):
             "train_live_targets",
             WeightedScalar(num_targets / target_labels.shape[0], target_labels.shape[0]),
         )
+        predicted_ids = jnp.argmax(logits, axis=-1)
         metrics = {
             "cross_entropy": loss_weighted,
             "per_token_loss": per_token_loss,
             "live_targets": live_targets,
             "num_targets": num_targets,
+            "predicted_ids": predicted_ids,
         }
         return loss_weighted, metrics
 
@@ -377,6 +382,12 @@ class Model(BaseModel):
         seq_axis_names: Optional[tuple[str]] = None
         # Configures training metrics.
         metrics: BaseLossMetrics.Config = metrics_config()
+        # The chunk size for logits scan. The default is None, which disables scanning.
+        # To enable scan, set a value. The chunk size must divide the sequence length.
+        # 512 is recommended for both TPU and GPU.
+        # For example, with a sequence length of 16k and a vocab size of 150k, this can save
+        # around 10 GB of memory, at the cost of about a 5% slowdown.
+        scan_chunk: Optional[int] = None
 
     def __init__(self, cfg: Config, *, parent: Module):
         super().__init__(cfg, parent=parent)
@@ -420,12 +431,11 @@ class Model(BaseModel):
                     unique positive values for different input sequences.
                 input_positions: An optional int Tensor of shape [batch_size, target_len] with
                     non-negative values representing token position indices.
-            return_aux: boolean to determine whether logits and decoder hidden states are returned.
+            return_aux: boolean to determine whether decoder hidden states and metrics are returned.
 
         Returns:
             loss: a scalar float Tensor.
             aux_outputs (a dict):
-                logits: a float Tensor of shape [batch_size, seq_len, vocab_size].
                 hidden_states: a float Tensor of shape [batch_size, seq_len, hidden_dim].
                 metrics: a nested Tensor. See corresponding `metrics` implementation for details.
         """
@@ -436,9 +446,11 @@ class Model(BaseModel):
         if target_labels is not None:
             loss, metrics = self._metrics(input_batch=input_batch, predict_outputs=predictions)
             aux_outputs.update(loss=loss, metrics=metrics)
-        # If return_aux, return the logits and output pre LM head (useful for downstream tasks),
-        # as well as training metrics like the per-token-loss.
+        # If return_aux, return the decoder hidden states, as well as training metrics like
+        # the per-token-loss.
         #
+        # N.B. Logits are not returned, because they can exceed 10 GB in long-context scenarios.
+        # If you need logits, call `compute_logits(aux_outputs)`.
         # N.B. Do not enable for large-scale training since auxiliary outputs are not partitioned.
         # TODO(rpang): support partitioning of auxiliary outputs.
         return loss, aux_outputs if return_aux else {}
@@ -517,11 +529,26 @@ class Model(BaseModel):
                     Used as decoder input ids. Values should be in the range [0, vocab_size].
 
         Returns:
-           A float Tensor of shape [batch_size, target_len, hidden_dim].
+            logits: A float Tensor of shape [batch_size, target_len, num_classes].
         """
         self._constrain_input_batch(input_batch)
         predictions = self.predict(input_batch)
-        return predictions["logits"]
+        # predict() already calls self.decoder.
+        with child_context("compute_logits", module=self):
+            logits = self.compute_logits(predictions)
+        return logits
+
+    def compute_logits(self, predictions: Nested[Tensor]) -> Tensor:
+        """Computes logits from decoder hidden states.
+
+        Args:
+            predictions: the output dict from predict(), including
+                hidden_states: A float Tensor of shape [batch_size, target_len, hidden_dim].
+
+        Returns:
+            logits: A float Tensor of shape [batch_size, target_len, num_classes].
+        """
+        return self.decoder.compute_logits(predictions)
 
     def score(self, input_batch: Nested[Tensor]) -> Nested[Tensor]:
         """Produce decoder score like per_token_loss and live_targets.
@@ -559,7 +586,6 @@ class Model(BaseModel):
 
         Returns:
             A dict containing:
-                logits: a float Tensor of shape [batch_size, seq_len, vocab_size]
                 hidden_states: a float Tensor of shape [batch_size, seq_len, hidden_dim]
         """
         self._constrain_input_batch(input_batch)
@@ -578,13 +604,116 @@ class Model(BaseModel):
         self.vlog(3, "targets=%s(%s)", target_labels.dtype, target_labels.shape)
         # Map padding targets to out-of-class label for metrics calculation.
         target_labels = jnp.where(target_labels == cfg.decoder.pad_token_id, -1, target_labels)
-
         ctx = self.get_invocation_context()
-        loss, metrics = self.metrics.forward(
+
+        def _metrics_step(carry: Tensor, xs: Nested[Tensor]):
+            input_batch = xs["input_batch"]
+            predict_outputs = xs["predict_outputs"]
+            with child_context("self_decoder_compute_logits", module=self):
+                logits = self.decoder.compute_logits(predict_outputs)
+                predict_outputs.update(logits=logits)
+
+            loss, metrics = self.metrics.forward(
+                input_batch=input_batch,
+                predict_outputs=predict_outputs,
+                module_outputs=ctx.get_module_outputs(),
+            )
+            return carry, (loss, metrics)
+
+        xs = dict(
             input_batch={**input_batch, "target_labels": target_labels},
             predict_outputs=predict_outputs,
-            module_outputs=ctx.get_module_outputs(),
         )
+        scan_chunk = cfg.scan_chunk
+        seq_len = target_labels.shape[1]
+        if scan_chunk is None or seq_len <= scan_chunk:
+            _, (loss, metrics) = _metrics_step(carry=None, xs=xs)
+        else:
+            num_chunks = seq_len // scan_chunk
+            if seq_len % scan_chunk != 0:
+                raise ValueError(f"{seq_len=} must be a multiple of {scan_chunk=}.")
+
+            def chunk(x: Tensor):
+                """Transforms `x` to shape [num_chunks, ...].
+
+                If x.ndim is 0 or 1, we repeat x by `num_chunks`. Otherwise we assume `x` has shape
+                [batch, seq_len, ...] and will divide the seq_len axis and transpose the array to
+                [num_chunks, batch, chunk_size, ...].
+                """
+                if x.ndim <= 0:
+                    return repeat(x, "... -> n ...", n=num_chunks)
+                chunked_x = rearrange(x, "b (n c) ... -> n b c ...", n=num_chunks, c=scan_chunk)
+                # For example, when sharding along axis=1 for sequence sharding, the chunks are
+                # computed in parallel across different shards.
+                # TODO(axlearn-dev): Move logits_partition_spec from decoder to causal_lm.
+                seq_batch_shard = (
+                    cfg.decoder.logits_partition_spec[1],
+                    cfg.decoder.logits_partition_spec[0],
+                )
+                suffix_shard = (None for i in range(chunked_x.ndim - 2))
+                chunked_x = with_sharding_constraint(
+                    chunked_x, PartitionSpec(*seq_batch_shard, *suffix_shard)
+                )
+                return chunked_x
+
+            xs = jax.tree.map(chunk, xs)
+            scan_prefix = "iter"
+            remat_kwargs = dict(
+                prevent_cse=False,
+                policy=maybe_instantiate(cfg.remat_spec.policy)
+                if cfg.remat_spec is not None
+                else None,
+            )
+            _, (loss, metrics) = scan_in_context(
+                _metrics_step,
+                carry=jnp.zeros(1, dtype=jnp.int32),
+                xs=dict(xs=xs),
+                child_name_prefix=scan_prefix,
+                remat_kwargs=remat_kwargs,
+                merge_summaries=True,
+            )
+
+            def flatten(x: Tensor):
+                if x.ndim == 1:
+                    return x
+                x = rearrange(x, "n b c ... -> b (n c) ...")
+                # [B, padded_T, ...] -> [B, T, ...]
+                return x[:, :seq_len]
+
+            metrics = jax.tree.map(flatten, metrics)
+
+            def _aggregate_scanned_scalar_weight(scalar: WeightedScalar) -> WeightedScalar:
+                total_weight = scalar.weight.sum()
+                total = (scalar.mean * scalar.weight).sum() / total_weight.clip(min=1)
+                return WeightedScalar(total, total_weight)
+
+            def aggregate(metrics, loss):
+                loss = _aggregate_scanned_scalar_weight(loss)
+
+                # This is heuristic because it needs to combine metrics returned by arbitrary
+                # metrics classes. For now, it supports all existing metrics classes.
+                def aggregate(each):
+                    if isinstance(each, WeightedScalar):
+                        # e.g., aux_loss.
+                        return _aggregate_scanned_scalar_weight(each)
+                    elif each.ndim == 1:
+                        # The int value is count like num_targets.
+                        return each.sum()
+                    else:
+                        # Tensors with rank 2 or higher contain component info. e.g. per_token_loss
+                        return each
+
+                metrics = jax.tree.map(
+                    aggregate, metrics, is_leaf=lambda x: isinstance(x, Tensor | WeightedScalar)
+                )
+                return loss, metrics
+
+            loss, metrics = aggregate(metrics, loss)
+
+            # flatten loss, metrics
+            for each in ctx.output_collection:
+                _update(each, each.pop(scan_prefix))
+
         # Flatten summaries for backwards compatibility.
         _update(ctx.output_collection.summaries, ctx.output_collection.summaries.pop("metrics"))
 

--- a/axlearn/common/causal_lm_test.py
+++ b/axlearn/common/causal_lm_test.py
@@ -2,6 +2,7 @@
 
 """Tests autoregressive models."""
 
+import contextlib
 from functools import partial
 from typing import cast
 
@@ -114,7 +115,15 @@ class Gpt2TransformerTest(TestCase):
             parameters_from_ref_layer=parameters_from_torch_layer,
             require_same_tree_structure=require_same_tree_structure,
         )
-        test_logits = test_aux["logits"]
+        params_from_ref = parameters_from_torch_layer(ref_layer, dst_layer=layer)
+        test_logits = functional(
+            layer,
+            prng_key=jax.random.PRNGKey(123),
+            state=params_from_ref,
+            inputs=dict(predictions=test_aux),
+            is_training=False,
+            method="compute_logits",
+        )[0]
         ref_logits = ref_outputs.logits.detach().numpy()
         assert_allclose(test_logits, ref_logits)
 
@@ -134,82 +143,54 @@ class ModelTest(TestCase):
         )
         return causal_lm.Model.default_config().set(decoder=decoder_cfg)
 
-    def test_metrics(self):
-        model = (
-            self._model_config(vocab_size=10, seq_len=10)
-            .set(name="metrics_test")
-            .instantiate(parent=None)
+    def _get_input_batch(self, batch_size, seq_len, vocab_size):
+        input_key, target_key = jax.random.split(jax.random.PRNGKey(123))
+        input_ids = jax.random.randint(
+            input_key, shape=[batch_size, seq_len], minval=0, maxval=vocab_size
         )
+        target_labels = jax.random.randint(
+            target_key, shape=[batch_size, seq_len], minval=-1, maxval=vocab_size
+        )
+        return dict(input_ids=input_ids, target_labels=target_labels)
 
+    def test_metrics_scan(self):
+        batch_size, seq_len, vocab_size = 3, 16, 10
+        scan_chunk = 8  # Note: seq_len > scan_chunk to enable scan chunk.
+
+        model_cfg = self._model_config(vocab_size=vocab_size, seq_len=seq_len)
+        test_cfg = model_cfg.clone().set(scan_chunk=scan_chunk)
+
+        model = model_cfg.set(name="ref").instantiate(parent=None)
+        test_model = test_cfg.set(name="test").instantiate(parent=None)
+
+        input_batch = self._get_input_batch(batch_size, seq_len, vocab_size)
         prng_key, init_key = jax.random.split(jax.random.PRNGKey(123))
         model_params = model.initialize_parameters_recursively(init_key)
-        # Compute summaries after forwarding two batches.
-        # The second batch is a dummy one - should not affect metrics.
-        target_labels = jnp.array([[[1, 3, 0], [2, 3, 1]], [[0, 0, 0], [0, 0, 0]]])
-        logits = jnp.array(
-            [
-                [
-                    [
-                        [0.1, 0.9, 0.1, 0.1],  # Target 1; pred 1.
-                        [0.1, 0.1, 0.9, 0.1],  # Target 3; pred 2.
-                        [0.9, 0.1, 0.1, 0.1],  # Target 0; pred 0.
-                    ],  # Example 0.
-                    [
-                        [0.1, 0.1, 0.9, 0.1],  # Target 2; pred 2.
-                        [0.1, 0.1, 0.9, 0.1],  # Target 3; pred 2.
-                        [0.9, 0.1, 0.1, 0.1],  # Target 1; pred 0.
-                    ],  # Example 1.
-                ],  # Batch 0.
-                [
-                    [
-                        [0.1, 0.9, 0.1, 0.1],  # Target 0; pred 1.
-                        [0.1, 0.1, 0.9, 0.1],  # Target 0; pred 2.
-                        [0.9, 0.1, 0.1, 0.1],  # Target 0; pred 0.
-                    ],  # Example 0.
-                    [
-                        [0.1, 0.1, 0.9, 0.1],  # Target 0; pred 2.
-                        [0.1, 0.1, 0.9, 0.1],  # Target 0; pred 2.
-                        [0.9, 0.1, 0.1, 0.1],  # Target 0; pred 0.
-                    ],  # Example 1.
-                ],  # Batch 1.
-            ]
+
+        # Ensure that forward outputs are consistent with metrics output.
+        common_kwargs = dict(prng_key=prng_key, state=model_params, is_training=True)
+        predictions, _ = functional(
+            **common_kwargs, module=model, inputs=dict(input_batch=input_batch), method="predict"
         )
-        target_num_bytes = jnp.array([[3, 7], [0, 0]])
-        live_targets = jnp.array([[[1, 1, 0], [1, 1, 1]], [[0, 0, 0], [0, 0, 0]]])
-        accumulator = MetricAccumulator.default_config().instantiate()
-        for i in range(2):
-            _, output_collection = functional(
-                model,
-                inputs=dict(
-                    input_batch=dict(
-                        target_labels=target_labels[i],
-                        target_num_bytes=target_num_bytes[i],
-                    ),
-                    predict_outputs=dict(
-                        logits=logits[i],
-                    ),
-                ),
-                is_training=True,
-                prng_key=prng_key,
-                state=model_params,
-                method="_metrics",
-            )
-            accumulator.update(output_collection.summaries)
-        summaries = accumulator.summaries()
-        # Only the first batch should affect results.
-        loss, loss_dict = cross_entropy(
-            logits=logits[0],
-            target_labels=target_labels[0],
-            live_targets=live_targets[0],
+        metrics_inputs = dict(
+            input_batch=dict(target_labels=input_batch["target_labels"]),
+            predict_outputs=dict(hidden_states=predictions["hidden_states"]),
         )
-        self.assertEqual(2.0 / 5, summaries["accuracy"].mean)
-        self.assertAlmostEqual(loss, summaries["loss"].mean)
-        self.assertEqual(5, summaries["loss"].weight)
-        self.assertAlmostEqual(jnp.exp(loss), summaries["perplexity"].mean, places=6)
-        per_token_loss = loss_dict["per_target_loss"] * live_targets
-        total_bytes = target_num_bytes.sum()
-        bits_per_byte = per_token_loss.sum() / jnp.maximum(1, total_bytes) / jnp.log(2)
-        self.assertAlmostEqual(bits_per_byte, summaries["bits_per_byte"].mean)
+
+        (ref_loss, ref_metrics), _ = functional(
+            **common_kwargs,
+            module=model,
+            inputs=metrics_inputs,
+            method="_metrics",
+        )
+        (test_loss, test_metrics), _ = functional(
+            **common_kwargs,
+            module=test_model,
+            inputs=metrics_inputs,
+            method="_metrics",
+        )
+        self.assertNestedAllClose(ref_loss, test_loss)
+        self.assertNestedAllClose(ref_metrics, test_metrics)
 
     def test_segment_ids(self):
         batch_size, seq_len, vocab_size = 3, 10, 10
@@ -225,19 +206,8 @@ class ModelTest(TestCase):
         model_cfg = causal_lm.Model.default_config().set(decoder=decoder_cfg, name="model")
         model = model_cfg.instantiate(parent=None)
 
+        input_batch = self._get_input_batch(batch_size, seq_len, vocab_size)
         prng_key, init_key = jax.random.split(jax.random.PRNGKey(123))
-
-        input_ids = jax.random.randint(
-            jax.random.PRNGKey(123), shape=[batch_size, seq_len], minval=0, maxval=vocab_size
-        )
-        target_labels = jax.random.randint(
-            jax.random.PRNGKey(123), shape=[batch_size, seq_len], minval=-1, maxval=vocab_size
-        )
-        input_batch = dict(
-            input_ids=input_ids,
-            target_labels=target_labels,
-        )
-
         model_params = ref_model.initialize_parameters_recursively(init_key)
 
         ctx = InvocationContext(
@@ -255,12 +225,6 @@ class ModelTest(TestCase):
         # Results should be the same.
         segment_ids = jnp.ones(shape=[batch_size, seq_len], dtype=jnp.int32)
         positions = jnp.broadcast_to(jnp.arange(seq_len), shape=[batch_size, seq_len])
-        input_batch = dict(
-            input_ids=input_ids,
-            target_labels=target_labels,
-            input_segment_ids=segment_ids,
-            input_positions=positions,
-        )
         ctx = InvocationContext(
             name="root",
             parent=None,
@@ -271,19 +235,17 @@ class ModelTest(TestCase):
             prng_key=prng_key,
         )
         with set_current_context(ctx):
-            loss, _ = model.forward(input_batch=input_batch)
+            loss, _ = model.forward(
+                input_batch=dict(
+                    **input_batch, input_segment_ids=segment_ids, input_positions=positions
+                )
+            )
 
         self.assertAlmostEqual(ref_loss, loss)
 
         # Use a different attention mask.
         segment_ids = jnp.broadcast_to(jnp.arange(seq_len), shape=[batch_size, seq_len])
         positions = jnp.broadcast_to(jnp.arange(seq_len), shape=[batch_size, seq_len])
-        input_batch = dict(
-            input_ids=input_ids,
-            target_labels=target_labels,
-            input_segment_ids=segment_ids,
-            input_positions=positions,
-        )
         ctx = InvocationContext(
             name="root",
             parent=None,
@@ -294,37 +256,44 @@ class ModelTest(TestCase):
             prng_key=prng_key,
         )
         with set_current_context(ctx):
-            loss, _ = model.forward(input_batch=input_batch)
+            loss, _ = model.forward(
+                input_batch=dict(
+                    **input_batch, input_segment_ids=segment_ids, input_positions=positions
+                )
+            )
         self.assertNotAlmostEqual(ref_loss, loss)
 
-    def test_forward(self):
-        batch_size, seq_len, vocab_size = 3, 10, 10
+    @parameterized.product(scan_chunk=[None, 8, 10])
+    def test_forward(self, scan_chunk):
+        batch_size, seq_len, vocab_size = 3, 16, 10
 
         model_cfg = self._model_config(vocab_size=vocab_size, seq_len=seq_len)
-        model = model_cfg.set(name="metrics_test").instantiate(parent=None)
+        model = model_cfg.set(scan_chunk=scan_chunk, name="metrics_test").instantiate(parent=None)
 
+        input_batch = self._get_input_batch(batch_size, seq_len, vocab_size)
         prng_key, init_key = jax.random.split(jax.random.PRNGKey(123))
         model_params = model.initialize_parameters_recursively(init_key)
 
-        input_ids = jax.random.randint(
-            jax.random.PRNGKey(123), shape=[batch_size, seq_len], minval=0, maxval=vocab_size
-        )
-        target_labels = jax.random.randint(
-            jax.random.PRNGKey(123), shape=[batch_size, seq_len], minval=-1, maxval=vocab_size
-        )
-        input_batch = dict(input_ids=input_ids, target_labels=target_labels)
-
         # Ensure that forward outputs are consistent with metrics output.
         common_kwargs = dict(module=model, prng_key=prng_key, state=model_params, is_training=True)
-        (loss, aux), _ = functional(
-            **common_kwargs,
-            inputs=dict(input_batch=input_batch, return_aux=True),
-        )
+        invalid_seq_len = scan_chunk and seq_len % scan_chunk != 0
+        if invalid_seq_len:
+            ctx = self.assertRaises(ValueError)
+        else:
+            ctx = contextlib.nullcontext()
+        with ctx:
+            (loss, aux), _ = functional(
+                **common_kwargs,
+                inputs=dict(input_batch=input_batch, return_aux=True),
+            )
+        if invalid_seq_len:
+            return
+
         (ref_loss, metrics), _ = functional(
             **common_kwargs,
             inputs=dict(
-                input_batch=dict(target_labels=target_labels),
-                predict_outputs=dict(logits=aux["logits"]),
+                input_batch=dict(target_labels=input_batch["target_labels"]),
+                predict_outputs=dict(hidden_states=aux["hidden_states"]),
             ),
             method="_metrics",
         )
@@ -363,11 +332,17 @@ class ModelTest(TestCase):
             target_labels = jax.random.randint(
                 target_key, shape=[batch_size, seq_len], minval=-1, maxval=vocab_size
             )
+            hidden_states = jax.random.normal(
+                target_key, shape=[batch_size, seq_len, model_cfg.decoder.dim]
+            )
             return functional(
                 module=model,
                 prng_key=forward_key,
                 state=model.initialize_parameters_recursively(init_key),
-                inputs=dict(input_batch=dict(target_labels=target_labels), predict_outputs={}),
+                inputs=dict(
+                    input_batch=dict(target_labels=target_labels),
+                    predict_outputs=dict(hidden_states=hidden_states),
+                ),
                 method="_metrics",
                 is_training=True,
                 drop_output_collections=(),
@@ -583,6 +558,82 @@ class CrossEntropyLossMetricsTest(TestCase):
         self.assertAlmostEqual(test_loss.value(), ref_loss)
         self.assertEqual(metrics["num_targets"], live_targets.sum())
 
+    def test_metrics(self):
+        layer = (
+            causal_lm.CrossEntropyLossMetrics.default_config()
+            .set(name="metrics_test")
+            .instantiate(parent=None)
+        )
+        prng_key, init_key = jax.random.split(jax.random.PRNGKey(123))
+        metric_params = layer.initialize_parameters_recursively(init_key)
+        # Compute summaries after forwarding two batches.
+        # The second batch is a dummy one - should not affect metrics.
+        target_labels = jnp.array([[[1, 3, 0], [2, 3, 1]], [[0, 0, 0], [0, 0, 0]]])
+        logits = jnp.array(
+            [
+                [
+                    [
+                        [0.1, 0.9, 0.1, 0.1],  # Target 1; pred 1.
+                        [0.1, 0.1, 0.9, 0.1],  # Target 3; pred 2.
+                        [0.9, 0.1, 0.1, 0.1],  # Target 0; pred 0.
+                    ],  # Example 0.
+                    [
+                        [0.1, 0.1, 0.9, 0.1],  # Target 2; pred 2.
+                        [0.1, 0.1, 0.9, 0.1],  # Target 3; pred 2.
+                        [0.9, 0.1, 0.1, 0.1],  # Target 1; pred 0.
+                    ],  # Example 1.
+                ],  # Batch 0.
+                [
+                    [
+                        [0.1, 0.9, 0.1, 0.1],  # Target 0; pred 1.
+                        [0.1, 0.1, 0.9, 0.1],  # Target 0; pred 2.
+                        [0.9, 0.1, 0.1, 0.1],  # Target 0; pred 0.
+                    ],  # Example 0.
+                    [
+                        [0.1, 0.1, 0.9, 0.1],  # Target 0; pred 2.
+                        [0.1, 0.1, 0.9, 0.1],  # Target 0; pred 2.
+                        [0.9, 0.1, 0.1, 0.1],  # Target 0; pred 0.
+                    ],  # Example 1.
+                ],  # Batch 1.
+            ]
+        )
+
+        target_num_bytes = jnp.array([[3, 7], [0, 0]])
+        live_targets = jnp.array([[[1, 1, 0], [1, 1, 1]], [[0, 0, 0], [0, 0, 0]]])
+        accumulator = MetricAccumulator.default_config().instantiate()
+        for i in range(2):
+            _, output_collection = functional(
+                layer,
+                inputs=dict(
+                    input_batch=dict(
+                        target_labels=target_labels[i],
+                        live_targets=live_targets[i],
+                        target_num_bytes=target_num_bytes[i],
+                    ),
+                    predict_outputs=dict(logits=logits[i]),
+                    module_outputs=None,
+                ),
+                is_training=True,
+                prng_key=prng_key,
+                state=metric_params,
+            )
+            accumulator.update(output_collection.summaries)
+        summaries = accumulator.summaries()
+        # Only the first batch should affect results.
+        loss, loss_dict = cross_entropy(
+            logits=logits[0],
+            target_labels=target_labels[0],
+            live_targets=live_targets[0],
+        )
+        self.assertEqual(2.0 / 5, summaries["accuracy"].mean)
+        self.assertAlmostEqual(loss, summaries["loss"].mean)
+        self.assertEqual(5, summaries["loss"].weight)
+        self.assertAlmostEqual(jnp.exp(loss), summaries["perplexity"].mean, places=6)
+        per_token_loss = loss_dict["per_target_loss"] * live_targets
+        total_bytes = target_num_bytes.sum()
+        bits_per_byte = per_token_loss.sum() / jnp.maximum(1, total_bytes) / jnp.log(2)
+        self.assertAlmostEqual(bits_per_byte, summaries["bits_per_byte"].mean)
+
 
 class CompositeLossMetricsTest(TestCase):
     """Tests CompositeLossMetrics."""
@@ -720,7 +771,7 @@ class ModelAuxLossTest(TestCase):
         )
         (ref_loss, metrics), _ = metrics_fn(
             input_batch=dict(target_labels=target_labels),
-            predict_outputs=dict(logits=aux["logits"]),
+            predict_outputs=dict(hidden_states=aux["hidden_states"]),
         )
         self.assertAlmostEqual(loss, ref_loss)
         self.assertNestedAllClose(aux["metrics"], metrics)

--- a/axlearn/common/decoder.py
+++ b/axlearn/common/decoder.py
@@ -7,7 +7,6 @@ from typing import Callable, Optional, Protocol, Union
 
 import jax
 from jax import numpy as jnp
-from jax.sharding import PartitionSpec
 
 from axlearn.common import logit_modifiers
 from axlearn.common.attention import (
@@ -47,13 +46,7 @@ from axlearn.common.module import (
     current_context,
     new_output_collection,
 )
-from axlearn.common.utils import (
-    Nested,
-    NestedTensor,
-    TensorSpec,
-    validate_contains_paths,
-    with_sharding_constraint,
-)
+from axlearn.common.utils import Nested, NestedTensor, TensorSpec, validate_contains_paths
 
 
 # TODO(markblee): Remove this when we have a better solution at the decoding loop level.
@@ -543,22 +536,35 @@ class Decoder(BaseLayer):
             raise ValueError(f"Unrecognized mode {mode}.")
         x = x.data
         self._add_tensor_stats("outputs", x)
-
         if "output_norm" in self.children:
             x = self.output_norm(x)
             self._add_tensor_stats("norm_outputs", x)
         x = self.output_dropout(x)
+
+        # TODO(markblee): Rename to just "transformer". "transformer_state" is a bit redundant.
+        return dict(transformer_state=transformer_state), dict(hidden_states=x)
+
+    def compute_logits(self, forward_outputs: Nested[Tensor]) -> Tensor:
+        """Computes logits from decoder hidden states.
+
+        Args:
+            forward_outputs: A dict contains
+                hidden_states: A float Tensor of shape [batch_size, target_len, hidden_dim].
+
+        Returns:
+            logits: A float Tensor of shape [batch_size, target_len, num_classes], where
+                num_classes depends on the configured lm_head.
+        """
+        hidden_states = forward_outputs["hidden_states"]
         if "lm_head" in self.children:
-            logits = self.lm_head(x)
+            logits = self.lm_head(hidden_states)
         else:
             # Reuse the token embedding.
-            with child_context("emb_attend", module=self.emb):
-                logits = self.emb.attend(x)
+            with child_context("self_emb_attend", module=self):
+                logits = self.emb.attend(hidden_states)
         if self._output_logits_modifier is not None:
             logits = self._output_logits_modifier(logits)
-        logits = with_sharding_constraint(logits, PartitionSpec(*self.config.logits_partition_spec))
-        # TODO(markblee): Rename to just "transformer". "transformer_state" is a bit redundant.
-        return dict(transformer_state=transformer_state), dict(logits=logits, hidden_states=x)
+        return logits
 
     def forward(
         self,
@@ -590,8 +596,6 @@ class Decoder(BaseLayer):
         Returns:
             A dict containing:
                 hidden_states: A float Tensor of shape [batch_size, target_len, hidden_dim].
-                logits: A float Tensor of shape [batch_size, target_len, num_classes], where
-                    num_classes depends on the configured lm_head.
         """
         validate_contains_paths(input_batch, paths=["input_ids"])
         input_ids = input_batch["input_ids"]
@@ -659,6 +663,7 @@ class Decoder(BaseLayer):
             ),
             **kwargs,
         )
+        outputs["logits"] = self.compute_logits(outputs)
         self.add_module_output("prefill_hidden_states", outputs["hidden_states"])
         states = dict(time_step=time_step, input_ids=input_ids, **states)
         return states, outputs
@@ -716,6 +721,8 @@ class Decoder(BaseLayer):
             cached_states=cached_states,
             **kwargs,
         )
+        # TODO(axlearn-dev): Evaluate whether sharding logits during decoding is actually necessary.
+        outputs["logits"] = self.compute_logits(outputs)
         updated_states = dict(
             input_ids=updated_inputs,
             # There are some non-greedy DFS/BFS and sliding attention algorithms that

--- a/axlearn/common/decoder_test.py
+++ b/axlearn/common/decoder_test.py
@@ -109,13 +109,23 @@ class TestDecoder(TestCase):
 
         # Test values.
         def layer_output(state, layer):
-            return functional(
+            prng_key = jax.random.PRNGKey(2)
+            outputs, _ = functional(
                 layer,
                 inputs=dict(input_batch=dict(input_ids=inputs)),
                 state=state,
                 is_training=False,
-                prng_key=jax.random.PRNGKey(2),
-            )[0]["logits"]
+                prng_key=prng_key,
+            )
+            logits, _ = functional(
+                layer,
+                inputs=dict(forward_outputs=outputs),
+                state=state,
+                is_training=False,
+                prng_key=prng_key,
+                method="compute_logits",
+            )
+            return logits
 
         # Similarities with encoder_decoder_test.
         # pylint: disable=duplicate-code
@@ -198,13 +208,23 @@ class TestDecoder(TestCase):
 
             # Test values.
             def layer_output(state, layer):
-                return functional(
+                prng_key = jax.random.PRNGKey(2)
+                outputs, _ = functional(
                     layer,
                     inputs=dict(input_batch=dict(input_ids=input_ids)),
                     state=state,
                     is_training=False,
-                    prng_key=jax.random.PRNGKey(2),
-                )[0]["logits"]
+                    prng_key=prng_key,
+                )
+                logits, _ = functional(
+                    layer,
+                    inputs=dict(forward_outputs=outputs),
+                    state=state,
+                    is_training=False,
+                    prng_key=prng_key,
+                    method="compute_logits",
+                )
+                return logits
 
             ref_decoder_logits = layer_output(ref_decoder_state, ref_decoder)
             test_decoder_logits = layer_output(test_decoder_state, test_decoder)
@@ -394,6 +414,7 @@ class TestDecoder(TestCase):
                 )
                 * NEG_INF
             )
+        prng_key = jax.random.PRNGKey(0)
         forward_outputs, _ = functional(
             layer,
             inputs=dict(
@@ -407,7 +428,15 @@ class TestDecoder(TestCase):
             ),
             state=layer_params,
             is_training=False,
-            prng_key=jax.random.PRNGKey(0),
+            prng_key=prng_key,
+        )
+        fwd_logits, _ = functional(
+            layer,
+            inputs=dict(forward_outputs=forward_outputs),
+            state=layer_params,
+            is_training=False,
+            prng_key=prng_key,
+            method="compute_logits",
         )
 
         (initial_state, initial_outputs), _ = functional(
@@ -465,7 +494,7 @@ class TestDecoder(TestCase):
 
         # [batch, num_classes, tgt_len] --> [batch, tgt_len, num_classes].
         logits = jnp.moveaxis(logits, -1, -2)
-        assert_allclose(logits, forward_outputs["logits"])
+        assert_allclose(logits, fwd_logits)
 
     @parameterized.product(
         stack_cfg=[
@@ -700,7 +729,15 @@ class TestDecoder(TestCase):
                 state=layer_params,
                 prng_key=prng_key,
             )
-            chex.assert_trees_all_close(outputs["logits"], logits / temperature)
+            fwd_logits = functional(
+                decoder,
+                inputs=dict(forward_outputs=outputs),
+                is_training=True,
+                prng_key=prng_key,
+                state=layer_params,
+                method="compute_logits",
+            )[0]
+            chex.assert_trees_all_close(fwd_logits, logits / temperature)
 
             # Test prefill.
             (cached_states, prefill_outputs), _ = functional(

--- a/axlearn/common/encoder_decoder.py
+++ b/axlearn/common/encoder_decoder.py
@@ -94,8 +94,6 @@ class EncoderDecoderModel(BaseEncoderDecoderModel):
         Returns:
             A dict containing:
                 hidden_states: A float Tensor of shape [batch_size, target_len, hidden_dim].
-                logits: A float Tensor of shape [batch_size, target_len, num_classes], where
-                    num_classes depends on the configured lm_head.
 
         Raises:
             ValueError: If source_segment_ids and target_segment_ids are not provided together.
@@ -127,6 +125,18 @@ class EncoderDecoderModel(BaseEncoderDecoderModel):
             cross_attention_logit_biases=cross_attention_logit_biases,
         )
         return decoder_output
+
+    def compute_logits(self, predictions: Nested[Tensor]) -> Tensor:
+        """Computes logits from decoder hidden states.
+
+        Args:
+            predictions: the output dict from predict(), including
+                hidden_states: A float Tensor of shape [batch_size, target_len, hidden_dim].
+
+        Returns:
+            logits: A float Tensor of shape [batch_size, target_len, num_classes].
+        """
+        return self.decoder.compute_logits(predictions)
 
     def compute_attention_logit_biases(self, source_ids: Tensor) -> Tensor:
         """Produces cross-attention logit biases.
@@ -160,8 +170,11 @@ class EncoderDecoderModel(BaseEncoderDecoderModel):
                     per_token_loss: A float Tensor of shape [batch_size, target_len].
         """
         validate_contains_paths(input_batch, paths=["target_labels"])
-        validate_contains_paths(predict_outputs, paths=["logits"])
-        logits: Tensor = predict_outputs["logits"]
+        validate_contains_paths(predict_outputs, paths=["hidden_states"])
+        with child_context("self_decoder_compute_logits", module=self):
+            # TODO(axlearn-dev): Logits can consume over 10GB of HBM. Therefore,
+            # optimize it with `scan`, like in `causal_lm`, if needed.
+            logits = self.decoder.compute_logits(predict_outputs)
         target_labels: Tensor = input_batch["target_labels"]
 
         num_classes = logits.shape[-1]

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -177,6 +177,7 @@ def propagate_repeated_output_collections(
     *,
     child_name_prefix: str,
     target_output_collection: OutputCollection,
+    merge_summaries: bool,
 ):
     """Propagates contents from `repeated_output_collection` to `target_target_output_collection`.
 
@@ -192,6 +193,9 @@ def propagate_repeated_output_collections(
         child_name_prefix: The child name prefix used for children to be added to
             `target_output_collection`.
         target_output_collection: The target OutputCollection.
+        merge_summaries: Whether to merge summaries or not. If set to True, summaries from the loop
+            will be merged into "iter", rather than being stored separately per iteration like
+            "iter0", "iter1", etc.
     """
     # Fill `target_output_collection[child_name_prefix]` with `repeated_output_collection`.
     child_output = target_output_collection.add_child(child_name_prefix)
@@ -207,11 +211,28 @@ def propagate_repeated_output_collections(
         first_summary_value = summary_values[0]
         assert first_summary_value.shape, "Stacked summaries should have a leading stack dimension."
         num_children = first_summary_value.shape[0]
-        for i in range(num_children):
-            child_i_output = target_output_collection.add_child(f"{child_name_prefix}{i}")
-            child_i_output.summaries.update(
-                jax.tree.map(lambda x, i=i: x[i], repeated_output_collection.summaries)
-            )
+        if merge_summaries:
+            summaries_list = []
+            for i in range(num_children):
+                summaries_list.append(
+                    jax.tree.map(lambda x, i=i: x[i], repeated_output_collection.summaries)
+                )
+
+            summaries_0th = summaries_list[0]
+            for i in range(1, num_children):
+                summaries_0th = jax.tree.map(
+                    lambda x, y: x.accumulate(y),
+                    summaries_0th,
+                    summaries_list[i],
+                    is_leaf=lambda x: isinstance(x, Summary),
+                )
+            child_output.summaries.update(**summaries_0th)
+        else:
+            for i in range(num_children):
+                child_i_output = target_output_collection.add_child(f"{child_name_prefix}{i}")
+                child_i_output.summaries.update(
+                    jax.tree.map(lambda x, i=i: x[i], repeated_output_collection.summaries)
+                )
 
 
 T = TypeVar("T")
@@ -1109,6 +1130,7 @@ def scan_in_context(
     child_name_prefix: str = "iter",
     unroll: Union[int, bool] = 1,
     remat_kwargs: Optional[dict[str, Any]] = None,
+    merge_summaries: bool = False,
 ) -> tuple[NestedTensor, NestedTensor]:
     """A thin wrapper around `jax.lax.scan` which is compatible with `OutputCollection`.
 
@@ -1145,6 +1167,9 @@ def scan_in_context(
                 `scan_fn = jax.checkpoint(scan_fn, **remat_kwargs)`
             Otherwise, `jax.checkpoint` is not used.
             See https://docs.jax.dev/en/latest/_autosummary/jax.checkpoint.html.
+        merge_summaries: Whether to merge summaries or not. If set to True, summaries from the loop
+            will be merged into "iter", rather than being stored separately per iteration like
+            "iter0", "iter1", etc.
 
     Returns:
         The scan outputs (carry, ys):
@@ -1201,6 +1226,7 @@ def scan_in_context(
         scan_ys.pop("output_collection"),
         child_name_prefix=child_name_prefix,
         target_output_collection=ctx.output_collection,
+        merge_summaries=merge_summaries,
     )
 
     return carry, scan_ys["y_i"]

--- a/axlearn/vision/virtex.py
+++ b/axlearn/vision/virtex.py
@@ -243,7 +243,11 @@ class VirTexModel(ImageBackboneModelMixin, BaseLayer):
             input_batch=dict(input_ids=decoder_ids),
             cross_attention_data=projected_visual_features,
         )
-        metrics = self._metrics(predictions["logits"], decoder_labels)
+        with child_context("textual_compute_logits", module=self.textual):
+            # TODO(axlearn-dev): Logits can consume over 10GB of HBM. Therefore,
+            # optimize it with `scan`, like in `causal_lm`, if needed.
+            logits = self.textual.compute_logits(predictions)
+        metrics = self._metrics(logits, decoder_labels)
 
         aux_outputs = dict(visual_features=projected_visual_features, **predictions)
         return metrics["loss"], aux_outputs if return_aux else {}


### PR DESCRIPTION
When the vocab size is large and the context length is long, full logits consume a significant amount of memory.
For example, with a sequence length of 16k and a vocab size of 153k, a single batch in FP32 consumes about 9.6 GB of HBM.
This is currently happening in the 3B model, and by eliminating this memory usage, we could reduce peak forward memory by roughly 1/3.

Logits are mainly used to compute ids and cross entropy, but after these ops, we only need memory of shape [16k, 1]. So we can achieve the same outcome without materializing the full logits.

This PR computes ids and cross entropy within a jax.lax.scan, evaluating every `scan_chunk` steps. When `scan_chunk=512`, peak memory drops from 16k × 153k (9.6GB) to 512 × 153k (313MB), a substantial reduction.

Furthermore, since logits are the primary memory bottleneck for long sequences, this approach allows us to support longer contexts (e.g., 32k, 128k, 1M) while keeping logits memory fixed at `scan_chunk` tokens.

**Change details:**
* CausalLM._metrics() uses scan to compute logits in chunks, and the LossMetrics classes compute loss metrics on a per-chunk basis. After the scan, the metrics across num_iterations are aggregated.
* To support this change, scan_in_context was updated to include an option that merges summaries across scan iterations before returning.

**Why jax.lax.scan?**
Among all tested options, jax.lax.scan(jax.remat) offered the best trade-off between memory and speed. Other alternatives either didn’t save much memory or were significantly slower. fori_loop was close in behavior but had slightly worse performance and does not support autodiff.

| Method                 | HBM (GB) | Time (s) |
|------------------------|----------|----------|
| as-is                 | 18.1     | 0.56     |
| scan                  | 24.0     | 0.90     |
| **scan (remat)**      | 14.4     | 0.62     |
| scan (remat + jit)    | 14.4     | 0.61     |
| fori                  | 32.7     | 2.99     |
| fori (remat)          | 16.4     | 0.62     |
| fori (remat + jit)    | 16.4     | 0.63     |
| lax.map               | 42.0     | 2.93     |
| jax.vmap              | 24.0     | 0.57     |
| jax.vmap (remat)      | 24.0     | 0.57     |
| jax.vmap (remat + jit)| 24.0     | 0.45     |

**New `scan_chunk` config is introduced.**
The default is None, which disables scanning.
To enable scan, you must set a value. 512 is recommended for both TPU and GPU. For example, with a sequence length of 16k and a vocab size of 150k, this can save around 10 GB of memory, at the cost of about a 5% slowdown, according to following benchmark results.

* v7/v8 3B Pretrain (seq_len=8k, FSDP=4, TPUv5p)
  * `scan_chunk 512` saves 2–3 GB of HBM with almost no impact on speed.

| Configuration         | Train HBM | Train sec/step | Forward HBM | Forward sec/step |
|-----------------------|-----------|----------------|-------------|------------------|
| As-is                 | 19.6 GB   | 1.116 s        | 8.43 GB     | 296 ms           |
| scan_chunk 64         | 17.4 GB   | 1.172 s        | 5.59 GB     | 295 ms           |
| scan_chunk 128        | 17.4 GB   | 1.172 s        | 5.59 GB     | 291 ms           |
| scan_chunk 256        | 17.4 GB   | 1.160 s        | 5.59 GB     | 290 ms           |
| **scan_chunk 512**        | 17.4 GB   | 1.161 s        | 5.59 GB     | 290 ms           |
| **scan_chunk 512**        | - 11%   | + 4%       | - 44%     | - 2%           |
| scan_chunk 1k         | 17.6 GB   | 1.161 s        | 5.59 GB     | 291 ms           |
| scan_chunk 2k         | 18.6 GB   | 1.158 s        | 5.59 GB     | 289 ms           |

* v7 3B + audio tokenizer Post-train (seq_len=16k, FSDP=4, TPUv5p)
  * `scan_chunk 512` saves 10 GB of HBM, but results in a 15–28% slowdown (likely due to audio embedding sharding, needs check).

| Configuration     | Train HBM | Train sec/step | Forward HBM | Forward sec/step |
|-------------------|-----------|----------------|-------------|------------------|
| As-is             | 38.8 GB   | 3.070 s        | 19.8 GB     | 0.899 s          |
| scan_chunk 64     | 30.7 GB   | 3.530 s        | 9.22 GB     | 1.158 s          |
| scan_chunk 128    | 27.6 GB   | 3.560 s        | 9.22 GB     | 1.096 s          |
| scan_chunk 256    | 27.6 GB   | 3.510 s        | 9.22 GB     | 1.149 s          |
| **scan_chunk 512**    | 27.6 GB   | 3.530 s        | 9.22 GB     | 1.149 s          |
| **scan_chunk 512**    | - 29%   | + 15%       | - 53%     | + 28%          |
| scan_chunk 1k     | 28.0 GB   | 3.530 s        | 9.23 GB     | 1.152 s          |
| scan_chunk 2k     | 30.7 GB   | 3.530 s        | 12.1 GB     | 1.148 s          |

* v7/v8 3B Pretrain (seq_len=8k, FSDP=8, H100)
  * `scan_chunk 512` saves 3.7 GB of HBM with a 7% slowdown.

| Configuration       | Train HBM | Train sec/step |
|---------------------|-----------|----------------|
| As-is               | 18.1 GB   | 1.670 s        |
| scan_chunk 128      | 14.4 GB   | 1.850 s        |
| scan_chunk 256      | 14.4 GB   | 1.806 s        |
| **scan_chunk 512**      | 14.5 GB   | 1.786 s        |
| **scan_chunk 512**      | - 20%   | + 7%        |
| scan_chunk 1k       | 14.7 GB   | 1.769 s        |
| scan_chunk 2k       | 15.3 GB   | 1.764 s        |
| scan_chunk 8k       | 24.1 GB   | 1.729 s        |
