### PR TITLE
Sliding window KV cache supports the flash attention path via standard attention fallback.

### DIFF
--- a/axlearn/common/flash_attention/gpu_attention.py
+++ b/axlearn/common/flash_attention/gpu_attention.py
@@ -66,6 +66,8 @@ from axlearn.common.flash_attention.common import (
     repeat_kv_heads,
 )
 from axlearn.common.flash_attention.remat import FLASH_ATTN_RESIDUAL_NAME
+from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
+from axlearn.common.kv_cache.kv_cache import KVCache
 from axlearn.common.layers import get_dropout_mask
 from axlearn.common.utils import Nested, Tensor
 
@@ -795,25 +797,28 @@ class CuDNNGPUFlashAttention(BaseFlashAttention):
     def is_supported(
         self,
         input_batch: Nested[Tensor | BaseAttentionBias],
+        kv_cache_type: Optional[type[BaseKVCache]],
     ) -> bool:
         """See `BaseFlashAttention.is_supported`."""
-        if not super().is_supported(
-            input_batch=input_batch,
-        ):
+        if not super().is_supported(input_batch=input_batch, kv_cache_type=kv_cache_type):
             return False
 
+        self._kv_cache_type = kv_cache_type
         query: Tensor = input_batch["query"]
         key: Tensor = input_batch["key"]
-        if self.cfg.is_decoding:
+        if kv_cache_type is None:
+            # cuDNN has no concept of block size. It only requires the length of query and
+            # key/value to be even.
+            if not self._check_block_size(input_batch, block_size=2):
+                return False
+        if kv_cache_type == KVCache:
             if query.shape[1] > 1:
                 return self._log_unsupported("multi-step decoding is not supported.")
             if not key.shape[1] % 2 == 0:
                 return self._log_unsupported(f"key sequence length {key.shape[1]} is not even.")
         else:
-            # cuDNN has no concept of block size. It only requires the length of query and
-            # key/value to be even.
-            if not self._check_block_size(input_batch, block_size=2):
-                return False
+            return self._log_unsupported(f"{kv_cache_type=}")
+
         if query.dtype not in (jnp.float16, jnp.bfloat16):
             return self._log_unsupported(
                 f"{query.dtype=} is not supported. Only supports float16 and bfloat16."
@@ -829,7 +834,7 @@ class CuDNNGPUFlashAttention(BaseFlashAttention):
         bias: BaseAttentionBias = input_batch["bias"]
         _, sliding, explicit_bias = split(bias, CausalAttentionBias, SlidingWindowAttentionBias)
         if sliding.has_value() and not self._allow_explicit_bias:
-            if self.cfg.is_decoding:
+            if kv_cache_type == KVCache:
                 return self._log_unsupported(
                     "cuDNN doesn't support sliding window in decoding "
                     "without folding it into explicit bias."
@@ -874,7 +879,19 @@ class CuDNNGPUFlashAttention(BaseFlashAttention):
         )
         # TODO(hanzhi-zhou): cuDNN decoding is only for testing. Enable in production once we
         # upgrade cuDNN frontend to enable lean attention.
-        if self.cfg.is_decoding:
+        if self._kv_cache_type is None:
+            causal, sliding, explicit_bias = split(
+                bias, CausalAttentionBias, SlidingWindowAttentionBias
+            )
+            mask_type = MaskType.CAUSAL if causal.has_value() else MaskType.NO_MASK
+            if sliding.has_value():
+                if self.cfg.dropout_rate != 0.0 or explicit_bias.has_value():
+                    explicit_bias += sliding
+                else:
+                    args["sliding_window_length"] = sliding.sliding_window_size + 1
+                    # When using cuDNN sliding window, mask must be set to CAUSAL.
+                    mask_type = MaskType.CAUSAL
+        elif self._kv_cache_type == KVCache:
             # Decoding needs PADDING mask to compute attention only up to `kv_seqlen`.
             mask_type = MaskType.PADDING
             mask, explicit_bias = split(bias, MaskFnAttentionBias)
@@ -889,17 +906,7 @@ class CuDNNGPUFlashAttention(BaseFlashAttention):
                 if mask.has_value():
                     explicit_bias += mask
         else:
-            causal, sliding, explicit_bias = split(
-                bias, CausalAttentionBias, SlidingWindowAttentionBias
-            )
-            mask_type = MaskType.CAUSAL if causal.has_value() else MaskType.NO_MASK
-            if sliding.has_value():
-                if self.cfg.dropout_rate != 0.0 or explicit_bias.has_value():
-                    explicit_bias += sliding
-                else:
-                    args["sliding_window_length"] = sliding.sliding_window_size + 1
-                    # When using cuDNN sliding window, mask must be set to CAUSAL.
-                    mask_type = MaskType.CAUSAL
+            return self._log_unsupported(f"{self._kv_cache_type=}")
         # cuDNN requires bias to have the same dtype as qkv.
         tensor_bias = explicit_bias.astype(query.dtype).value()
         # TODO(kelvin-zou): Add support for segment IDs.
@@ -925,11 +932,10 @@ class PallasGPUFlashAttention(BaseFlashAttention):
     def is_supported(
         self,
         input_batch: Nested[Tensor | BaseAttentionBias],
+        kv_cache_type: Optional[type[BaseKVCache]],
     ) -> bool:
         """See `BaseFlashAttention.is_supported`."""
-        if not super().is_supported(
-            input_batch=input_batch,
-        ):
+        if not super().is_supported(input_batch=input_batch, kv_cache_type=kv_cache_type):
             return False
         block_size = self.cfg.gpu_block_size
         query: Tensor = input_batch["query"]

--- a/axlearn/common/flash_attention/gpu_attention_test.py
+++ b/axlearn/common/flash_attention/gpu_attention_test.py
@@ -162,7 +162,7 @@ def test_triton_fwd_only_against_ref(
     input_batch = dict(
         query=q, key=k, value=v, prng_key=jax.random.PRNGKey(43), bias=bias, logit_sink=None
     )
-    chex.assert_equal(test_fn.is_supported(input_batch), True)
+    chex.assert_equal(test_fn.is_supported(input_batch, kv_cache_type=None), True)
     o = test_fn(input_batch)
     o_ref = ref_fn(input_batch)
 
@@ -226,7 +226,7 @@ def test_triton_against_xla_ref(
     test_fn = PallasGPUFlashAttention.default_config().set(**cfg).instantiate()
     ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
     input_batch = dict(query=q, key=k, value=v, bias=bias, logit_sink=None)
-    chex.assert_equal(test_fn.is_supported(input_batch), True)
+    chex.assert_equal(test_fn.is_supported(input_batch, kv_cache_type=None), True)
 
     def forward_tol_fn(backend, dtype):
         del dtype
@@ -276,9 +276,9 @@ def test_sliding_window_mask(
     test_fn = test_cls.default_config().set(**cfg).instantiate()
     input_batch = dict(query=q, key=k, value=v, bias=bias, logit_sink=None)
     if test_cls is CuDNNGPUFlashAttention and use_segment_ids:
-        chex.assert_equal(test_fn.is_supported(input_batch), False)
+        chex.assert_equal(test_fn.is_supported(input_batch, kv_cache_type=None), False)
         test_fn = CuDNNGPUFlashAttentionWithExplicitBias.default_config().set(**cfg).instantiate()
-    chex.assert_equal(test_fn.is_supported(input_batch), True)
+    chex.assert_equal(test_fn.is_supported(input_batch, kv_cache_type=None), True)
     ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
     _test_forward_and_backward(q, k, v, bias, ref_fn=ref_fn, test_fn=test_fn)
 
@@ -324,7 +324,7 @@ def test_cudnn_against_triton_ref(
     # Compare outputs.
     test_fn = CuDNNGPUFlashAttention.default_config().set(**cfg).instantiate()
     input_batch = dict(query=q, key=k, value=v, bias=bias, logit_sink=None)
-    chex.assert_equal(test_fn.is_supported(input_batch), True)
+    chex.assert_equal(test_fn.is_supported(input_batch, kv_cache_type=None), True)
     ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
 
     def forward_tol_fn(backend, dtype):
@@ -414,7 +414,7 @@ def test_cudnn_dropout_against_xla_dropout(
     k = jax.random.normal(k2, qkv_shape, dtype=dtype)
     v = jax.random.normal(k3, qkv_shape, dtype=dtype)
     input_batch = dict(query=q, key=k, value=v, bias=bias, logit_sink=None)
-    chex.assert_equal(test_fn.is_supported(input_batch), True)
+    chex.assert_equal(test_fn.is_supported(input_batch, kv_cache_type=None), True)
 
     ref_fn = functools.partial(
         ref_fn,
@@ -465,7 +465,7 @@ def test_cudnn_seqlen_head_support(
     test_fn = CuDNNGPUFlashAttention.default_config().set(**cfg).instantiate()
     ref_fn = ReferenceMHA.default_config().set(**cfg).instantiate()
     input_batch = dict(query=q, key=k, value=v, bias=bias, logit_sink=None)
-    chex.assert_equal(test_fn.is_supported(input_batch), True)
+    chex.assert_equal(test_fn.is_supported(input_batch, kv_cache_type=None), True)
 
     _test_forward_and_backward(
         q, k, v, bias, ref_fn=ref_fn, test_fn=test_fn, forward_tol_fn=_cudnn_xla_forward_tol_fn

--- a/axlearn/common/flash_attention/gpu_decoding.py
+++ b/axlearn/common/flash_attention/gpu_decoding.py
@@ -59,6 +59,8 @@ from axlearn.common.attention_bias import (
     split,
 )
 from axlearn.common.flash_attention.common import BaseSingleStepDecoding, get_gpu_dot_precision
+from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
+from axlearn.common.kv_cache.kv_cache import KVCache
 from axlearn.common.utils import Nested, Tensor
 
 
@@ -278,6 +280,18 @@ def _decode_attn_unbatched(
 
 class GPUDecoding(BaseSingleStepDecoding):
     """Implements GPU FlashDecoding with GQA support."""
+
+    def is_supported(
+        self,
+        input_batch: Nested[Tensor | BaseAttentionBias],
+        kv_cache_type: Optional[type[BaseKVCache]],
+    ) -> bool:
+        """See `BaseSingleStepDecoding.is_supported`."""
+        if not super().is_supported(input_batch, kv_cache_type=kv_cache_type):
+            return False
+        if kv_cache_type != KVCache:
+            return self._log_unsupported(f"{kv_cache_type=}")
+        return True
 
     @functools.partial(jax.jit, static_argnames=["self"])
     def __call__(

--- a/axlearn/common/flash_attention/gpu_paged_attention.py
+++ b/axlearn/common/flash_attention/gpu_paged_attention.py
@@ -31,6 +31,7 @@ from axlearn.common.attention_bias import (
 )
 from axlearn.common.flash_attention.common import BasePagedAttention, get_gpu_dot_precision
 from axlearn.common.flash_attention.gpu_decoding import _get_sm_count as get_sm_count
+from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
 from axlearn.common.utils import Nested, Tensor
 
 
@@ -301,9 +302,10 @@ class GPUPagedAttention(BasePagedAttention):
     def is_supported(
         self,
         input_batch: Nested[Tensor | BaseAttentionBias],
+        kv_cache_type: Optional[type[BaseKVCache]],
     ) -> bool:
         """See `BasePagedAttention.is_supported`."""
-        if not super().is_supported(input_batch):
+        if not super().is_supported(input_batch, kv_cache_type=kv_cache_type):
             return False
         key: Tensor = input_batch["key"]
         if not self._check_block_size(input_batch, block_size=self.cfg.gpu_block_size):

--- a/axlearn/common/flash_attention/neuron_attention.py
+++ b/axlearn/common/flash_attention/neuron_attention.py
@@ -17,6 +17,7 @@ from neuronxcc.nki.kernels.attention import flash_attn_bwd, flash_fwd
 
 from axlearn.common.attention_bias import BaseAttentionBias, CausalAttentionBias, split
 from axlearn.common.flash_attention.common import BaseFlashAttention, repeat_kv_heads
+from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
 from axlearn.common.utils import Nested
 
 # pytype: enable=import-error
@@ -227,13 +228,12 @@ class NeuronFlashAttention(BaseFlashAttention):
     def is_supported(
         self,
         input_batch: Nested[Tensor | BaseAttentionBias],
+        kv_cache_type: Optional[type[BaseKVCache]],
     ) -> bool:
         """See `BaseFlashAttention.is_supported`."""
         # TODO(hanzhi-zhou): neuron may error out for unsupported sequence length and head size.
         # Should we add checks for them and fallback to XLA?
-        if not super().is_supported(
-            input_batch=input_batch,
-        ):
+        if not super().is_supported(input_batch=input_batch, kv_cache_type=kv_cache_type):
             return False
         if self.cfg.dropout_rate != 0.0:
             return self._log_unsupported("dropout is not supported.")

--- a/axlearn/common/flash_attention/tpu_attention.py
+++ b/axlearn/common/flash_attention/tpu_attention.py
@@ -46,6 +46,7 @@ from axlearn.common.flash_attention.common import (
     repeat_kv_heads,
 )
 from axlearn.common.flash_attention.remat import FLASH_ATTN_RESIDUAL_NAME
+from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
 from axlearn.common.utils import Nested, Tensor
 
 MaskFnOrZero = MaskFnAttentionBias | ZeroAttentionBias
@@ -71,7 +72,7 @@ def _to_splash_mask(
 
     # Because mask.mask() may use jnp ops. e.g. jnp.logical_and.
     with jax.ensure_compile_time_eval():
-        # This code is reached only when `is_decoding == False` (i.e., forward and prefill) and
+        # This code is reached only when `kv_cache_type=None` (i.e., forward and prefill) and
         # `target_len == source_len` (i.e., self-attention) (see `check_tpu_splash_attention`).
         # `target_positions` and `source_positions` are always in the range [0, seq_len].
         target_positions = np.arange(mask_shape[0])[None, :, None]
@@ -863,11 +864,10 @@ class TPUFlashAttention(BaseFlashAttention):
     def is_supported(
         self,
         input_batch: Nested[Tensor | BaseAttentionBias],
+        kv_cache_type: Optional[type[BaseKVCache]],
     ) -> bool:
         """See `BaseFlashAttention.is_supported`."""
-        if not super().is_supported(
-            input_batch=input_batch,
-        ):
+        if not super().is_supported(input_batch=input_batch, kv_cache_type=kv_cache_type):
             return False
         block_size = self.cfg.tpu_block_size
         if not self._check_block_size(input_batch=input_batch, block_size=block_size):
@@ -896,9 +896,10 @@ class TPUSplashAttention(TPUFlashAttention):
     def is_supported(
         self,
         input_batch: Nested[Tensor | BaseAttentionBias],
+        kv_cache_type: Optional[type[BaseKVCache]],
     ) -> bool:
         """See `BaseFlashAttention.is_supported`."""
-        if not super().is_supported(input_batch):
+        if not super().is_supported(input_batch, kv_cache_type=kv_cache_type):
             return False
         bias: BaseAttentionBias = input_batch["bias"]
         _, _, explicit_bias = split(bias, MaskFnAttentionBias, SegmentIdAttentionBias)
@@ -1030,9 +1031,10 @@ class LegacyTPUFlashAttention(TPUFlashAttention):
     def is_supported(
         self,
         input_batch: Nested[Tensor | BaseAttentionBias],
+        kv_cache_type: Optional[type[BaseKVCache]],
     ) -> bool:
         """See `BaseFlashAttention.is_supported`."""
-        if not super().is_supported(input_batch):
+        if not super().is_supported(input_batch, kv_cache_type=kv_cache_type):
             return False
         query: Tensor = input_batch["query"]
         key: Tensor = input_batch["key"]

--- a/axlearn/common/flash_attention/tpu_attention_test.py
+++ b/axlearn/common/flash_attention/tpu_attention_test.py
@@ -199,7 +199,7 @@ class TestFlashAttention(TestCase):
         with jax.default_matmul_precision(matmul_precision) if matmul_precision else nullcontext():
             err = matmul_precision == "highest" and q_dtype == jnp.bfloat16
             with self.assertRaises(ValueError) if err else nullcontext():
-                is_supported = fn.is_supported(input_batch=input_batch)
+                is_supported = fn.is_supported(input_batch=input_batch, kv_cache_type=None)
             if err:
                 return
 
@@ -207,7 +207,7 @@ class TestFlashAttention(TestCase):
                 # Check splash attention is used when it should be.
                 self.assertEqual(fallback_to_legacy, True)
                 fn = tpu_attention.LegacyTPUFlashAttention.default_config().set(**cfg).instantiate()
-                legacy_supported = fn.is_supported(input_batch=input_batch)
+                legacy_supported = fn.is_supported(input_batch=input_batch, kv_cache_type=None)
                 if q_dtype != kv_dtype:
                     self.assertEqual(legacy_supported, False)
                     return
@@ -292,7 +292,7 @@ class TestFlashAttention(TestCase):
         )
 
         # Check if the kernel supports this configuration
-        is_supported = fn.is_supported(input_batch=input_batch)
+        is_supported = fn.is_supported(input_batch=input_batch, kv_cache_type=None)
         if not is_supported:
             pytest.skip(reason="Configuration not supported by TPUSplashAttention")
 
@@ -353,7 +353,7 @@ class TestFlashAttention(TestCase):
 
         # This should raise a ValueError due to shape mismatch
         with self.assertRaises(ValueError):
-            fn.is_supported(input_batch=input_batch)
+            fn.is_supported(input_batch=input_batch, kv_cache_type=None)
 
 
 if __name__ == "__main__":

--- a/axlearn/common/flash_attention/tpu_decoding.py
+++ b/axlearn/common/flash_attention/tpu_decoding.py
@@ -46,6 +46,8 @@ from axlearn.common.flash_attention.common import (
     get_tpu_dot_precision,
     query_iterator_indices,
 )
+from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
+from axlearn.common.kv_cache.kv_cache import KVCache
 from axlearn.common.utils import Nested, Tensor
 
 
@@ -144,12 +146,14 @@ class TPUDecoding(BaseSingleStepDecoding):
     def is_supported(
         self,
         input_batch: Nested[Tensor | BaseAttentionBias],
+        kv_cache_type: Optional[type[BaseKVCache]],
     ) -> bool:
         """See `BaseFlashAttention.is_supported`."""
-        if not super().is_supported(
-            input_batch=input_batch,
-        ):
+        if not super().is_supported(input_batch=input_batch, kv_cache_type=kv_cache_type):
             return False
+
+        if kv_cache_type != KVCache:
+            return self._log_unsupported(f"{kv_cache_type=}")
 
         block_size = self.cfg.tpu_block_size
         key: Tensor = input_batch["key"]

--- a/axlearn/common/flash_attention/tpu_paged_attention.py
+++ b/axlearn/common/flash_attention/tpu_paged_attention.py
@@ -29,6 +29,7 @@ from axlearn.common.attention_bias import (
     split,
 )
 from axlearn.common.flash_attention.common import BasePagedAttention
+from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
 from axlearn.common.utils import Nested, Tensor
 
 
@@ -425,9 +426,10 @@ class TPUPagedAttention(BasePagedAttention):
     def is_supported(
         self,
         input_batch: Nested[Tensor | BaseAttentionBias],
+        kv_cache_type: Optional[type[BaseKVCache]],
     ) -> bool:
         """See `BasePagedAttention.is_supported`."""
-        if not super().is_supported(input_batch=input_batch):
+        if not super().is_supported(input_batch=input_batch, kv_cache_type=kv_cache_type):
             return False
 
         key: Tensor = input_batch["key"]

--- a/axlearn/common/flash_attention/utils.py
+++ b/axlearn/common/flash_attention/utils.py
@@ -17,6 +17,8 @@ from axlearn.common.flash_attention.gpu_paged_attention import GPUPagedAttention
 from axlearn.common.flash_attention.tpu_attention import LegacyTPUFlashAttention, TPUSplashAttention
 from axlearn.common.flash_attention.tpu_decoding import TPUDecoding
 from axlearn.common.flash_attention.tpu_paged_attention import TPUPagedAttention
+from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
+from axlearn.common.kv_cache.paged_kv_cache import PagedKVCache
 from axlearn.common.utils import Tensor
 
 BACKENDS = dict(
@@ -52,7 +54,7 @@ def flash_attention_implementation(
     bias: BaseAttentionBias,
     logit_sink: Optional[Tensor] = None,
     softmax_scale: float = 1.0,
-    is_decoding: bool = False,
+    kv_cache_type: Optional[type[BaseKVCache]] = None,
     tpu_block_size: int = 512,
     gpu_block_size: int = 128,
     dropout_rate: Optional[float] = 0.0,
@@ -80,7 +82,7 @@ def flash_attention_implementation(
         bias: Attention bias to apply.
         logit_sink: An optional Tensor of shape [num_heads].
         softmax_scale: A scalar value applied to the logits before softmax.
-        is_decoding: Whether it is in decoding.
+        kv_cache_type: KV cache type. If None, it is on a forward pass.
         tpu_block_size: The size of the computation-block unit for 'tpu' backend.
             A multiple of 128, and should be less than the target sequence length.
             Smaller values are more memory efficient but less compute efficient.
@@ -113,11 +115,10 @@ def flash_attention_implementation(
         BACKENDS["neuron"] = [NeuronFlashAttention]
 
     attn_configs = BACKENDS.get(backend, [])
-    if page_tables is not None and is_decoding:
+    if kv_cache_type == PagedKVCache:
         attn_configs = PAGED_ATTN_BACKENDS.get(backend, [])
 
     common_cfg = dict(
-        is_decoding=is_decoding,
         dropout_rate=dropout_rate,
         interpret=_interpret(backend),
         softmax_scale=softmax_scale,
@@ -134,9 +135,7 @@ def flash_attention_implementation(
     )
     for cfg in attn_configs:
         attn_fn = cfg.default_config().set(**common_cfg).instantiate()
-        is_supported = attn_fn.is_supported(
-            input_batch=input_batch,
-        )
+        is_supported = attn_fn.is_supported(input_batch=input_batch, kv_cache_type=kv_cache_type)
         if is_supported:
             return attn_fn
     # Fall back to standard attention if no backend kernels are supported for the given


### PR DESCRIPTION
There are two ways to support the flash attention path with sliding window KV cache:
1. Using standard attention fallback [1], or
2. Modifying the TPU/GPU flash decoding to support sliding window KV cache.

[1] https://github.com/apple/axlearn/blob/bf6f65a7b53510bef0a621917f9b7d9f58bf1964/axlearn/common/flash_attention/layer.py#L199-L201

In this PR, I chose the first approach. I judged that the alternative does not provide significant speed gain relative to the added code complexity.

Flash attention gains speed primarily by eliminating O(T²) HBM read/write bottlenecks and skipping unnecessary blocks.

In the decoding path, since `q_len = 1`, there is no O(T²) HBM read/write bottleneck to begin with. Thus, most of the speed benefit comes from skipping unnecessary blocks. According to benchmarks [2], flash attention is about 5–20% faster than standard attention fallback in this case: [2] https://github.com/apple/axlearn/blob/main/axlearn/common/flash_attention/gpu_decoding.py#L34

This was measured in scenarios where the causal mask is used together with KVCache — where the KVCache holds up to `max_seq_len`, and the speed gain comes from skipping KV cache beyond the current time step.

However, in SlidingWindowKVCache, there is no cache to skip, since only the valid window is stored. Therefore, in the decoding path, there is neither an O(T²) HBM bottleneck nor blocks to skip, meaning there is no reason to use flash attention. The additional code complexity required to support flash attention in this case does not justify the minimal speed benefit, so this code path falls back to standard attention.

Moreover, when PagedKVCache is used in serving in the future, it will handle both local and global attention. Thus, there is no need to implement flash attention specifically for SlidingWindowKVCache.

**Benchmark**
I compared Flash Attention decoding and Standard Attention decoding on TPU v5p, checking both 16k (global) and 4k (local) KV cache configurations. On TPU, there are no benchmark cases where Flash decoding is faster than Standard decoding, in
[tpu_attention_benchmark.py](https://github.com/apple/axlearn/blob/main/axlearn/common/flash_attention/tpu_attention_benchmark.py).

Flash Attention decoding vs Standard Attention decoding (1-step decoding, TPU v5)

Model Size | Standard (16k) | Flash (16k) | HBM (16k) | Standard (4k) | Flash (4k) | HBM (4k)
-- | -- | -- | -- | -- | -- | --
1.2B | 0.4019 ms | 0.5910 ms | — | 0.2569 ms | 0.3755 ms | —
12.6B | 0.6049 ms | 1.1137 ms | 256.43M | 0.3214 ms | 0.6032 ms | 64.36M
29.6B | 0.2542 ms | 0.2652 ms | 640.46M | 0.1977 ms | 0.2143 ms | 160.38M
65.2B | 1.0380 ms | 1.7251 ms | 1.12G | 0.4452 ms | 0.8791 ms | 288.49M
134B | 1.1095 ms | 2.0664 ms | 1.38G | 0.4678 ms | 1.0134 ms | 352.51M
261.7B | 1.5863 ms | 2.4353 ms | 1.72G | 0.5682 ms | 1.2005 ms | 440.46M

This PR switches sliding window decoding from Flash (16k) to Standard (4k), reducing KV cache memory usage by 4× and improving speed by more than 4×.

While it's theoretically possible to modify the TPU/GPU decoding code to support sliding window KV cache as an alternative to Flash (4k), it offers no advantage over Standard (4k), so the additional effort isn't justified.

For 134B 4k case, this is profile results: Flash is 3-4 times slower.
* Standard (4k): 246us ![image](https://github.com/user-attachments/assets/8c00ec08-df84-4433-a6dc-2936aa006f20)

* Flash (4k): 800us ![image](https://github.com/user-attachments/assets/0a6d6f69-4ac3-4cbb-840a-acb40ce87f83)

**Conclusion**: Sliding window KV cache supports the flash attention path via standard attention fallback.