### PR TITLE
feat(utils): add `to_bool` for consistent boolean conversion

### DIFF
--- a/axlearn/cloud/common/bundler.py
+++ b/axlearn/cloud/common/bundler.py
@@ -62,6 +62,7 @@ from axlearn.cloud.common.utils import (
     copy_blobs,
     get_pyproject_version,
     parse_kv_flags,
+    to_bool,
 )
 from axlearn.common.config import REQUIRED, Configurable, Required, config_class
 from axlearn.common.file_system import copy, exists, makedirs
@@ -341,9 +342,17 @@ class BaseDockerBundler(Bundler):
         cfg: BaseDockerBundler.Config = super().from_spec(spec, fv=fv)
         kwargs = parse_kv_flags(spec, delimiter="=")
         cache_from = canonicalize_to_list(kwargs.pop("cache_from", None))
+        skip_bundle = to_bool(kwargs.pop("skip_bundle", False))
+        allow_dirty = to_bool(kwargs.pop("allow_dirty", False))
         # Non-config specs are treated as build args.
         build_args = {k: kwargs.pop(k) for k in list(kwargs.keys()) if k not in cfg}
-        return cfg.set(build_args=build_args, cache_from=cache_from, **kwargs)
+        return cfg.set(
+            build_args=build_args,
+            cache_from=cache_from,
+            skip_bundle=skip_bundle,
+            allow_dirty=allow_dirty,
+            **kwargs,
+        )
 
     # pylint: disable-next=arguments-renamed
     def id(self, tag: str) -> str:

--- a/axlearn/cloud/common/utils.py
+++ b/axlearn/cloud/common/utils.py
@@ -292,6 +292,19 @@ def merge(base: dict, overrides: dict):
     return base
 
 
+def to_bool(value: Any) -> bool:
+    """Converts a string representation of truth to a bool."""
+    if isinstance(value, bool):
+        return value
+    elif isinstance(value, str):
+        val_lower = value.lower()
+        if val_lower == "true":
+            return True
+        elif val_lower == "false":
+            return False
+    raise ValueError(f"Invalid truth value: '{value}'")
+
+
 _Row = list[Any]
 
 

--- a/axlearn/cloud/common/utils_test.py
+++ b/axlearn/cloud/common/utils_test.py
@@ -222,6 +222,24 @@ class UtilsTest(TestWithTemporaryCWD):
     def test_merge(self, base, overrides, expected):
         self.assertEqual(expected, utils.merge(base, overrides))
 
+    @parameterized.parameters(
+        ("true", True),
+        ("True", True),
+        ("false", False),
+        ("False", False),
+        (True, True),
+        (False, False),
+        ("yes", ValueError),
+        (1, ValueError),
+    )
+    def test_to_bool(self, value, expected):
+        if isinstance(expected, type) and issubclass(expected, Exception):
+            with self.assertRaises(expected):
+                utils.to_bool(value)
+        else:
+            result = utils.to_bool(value)
+            self.assertEqual(result, expected)
+
     def test_infer_resources(self):
         @config_class
         class DummyConfig(ConfigBase):

--- a/axlearn/cloud/gcp/bundler.py
+++ b/axlearn/cloud/gcp/bundler.py
@@ -58,7 +58,7 @@ from axlearn.cloud.common.bundler import main as bundler_main
 from axlearn.cloud.common.bundler import main_flags as bundler_main_flags
 from axlearn.cloud.common.bundler import register_bundler
 from axlearn.cloud.common.docker import registry_from_repo
-from axlearn.cloud.common.utils import canonicalize_to_list
+from axlearn.cloud.common.utils import canonicalize_to_list, to_bool
 from axlearn.cloud.gcp.cloud_build import get_cloud_build_status
 from axlearn.cloud.gcp.config import gcp_settings
 from axlearn.cloud.gcp.utils import common_flags
@@ -148,9 +148,7 @@ class CloudBuildBundler(BaseDockerBundler):
         cfg.project = cfg.project or gcp_settings("project", required=False, fv=fv)
         cfg.repo = cfg.repo or gcp_settings("docker_repo", required=False, fv=fv)
         cfg.dockerfile = cfg.dockerfile or gcp_settings("default_dockerfile", required=False, fv=fv)
-        # The value from from_spec is a str and will result in wrong condition.
-        if isinstance(cfg.is_async, str):
-            cfg.is_async = cfg.is_async.lower() != "false"
+        cfg.is_async = to_bool(cfg.is_async)
         return cfg
 
     # pylint: disable-next=no-self-use,unused-argument


### PR DESCRIPTION
* Introduces a `to_bool` utility function that converts string representations ("true", "false") to boolean values.

* This function is now used by `is_async`, `skip_bundle`, and `allow_dirty` to ensure consistent boolean parsing from string inputs.