### PR TITLE
[Blackwell] Fix GPU Attention Test: test_sliding_window_mask

### DIFF
--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -271,7 +271,7 @@ def test_sliding_window_mask(
 
     cfg = dict(
         softmax_scale=q.shape[-1] ** -0.5,
-        interpret=jax.default_backend() == "cpu"
+        interpret=jax.default_backend() == "cpu",
     )
 
     # Override B200 block size for Pallas kernels only

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -274,7 +274,8 @@ def test_sliding_window_mask(
         interpret=jax.default_backend() == "cpu",
     )
 
-    # Override B200 block size for Pallas kernels only
+    # The memory layout of B200 is different than previous GPU generations
+    # and requires a smaller block size to work with Pallas kernels
     if jax.default_backend() == "gpu" and test_cls is PallasGPUFlashAttention:
         if "NVIDIA B200" in jax.devices("gpu")[0].device_kind:
             cfg["gpu_block_size"] = 64

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -271,8 +271,14 @@ def test_sliding_window_mask(
 
     cfg = dict(
         softmax_scale=q.shape[-1] ** -0.5,
-        interpret=jax.default_backend() == "cpu",
+        interpret=jax.default_backend() == "cpu"
     )
+
+    # Override B200 block size for Pallas kernels only
+    if jax.default_backend() == "gpu" and test_cls is PallasGPUFlashAttention:
+        if "NVIDIA B200" in jax.devices("gpu")[0].device_kind:
+            cfg['gpu_block_size'] = 64
+
     test_fn = test_cls.default_config().set(**cfg).instantiate()
     input_batch = dict(query=q, key=k, value=v, bias=bias, logit_sink=None)
     if test_cls is CuDNNGPUFlashAttention and use_segment_ids:

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -277,7 +277,7 @@ def test_sliding_window_mask(
     # Override B200 block size for Pallas kernels only
     if jax.default_backend() == "gpu" and test_cls is PallasGPUFlashAttention:
         if "NVIDIA B200" in jax.devices("gpu")[0].device_kind:
-            cfg['gpu_block_size'] = 64
+            cfg["gpu_block_size"] = 64
 
     test_fn = test_cls.default_config().set(**cfg).instantiate()
     input_batch = dict(query=q, key=k, value=v, bias=bias, logit_sink=None)


### PR DESCRIPTION
This PR adds the required `gpu_block_size` override required for Pallas kernels on the B200 platform. This fix is already present in `gpu_attention_test.py` for the test `test_triton_again_xla_ref`.