### PR TITLE
Add .zed/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,9 @@ cython_debug/
 # Vscode
 .vscode/
 
+# Zed
+.zed/
+
 # Weights & Biases
 wandb/
 


### PR DESCRIPTION
Zed IDE is a new IDE people also use, similar to VSCode

https://zed.dev/

Adding its metadata folder to gitignore.