### PR TITLE
`CompositeLossMetrics` now performs a weighted sum of losses.

### DIFF
--- a/axlearn/common/causal_lm_test.py
+++ b/axlearn/common/causal_lm_test.py
@@ -596,18 +596,13 @@ class CompositeLossMetricsTest(TestCase):
                 del kwargs
                 return WeightedScalar(input_batch[self.name], 1.0), {}
 
-        class FixedLossWeights(causal_lm.CompositeLossWeights):
-            def forward(self, child_metrics):
-                del child_metrics
-                return loss_weights
-
         cfg = causal_lm.CompositeLossMetrics.default_config().set(
             name="test",
             metrics={
                 "test0": DummyMetrics.default_config(),
                 "test1": DummyMetrics.default_config(),
             },
-            loss_weights=FixedLossWeights.default_config(),
+            loss_weights=loss_weights,
         )
 
         metrics = cfg.instantiate(parent=None)
@@ -622,14 +617,17 @@ class CompositeLossMetricsTest(TestCase):
             is_training=True,
         )
         self.assertAlmostEqual(
-            loss.value(), 1.23 * loss_weights["test0"] + 3.45 * loss_weights["test1"]
+            loss.value(),
+            (1.23 * loss_weights["test0"] + 3.45 * loss_weights["test1"])
+            / (loss_weights["test0"] + loss_weights["test1"]),
         )
 
         def _aggregate(aux):
-            loss = 0.0
-            for name, loss_weight in loss_weights.items():
-                loss += loss_weight * aux[f"loss_{name}"].mean
-            return loss
+            loss_sum = weight = 0.0
+            for name in loss_weights:
+                loss_sum += aux[f"loss_{name}"].weight * aux[f"loss_{name}"].mean
+                weight += aux[f"loss_{name}"].weight
+            return loss_sum / weight
 
         self.assertAlmostEqual(loss.value(), _aggregate(aux))
 
@@ -733,7 +731,7 @@ class ModelAuxLossTest(TestCase):
             else:
                 self.assertEqual(aux["metrics"]["aux_loss"].value(), 0.0)
             self.assertEqual(
-                aux["metrics"]["cross_entropy"].value() + aux["metrics"]["aux_loss"].value(), loss
+                (aux["metrics"]["cross_entropy"] + aux["metrics"]["aux_loss"]).value(), loss
             )
         else:
             self.assertNotIn("aux_loss", aux)
@@ -811,7 +809,7 @@ class ModelAuxLossTest(TestCase):
         self.assertIn("aux_loss", summaries)
         self.assertEqual(summaries["aux_loss"].value(), 1.0)
         self.assertNestedAllClose(
-            summaries["cross_entropy_loss"].value() + summaries["aux_loss"].value(),
+            (summaries["cross_entropy_loss"] + summaries["aux_loss"]).value(),
             outputs.forward_outputs.loss,
         )
 


### PR DESCRIPTION
Currently, `CompositeLossMetrics` sums the losses without considering their weights (i.e., the number of live targets). To make this a weighted sum, downstream code has been implementing `CompositeLossWeights` to inject the number of live targets into `loss_weights`. This is essentially patching a surprising logic (initail loss sum) with complex logic (CompositeLossWeights) into a straightforward one (weighted sum).

Therefore, we’re changing the default loss aggregation logic to be straightforward from the beginning.

From now on, our standarized loss aggregation logic is
```
loss = sum(each_loss_weight * each_loss * num_each_samples) / sum(each_loss_weight * num_each_samples)
```

Historically, the complex logic was introduced because the weights of losses returned by child metrics were unknown. But now that child metrics return losses as `WeightedScalar`, we can adopt a simpler, cleaner aggregation logic.

Note: alternative formulation could be
```
loss = sum(each_loss_weight * each_loss * num_each_samples) / sum(num_each_samples)
```
However, when num_each_samples is large and each_loss_weight is small, the denominator can become disproportionately large. So we discard this option.