### PR TITLE
feat: Logit sinks with Splash Attention kernel

### DIFF
--- a/axlearn/common/flash_attention/decoding_test.py
+++ b/axlearn/common/flash_attention/decoding_test.py
@@ -130,6 +130,7 @@ class DecodingTest(TestCase):
             value=v,
             page_tables=page_tables,
             bias=bias,
+            logit_sink=None,
         )
 
         fn = decoding_fn.default_config().set(**cfg).instantiate()
@@ -214,6 +215,7 @@ class DecodingTest(TestCase):
             key=k,
             value=v,
             bias=bias,
+            logit_sink=None,
         )
         fn = decoding_fn.default_config().set(**cfg).instantiate()
         is_supported = fn.is_supported(input_batch=input_batch)
@@ -230,9 +232,9 @@ class DecodingTest(TestCase):
         self.assertTrue(is_supported)
 
         o = fn(input_batch)
-        with jax.default_matmul_precision(
-            "highest"
-        ) if input_dtype is jnp.float32 else nullcontext():
+        with (
+            jax.default_matmul_precision("highest") if input_dtype is jnp.float32 else nullcontext()
+        ):
             o_ref = ReferenceMHA.default_config().set(**cfg).instantiate()(input_batch)
 
         if input_dtype not in (jnp.float16, jnp.bfloat16, jnp.float32):

--- a/axlearn/common/flash_attention/neuron_attention_test.py
+++ b/axlearn/common/flash_attention/neuron_attention_test.py
@@ -62,7 +62,7 @@ def test_fwd_against_ref(
     # Compare outputs.
     test_fn = NeuronFlashAttention.default_config().set(**cfg).instantiate()
     ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
-    input_batch = dict(query=q, key=k, value=v, bias=bias)
+    input_batch = dict(query=q, key=k, value=v, bias=bias, logit_sink=None)
     o = test_fn(input_batch)
     o_ref = ref_fn(input_batch)
     if input_dtype == jnp.float16:

--- a/axlearn/common/flash_attention/utils.py
+++ b/axlearn/common/flash_attention/utils.py
@@ -50,6 +50,7 @@ def flash_attention_implementation(
     key: Tensor,
     value: Tensor,
     bias: BaseAttentionBias,
+    logit_sink: Optional[Tensor] = None,
     softmax_scale: float = 1.0,
     is_decoding: bool = False,
     tpu_block_size: int = 512,
@@ -77,6 +78,7 @@ def flash_attention_implementation(
             for paged attention; a physical-page layout where each value page
             has exactly `page_size` tokens.
         bias: Attention bias to apply.
+        logit_sink: An optional Tensor of shape [num_heads].
         softmax_scale: A scalar value applied to the logits before softmax.
         is_decoding: Whether it is in decoding.
         tpu_block_size: The size of the computation-block unit for 'tpu' backend.
@@ -128,6 +130,7 @@ def flash_attention_implementation(
         value=value,
         page_tables=page_tables,
         bias=bias,
+        logit_sink=logit_sink,
     )
     for cfg in attn_configs:
         attn_fn = cfg.default_config().set(**common_cfg).instantiate()

--- a/axlearn/common/flash_attention/utils_test.py
+++ b/axlearn/common/flash_attention/utils_test.py
@@ -186,6 +186,7 @@ class TestFlashAttention(TestCase):
                     value=value,
                     prng_key=prng_key,
                     bias=bias,
+                    logit_sink=None,
                 )
                 ref_out = ref_fn(input_batch)
                 test_out = test_fn(input_batch)
@@ -286,6 +287,7 @@ class TestFlashAttention(TestCase):
                     value=value_for_forward,
                     prng_key=prng_key,
                     bias=bias,
+                    logit_sink=None,
                 )
                 fwd_out = fwd_fn(forward_batch)
                 # Limit generation length to 16 to save test time.
@@ -317,6 +319,7 @@ class TestFlashAttention(TestCase):
                         prng_key=prng_key,
                         page_tables=page_tables,
                         bias=bias_step,
+                        logit_sink=None,
                     )
                     decoding_out = decode_fn(
                         input_batch=decode_batch,


### PR DESCRIPTION
- Add logit sink functionality to `softmax_with_biases` in attention.py
- Extend Flash Attention layers with sink support
- Implement TPU Splash Attention kernel integration
- Add comprehensive test coverage across GPU/TPU attention modules
- Update attention utilities and common interfaces