### PR TITLE
Upgrade Tensorboard Plugin Profile to enable Roofline and Framework Ops Stats views.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN pip install --upgrade pip && pip install uv flit && pip cache purge
 FROM base AS ci
 
 # TODO(markblee): Remove gcp,vertexai_tensorboard from CI.
-RUN uv pip install .[core,dev,grain,gcp,vertexai_tensorboard,open_api] && uv cache clean
+RUN uv pip install --prerelease=allow .[core,dev,grain,gcp,vertexai_tensorboard,open_api] && uv cache clean
 COPY . .
 
 # Defaults to an empty string, i.e. run pytest against all files.
@@ -58,7 +58,7 @@ FROM base AS bastion
 # TODO(markblee): Consider copying large directories separately, to cache more aggressively.
 # TODO(markblee): Is there a way to skip the "production" deps?
 COPY . /root/
-RUN uv pip install .[core,gcp,vertexai_tensorboard] && uv cache clean
+RUN uv pip install --prerelease=allow .[core,gcp,vertexai_tensorboard] && uv cache clean
 
 ################################################################################
 # Dataflow container spec.                                                     #
@@ -69,7 +69,7 @@ FROM base AS dataflow
 # Beam workers default to creating a new virtual environment on startup. Instead, we want them to
 # pickup the venv setup above. An alternative is to install into the global environment.
 ENV RUN_PYTHON_SDK_IN_DEFAULT_ENVIRONMENT=1
-RUN uv pip install .[core,gcp,dataflow] && uv cache clean
+RUN uv pip install --prerelease=allow .[core,gcp,dataflow] && uv cache clean
 COPY . .
 
 # Dataflow workers can't start properly if the entrypoint is not set
@@ -105,7 +105,7 @@ RUN curl -o cuda-keyring_1.1-1_all.deb https://developer.download.nvidia.com/com
     dpkg -i cuda-keyring_1.1-1_all.deb && \
     apt-get update && apt-get install -y cuda-libraries-dev-12-8 ibverbs-utils && \
     apt clean -y
-RUN uv pip install .[core,gpu] && uv cache clean
+RUN uv pip install --prerelease=allow .[core,gpu] && uv cache clean
 COPY . .
 
 ################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN pip install --upgrade pip && pip install uv flit && pip cache purge
 FROM base AS ci
 
 # TODO(markblee): Remove gcp,vertexai_tensorboard from CI.
-RUN uv pip install --prerelease=allow .[core,dev,grain,gcp,vertexai_tensorboard,open_api] && uv cache clean
+RUN uv pip install .[core,dev,grain,gcp,vertexai_tensorboard,open_api] && uv cache clean
 COPY . .
 
 # Defaults to an empty string, i.e. run pytest against all files.
@@ -58,7 +58,7 @@ FROM base AS bastion
 # TODO(markblee): Consider copying large directories separately, to cache more aggressively.
 # TODO(markblee): Is there a way to skip the "production" deps?
 COPY . /root/
-RUN uv pip install --prerelease=allow .[core,gcp,vertexai_tensorboard] && uv cache clean
+RUN uv pip install .[core,gcp,vertexai_tensorboard] && uv cache clean
 
 ################################################################################
 # Dataflow container spec.                                                     #
@@ -69,7 +69,7 @@ FROM base AS dataflow
 # Beam workers default to creating a new virtual environment on startup. Instead, we want them to
 # pickup the venv setup above. An alternative is to install into the global environment.
 ENV RUN_PYTHON_SDK_IN_DEFAULT_ENVIRONMENT=1
-RUN uv pip install --prerelease=allow .[core,gcp,dataflow] && uv cache clean
+RUN uv pip install .[core,gcp,dataflow] && uv cache clean
 COPY . .
 
 # Dataflow workers can't start properly if the entrypoint is not set
@@ -105,7 +105,7 @@ RUN curl -o cuda-keyring_1.1-1_all.deb https://developer.download.nvidia.com/com
     dpkg -i cuda-keyring_1.1-1_all.deb && \
     apt-get update && apt-get install -y cuda-libraries-dev-12-8 ibverbs-utils && \
     apt clean -y
-RUN uv pip install --prerelease=allow .[core,gpu] && uv cache clean
+RUN uv pip install .[core,gpu] && uv cache clean
 COPY . .
 
 ################################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ core = [
     "portpicker",
     "pyarrow>=20.0.0,<21.0.0",  # Pin to v20.x to avoid PyExtensionType -> ExtensionType breaking change in v21
     "protobuf>=3.20.3",
-    "tensorboard-plugin-profile==2.15.1",
+    "tensorboard-plugin-profile==2.19.9",
     # This has both x86 and arm64 wheels. Underneath the hood it uses tensorflow-macos since 2.13.
     "tensorflow==2.17.1",
     "tensorflow-datasets>=4.9.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ core = [
     "portpicker",
     "pyarrow>=20.0.0,<21.0.0",  # Pin to v20.x to avoid PyExtensionType -> ExtensionType breaking change in v21
     "protobuf>=3.20.3",
-    "tensorboard-plugin-profile==2.19.9",
+    "tbp-nightly==2.21.2a20250717",
     # This has both x86 and arm64 wheels. Underneath the hood it uses tensorflow-macos since 2.13.
     "tensorflow==2.17.1",
     "tensorflow-datasets>=4.9.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ core = [
     "portpicker",
     "pyarrow>=20.0.0,<21.0.0",  # Pin to v20.x to avoid PyExtensionType -> ExtensionType breaking change in v21
     "protobuf>=3.20.3",
-    "tbp-nightly==2.21.2a20250717",
+    "tensorboard-plugin-profile==2.20.2a0",
     # This has both x86 and arm64 wheels. Underneath the hood it uses tensorflow-macos since 2.13.
     "tensorflow==2.17.1",
     "tensorflow-datasets>=4.9.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ core = [
     "portpicker",
     "pyarrow>=20.0.0,<21.0.0",  # Pin to v20.x to avoid PyExtensionType -> ExtensionType breaking change in v21
     "protobuf>=3.20.3",
-    "tensorboard-plugin-profile==2.20.2a0",
+    "tensorboard-plugin-profile==2.20.4",
     # This has both x86 and arm64 wheels. Underneath the hood it uses tensorflow-macos since 2.13.
     "tensorflow==2.17.1",
     "tensorflow-datasets>=4.9.2",


### PR DESCRIPTION
Upgrade the Tensorboard's profile plugin to take advantage of Roofline and Framework Ops stats views that come with the new version.

Tested the new version:
```
> pip freeze | grep tensorboard_plugin_profile
tensorboard_plugin_profile==2.20.4

> tensorboard serve --logdir ./test-profile
```

## Roofline view
<img width="2287" height="1200" alt="roofline-graph-1" src="https://github.com/user-attachments/assets/001e3d1d-3f59-4596-b754-c0cb50da1d39" />


## Framework Ops stats view
<img width="2299" height="1205" alt="framework-ops-stats" src="https://github.com/user-attachments/assets/758f28b4-1bcf-46f3-a86c-2fa8eddabab4" />

