### PR TITLE
Pathways: jax client on Mac support

### DIFF
--- a/axlearn/cloud/gcp/pathways_utils.py
+++ b/axlearn/cloud/gcp/pathways_utils.py
@@ -39,8 +39,8 @@ _PATHWAYS_RESOURCE_MANAGER_PORT = 29001
 # The specific value is not important, as long as clients and servers use the same port.
 _PATHWAYS_WORKER_PORT = 29001
 # Pin to specific pathways image version for stable release.
-# There is guarantee that this image will work with newer Jax releases.
-# However this image was tested in Maxtext with Jax 0.6.1.
+# There is no guarantee that this image will work with newer Jax releases.
+# However this image was also tested in Maxtext with Jax 0.6.1.
 _PATHWAYS_IMAGE_TAG = "jax-0.5.3-patch060625"
 # The docker image used by pathways proxy container.
 _PATHWAYS_PROXY_IMAGE = (

--- a/axlearn/cloud/gcp/pathways_utils.py
+++ b/axlearn/cloud/gcp/pathways_utils.py
@@ -39,8 +39,9 @@ _PATHWAYS_RESOURCE_MANAGER_PORT = 29001
 # The specific value is not important, as long as clients and servers use the same port.
 _PATHWAYS_WORKER_PORT = 29001
 # Pin to specific pathways image version for stable release.
-# Verified the backwards compatibility works.
-_PATHWAYS_IMAGE_TAG = "jax-0.5.3"
+# There is guarantee that this image will work with newer Jax releases.
+# However this image was tested in Maxtext with Jax 0.6.1.
+_PATHWAYS_IMAGE_TAG = "jax-0.5.3-patch060625"
 # The docker image used by pathways proxy container.
 _PATHWAYS_PROXY_IMAGE = (
     f"us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:{_PATHWAYS_IMAGE_TAG}"
@@ -293,6 +294,10 @@ class PathwaysReplicatedJob(BaseReplicatedJob):
         ]
         cmd_args.extend(xla_flags_from_options(self._xla_options).split())
 
+        # This is required for GKE Workload Identity and Mac Jax Client support.
+        # TODO(samos123): Remove this once this becomes the default.
+        proxy_env = [{"name": "IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS", "value": "true"}]
+
         return [
             dict(
                 name=_PATHWAYS_PROXY_CONTAINER_NAME,
@@ -301,6 +306,7 @@ class PathwaysReplicatedJob(BaseReplicatedJob):
                 # SideCar container is an init container with restartPolicy as "Always".
                 restartPolicy="Always",
                 args=cmd_args,
+                env=proxy_env,
                 ports=[dict(containerPort=_PATHWAYS_PROXY_PORT)],
             ),
             dict(


### PR DESCRIPTION
Pathways interactive super computing allows you to run your Jax client from
anywhere. The Jax client can now run in a notebook, your VSCode editor or a
Ray job running on CPU.

There are 2 steps:
1. Creating the headless pathways cluster with no Jax client
2. Creating a Jax client that connects to the pathways proxy in the pathways cluster.

#### Creating a Headless Pathways cluster

```
export CLUSTER=$(axlearn gcp config | grep gke_cluster | \
                 awk '{ print $3 }' | tr -d  '"')
axlearn gcp launch run --cluster=$CLUSTER \
        --runner_name gke_tpu_pathways \
        --name=$USER \
        --instance_type=tpu-v6e-16 \
        --num_replicas=1 \
        --bundler_spec=allow_dirty=True \
        --bundler_type=artifactregistry --bundler_spec=image=tpu \
        --bundler_spec=dockerfile=Dockerfile --bundler_spec=target=tpu \
        -- sleep infinity;
```

#### Exposing the Pathways cluster using port-forward

You have to setup something like `kubectl port-forward` to expose the pathways-proxy.

Setup a port-forward to the pathways proxy pod:

```
kubectl get pods -o name | grep "${USER}.*head-0-0.*" | xargs -I{} kubectl port-forward {} 29000:29000
```


#### Running a Jax client from your local CLI


Now run local jax client:
```
export TEST_UNDECLARED_OUTPUTS_DIR=true
JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 \
  python -c 'import pathwaysutils; import jax; import pprint; pathwaysutils.initialize(); pprint.pprint(jax.devices())'
```


#### Running Jax client Fuji v2 7B from VSCode on Mac

Create the file `.vscode/launch.json` with the following content in your AXLearn repo:
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Fuji v2 7b flash",
            "type": "debugpy",
            "request": "launch",
            "program": "axlearn/common/launch_trainer_main.py",
            "args": "--module=text.gpt.c4_trainer --config=fuji-7B-v2-flash --trainer_dir=local-train-dir --data_dir=gs://axlearn-public/tensorflow_datasets  --jax_backend=proxy --mesh_selector=tpu-v6e-16",
            "console": "integratedTerminal",
            "env": {
                "JAX_PLATFORMS": "proxy",
                "JAX_BACKEND_TARGET": "grpc://127.0.0.1:29000",
                "PROJECT_ID": "tpu-prod-env-multipod",
                "TF_CPP_MIN_LOG_LEVEL": "0",
                "TF_CPP_VMODULE": "grpc_host_buffer=3,rpc_helper=3,host_buffer=3,ifrt_backend=3,grpc_service_impl=3",
                "TEST_UNDECLARED_OUTPUTS_DIR": "true",
                "PYDEVD_WARN_SLOW_RESOLVE_TIMEOUT": "30",
            }
        },
    ]
}
```

Inside VSCode AXLearn directory create the `local-train-dir` directory:
```
mkdir -p local-train-dir
```

Now you can go "Run and Debug" and Launch an AXLearn Fuji v2 7B job.