### PR TITLE
Retire remat_in_scan in repeat layer.

### DIFF
--- a/axlearn/common/repeat.py
+++ b/axlearn/common/repeat.py
@@ -67,7 +67,6 @@ from axlearn.common.config import (
     Required,
     config_class,
     config_for_function,
-    maybe_instantiate,
 )
 from axlearn.common.module import Module, child_context, new_output_collection, scan_in_context
 from axlearn.common.utils import (
@@ -109,12 +108,6 @@ class Repeat(BaseLayer):
         # if the loop is competely unrolled or left completely rolled.
         # If None, defaults to 1 (same as jax.lax.scan's default value).
         unroll: Optional[Union[bool, int]] = None
-        # remat: Whether to apply `jax.checkpoint` to the scanned function for memory-efficient
-        # training. If True, wraps the scan body function with `jax.checkpoint` to trade
-        # increased compute for reduced memory usage by recomputing intermediate activations
-        # during backward pass.
-        # The default is None for backward compatibility, but it’s recommended to set it to True.
-        remat_in_scan: Optional[bool] = None
 
     def __init__(self, cfg: Config, *, parent: Optional[Module]):
         super().__init__(cfg, parent=parent)
@@ -210,15 +203,6 @@ class Repeat(BaseLayer):
                 initializer=cfg.num_layers,
             )
 
-            if cfg.remat_in_scan:
-                remat_kwargs = dict(
-                    prevent_cse=False,
-                    policy=maybe_instantiate(cfg.remat_spec.policy)
-                    if cfg.remat_spec is not None
-                    else None,
-                )
-            else:
-                remat_kwargs = None
             carry, ys = scan_in_context(
                 fn,
                 carry=carry,
@@ -230,7 +214,6 @@ class Repeat(BaseLayer):
                 drop_output=self._drop_output,
                 child_name_prefix="layer",
                 unroll=cfg.unroll if cfg.unroll is not None else 1,
-                remat_kwargs=remat_kwargs,
             )
 
         self.get_invocation_context().output_collection.update(layer_output_collection)

--- a/axlearn/common/repeat_test.py
+++ b/axlearn/common/repeat_test.py
@@ -152,7 +152,6 @@ class RepeatTest(TestCase):
 
     @parameterized.product(
         dtype=(jnp.float32, jnp.bfloat16),
-        remat_in_scan=(False, True),
         remat_spec=(
             None,
             RematSpec(prevent_cse=False),
@@ -162,7 +161,7 @@ class RepeatTest(TestCase):
         num_layers_total=(4, 6),
         unroll=(True, False, 1, 2),
     )
-    def test_repeat(self, dtype, remat_in_scan, remat_spec, drop_output, num_layers_total, unroll):
+    def test_repeat(self, dtype, remat_spec, drop_output, num_layers_total, unroll):
         batch_size, num_layers = 14, 4
         cfg = TestEnsemble.default_config().set(
             name="test", num_layers=num_layers_total, dtype=dtype
@@ -171,7 +170,6 @@ class RepeatTest(TestCase):
             remat_spec=remat_spec,
             drop_output=drop_output,
             unroll=unroll,
-            remat_in_scan=remat_in_scan,
         )
         layer: TestEnsemble = cfg.instantiate(parent=None)
         self.assertEqual(
@@ -354,14 +352,13 @@ class RepeatTest(TestCase):
 
     @parameterized.product(
         dtype=[jnp.float32, jnp.bfloat16],
-        remat_in_scan=(False, True),
         remat_spec=(
             None,
             RematSpec(prevent_cse=False),
             RematSpec(policy=jax.checkpoint_policies.everything_saveable),
         ),
     )
-    def test_shared_module(self, dtype, remat_in_scan, remat_spec):
+    def test_shared_module(self, dtype, remat_spec):
         """Test repeat with shared modules."""
         batch_size, num_layers = 14, 4
 
@@ -376,7 +373,6 @@ class RepeatTest(TestCase):
                         remat_spec=remat_spec,
                     ),
                     num_layers=num_layers,
-                    remat_in_scan=remat_in_scan,
                 ),
                 # Test nested repeat to a shared module.
                 nested=ParentLayer.default_config().set(


### PR DESCRIPTION
`remat_in_scan` is redundant because it can be fully replaced by `BaseLayer.remat_spec`.

For example, in `RepeatedTransformerLayer`, `remat_in_scan` is used in the form `scan(remat(layer))`. But if `layer.remat_spec` is already defined, then `layer.call` ends up applying `remat` redundantly. Even if we retire `remat_in_scan`, the same behavior can be fully replicated using `layer.remat_spec`.
Therefore, we are retiring `remat_in_scan`.