### PR TITLE
Set default PRNG implementation on pathways

### DIFF
--- a/axlearn/common/launch.py
+++ b/axlearn/common/launch.py
@@ -115,6 +115,12 @@ def setup():
 
     with _init_context():
         if FLAGS.jax_backend == "proxy":
+            # AXLearn assumes rbg PRNG implementation and restore from checkpoint
+            # will fail on pathways if this isn't set. This is due shape of [4]
+            # being hardcoded here:
+            # https://github.com/apple/axlearn/blob/8bb4421e62c815ef9f1ba3679c3277b8bbc6a449/axlearn/common/trainer.py#L330
+            jax.config.update("jax_default_prng_impl", "rbg")
+
             # pylint: disable-next=import-error,import-outside-toplevel
             import pathwaysutils  # pytype: disable=import-error
 


### PR DESCRIPTION
AXLearn assumes implicitely that rbg is used as the PNRG implementation.