### PR TITLE
Reduce verbose logging in evalers.

### DIFF
--- a/axlearn/common/evaler.py
+++ b/axlearn/common/evaler.py
@@ -548,10 +548,8 @@ def every_n_steps_policy(
     def fn(*, step: int, train_summaries: dict[str, Any]) -> bool:
         del train_summaries
         if step < min_step:
-            logging.info(
-                "Skipping eval, as step (%s) < min_step (%s).",
-                step,
-                min_step,
+            logging.log_first_n(
+                logging.INFO, "Skipping eval, as step (%s) < min_step (%s).", 10, step, min_step
             )
             return False
         return step % n == 0 or (max_step is not None and step >= max_step)


### PR DESCRIPTION
The following log appears too frequently and makes it hard to find the actual model loss: `Skipping eval, as step (497) < min_step (10000).`