### PR TITLE
Ensure Jax config is set for Pathways

### DIFF
--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -47,6 +47,7 @@ from absl import flags, logging
 from axlearn.common.status_server import StatusHTTPServer
 from axlearn.common.utils import get_data_dir
 from axlearn.common.utils_spmd import setup as setup_spmd
+from axlearn.common.utils_spmd import setup_jax_config
 
 # pylint: enable=wrong-import-position
 
@@ -115,6 +116,10 @@ def setup():
 
     with _init_context():
         if FLAGS.jax_backend == "proxy":
+            # These Jax configs are required and set in setup_spmd() which isn't
+            # called by Pathways.
+            setup_jax_config()
+
             # pylint: disable-next=import-error,import-outside-toplevel
             import pathwaysutils  # pytype: disable=import-error
 

--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -114,6 +114,12 @@ def setup():
         logging.info("LIBTPU_INIT_ARGS='%s'", os.environ["LIBTPU_INIT_ARGS"])
 
     with _init_context():
+        # Jax config needs to be set for both pathways and Jax.
+        # Use a GSPMD-friendly PRNG implementation.
+        jax.config.update("jax_default_prng_impl", "rbg")
+        # This allows replicated jax.Arrays to be used for computation on the host.
+        jax.config.update("jax_spmd_mode", "allow_all")
+
         if FLAGS.jax_backend == "proxy":
             # pylint: disable-next=import-error,import-outside-toplevel
             import pathwaysutils  # pytype: disable=import-error

--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -114,12 +114,6 @@ def setup():
         logging.info("LIBTPU_INIT_ARGS='%s'", os.environ["LIBTPU_INIT_ARGS"])
 
     with _init_context():
-        # Jax config needs to be set for both pathways and Jax.
-        # Use a GSPMD-friendly PRNG implementation.
-        jax.config.update("jax_default_prng_impl", "rbg")
-        # This allows replicated jax.Arrays to be used for computation on the host.
-        jax.config.update("jax_spmd_mode", "allow_all")
-
         if FLAGS.jax_backend == "proxy":
             # pylint: disable-next=import-error,import-outside-toplevel
             import pathwaysutils  # pytype: disable=import-error

--- a/axlearn/common/utils_spmd.py
+++ b/axlearn/common/utils_spmd.py
@@ -41,6 +41,11 @@ def setup(
             * one of num_processes or process_id is None when jax_backend is not "tpu";
             * distributed_coordinator is None when jax_backend is not "tpu" and num_processes > 1.
     """
+    # Use a GSPMD-friendly PRNG implementation.
+    jax.config.update("jax_default_prng_impl", "rbg")
+    # This allows replicated jax.Arrays to be used for computation on the host.
+    jax.config.update("jax_spmd_mode", "allow_all")
+
     global _jax_distributed_initialized  # pylint: disable=global-statement
     if not _jax_distributed_initialized:
         init_kwargs = {}

--- a/axlearn/common/utils_spmd.py
+++ b/axlearn/common/utils_spmd.py
@@ -41,11 +41,6 @@ def setup(
             * one of num_processes or process_id is None when jax_backend is not "tpu";
             * distributed_coordinator is None when jax_backend is not "tpu" and num_processes > 1.
     """
-    # Use a GSPMD-friendly PRNG implementation.
-    jax.config.update("jax_default_prng_impl", "rbg")
-    # This allows replicated jax.Arrays to be used for computation on the host.
-    jax.config.update("jax_spmd_mode", "allow_all")
-
     global _jax_distributed_initialized  # pylint: disable=global-statement
     if not _jax_distributed_initialized:
         init_kwargs = {}

--- a/axlearn/common/utils_spmd.py
+++ b/axlearn/common/utils_spmd.py
@@ -11,6 +11,13 @@ import portpicker
 _jax_distributed_initialized = False
 
 
+def setup_jax_config():
+    # Use a GSPMD-friendly PRNG implementation.
+    jax.config.update("jax_default_prng_impl", "rbg")
+    # This allows replicated jax.Arrays to be used for computation on the host.
+    jax.config.update("jax_spmd_mode", "allow_all")
+
+
 def setup(
     *,
     jax_backend: str,
@@ -41,10 +48,7 @@ def setup(
             * one of num_processes or process_id is None when jax_backend is not "tpu";
             * distributed_coordinator is None when jax_backend is not "tpu" and num_processes > 1.
     """
-    # Use a GSPMD-friendly PRNG implementation.
-    jax.config.update("jax_default_prng_impl", "rbg")
-    # This allows replicated jax.Arrays to be used for computation on the host.
-    jax.config.update("jax_spmd_mode", "allow_all")
+    setup_jax_config()
 
     global _jax_distributed_initialized  # pylint: disable=global-statement
     if not _jax_distributed_initialized:


### PR DESCRIPTION
This is needed to fix a mismatch in pnrg keys when using Pathways and restoring from a checkpoint.