### PR TITLE
Fix for jax 0.6.1

### DIFF
--- a/axlearn/common/flash_attention/gpu_decoding.py
+++ b/axlearn/common/flash_attention/gpu_decoding.py
@@ -49,6 +49,7 @@ from absl import logging
 from jax import lax
 from jax._src.cudnn.fused_attention_stablehlo import check_compute_capability
 from jax.experimental import pallas as pl
+from jax.experimental.pallas.triton import TritonCompilerParams
 
 from axlearn.common.attention_bias import (
     NEG_INF,
@@ -58,7 +59,6 @@ from axlearn.common.attention_bias import (
     split,
 )
 from axlearn.common.flash_attention.common import BaseSingleStepDecoding, get_gpu_dot_precision
-from axlearn.common.flash_attention.gpu_attention import NoPopDict
 from axlearn.common.utils import Nested, Tensor
 
 
@@ -250,7 +250,7 @@ def _decode_attn_unbatched(
             pl.BlockSpec((None, None, block_h), lambda kv_h, q_h, k: (kv_h, k, q_h)),  # l
             pl.BlockSpec((None, None, block_h), lambda kv_h, q_h, k: (kv_h, k, q_h)),  # m
         ],
-        compiler_params=NoPopDict(triton=NoPopDict(num_warps=num_warps, num_stages=num_stages)),
+        compiler_params=TritonCompilerParams(num_warps=num_warps, num_stages=num_stages),
         out_shape=[
             jax.ShapeDtypeStruct(
                 shape=(num_kvheads, k_splits, *q.shape[1:]), dtype=jnp.float32

--- a/axlearn/common/flash_attention/gpu_paged_attention.py
+++ b/axlearn/common/flash_attention/gpu_paged_attention.py
@@ -19,6 +19,7 @@ import jax
 import jax.numpy as jnp
 from jax import lax
 from jax.experimental import pallas as pl
+from jax.experimental.pallas.triton import TritonCompilerParams
 
 from axlearn.common.attention_bias import (
     NEG_INF,
@@ -28,7 +29,6 @@ from axlearn.common.attention_bias import (
     split,
 )
 from axlearn.common.flash_attention.common import BasePagedAttention, get_gpu_dot_precision
-from axlearn.common.flash_attention.gpu_attention import NoPopDict
 from axlearn.common.flash_attention.gpu_decoding import _get_sm_count as get_sm_count
 from axlearn.common.utils import Nested, Tensor
 
@@ -282,7 +282,7 @@ def _paged_attention_unbatched(
         ],
         debug=debug,
         interpret=interpret,
-        compiler_params=NoPopDict(triton=NoPopDict(num_warps=num_warps, num_stages=num_stages)),
+        compiler_params=TritonCompilerParams(num_warps=num_warps, num_stages=num_stages),
         name=f"paged_attention_{block_h=}_{pages_per_compute_block=}",
     )(q_reshaped, key, value, page_tables, bias_reshaped, lengths)
 


### PR DESCRIPTION
Changes
1. Remove NoPopDict, as https://github.com/jax-ml/jax/issues/25714 is resolved.
2. Pallas after jax 0.6.x expects a `CompilerParams` rather than a plain dict. 