### PR TITLE
Add page_pool argument

### DIFF
--- a/axlearn/common/decoder.py
+++ b/axlearn/common/decoder.py
@@ -496,6 +496,7 @@ class Decoder(BaseLayer):
         cross_attention_data: Optional[Tensor] = None,
         cross_attention_logit_biases: Optional[Tensor] = None,
         cached_states: Optional[NestedTensor] = None,
+        page_pool: Optional[Nested[Tensor]] = None,
     ) -> tuple[Optional[NestedTensor], Tensor]:
         validate_contains_paths(input_batch, paths=["input_ids"])
         input_segment_ids = input_batch.get("input_segment_ids", None)
@@ -538,6 +539,7 @@ class Decoder(BaseLayer):
                 self_attention_logit_biases=self_attention_logit_biases,
                 cross_attention_data=cross_attention_data,
                 cross_attention_logit_biases=cross_attention_logit_biases,
+                page_pool=page_pool,
             )
         else:
             raise ValueError(f"Unrecognized mode {mode}.")

--- a/axlearn/common/kv_cache/base_kv_cache.py
+++ b/axlearn/common/kv_cache/base_kv_cache.py
@@ -84,6 +84,7 @@ class BaseKVCache(BaseLayer):
         v_proj: Tensor,
         key_positions: Tensor,
         live_step_len: Optional[Tensor] = None,
+        page_pool: Optional[Nested[Tensor]] = None,
     ) -> tuple[Nested[Tensor], Output]:
         """Updates the KV cache per extend step.
 
@@ -96,8 +97,9 @@ class BaseKVCache(BaseLayer):
             k_proj: A Tensor of shape [batch, step_length, num_kv_heads, per_head_dim].
             v_proj: A Tensor of shape [batch, step_length, num_kv_heads, per_head_dim].
             key_positions: An optional Tensor of shape [1|batch, step_length].
-            live_step_len: An optional Tensor of shape [batch]. Please refer to ``On live_step_len``
-                in the file docstring for details.
+            live_step_len: An optional Tensor of shape [batch]. See file-level docstring of
+                `attention.py`
+            page_pool: See file-level docstring of `attention.py`.
 
         Returns:
             A tuple (updated_state, output):

--- a/axlearn/common/kv_cache/kv_cache.py
+++ b/axlearn/common/kv_cache/kv_cache.py
@@ -38,11 +38,13 @@ class KVCache(BaseKVCache):
         v_proj: Tensor,
         key_positions: Tensor,
         live_step_len: Optional[Tensor] = None,
+        page_pool: Optional[Nested[Tensor]] = None,
     ) -> tuple[Nested[Tensor], BaseKVCache.Output]:
         # TODO(dhwang2): By returning only the valid portions of the KV (by live_step_len),
         # the attention complexity can be reduced from O(max_len²) to O(live_step_len²), especially
         # in prefill.
         # The remaining part after `live_step_len` is considered padding.
+        assert page_pool is None
         del live_step_len
         if k_proj.shape != v_proj.shape:
             raise ValueError(f"{k_proj.shape=} != {v_proj.shape=}")

--- a/axlearn/common/kv_cache/sliding_window_kv_cache.py
+++ b/axlearn/common/kv_cache/sliding_window_kv_cache.py
@@ -53,6 +53,7 @@ class SlidingWindowKVCache(BaseKVCache):
         v_proj: Tensor,
         key_positions: Tensor,
         live_step_len: Optional[Tensor] = None,
+        page_pool: Optional[Nested[Tensor]] = None,
     ) -> tuple[Nested[Tensor], BaseKVCache.Output]:
         """Updates the sliding window KV cache per extend step.
 
@@ -70,6 +71,7 @@ class SlidingWindowKVCache(BaseKVCache):
             * output: The output k_proj, v_proj, and key_positions, which are merged with
                 KV cache, resulting in a length of `cached_kv_length + step_size`.
         """
+        assert page_pool is None
         cfg = self.config
         cached_key: Tensor = cached_states["key"]
         cached_value: Tensor = cached_states["value"]

--- a/axlearn/common/module.py
+++ b/axlearn/common/module.py
@@ -1002,6 +1002,8 @@ class _Functional:
     context: InvocationContext = struct.field(pytree_node=True)
     # Whether to require that context.parent is current_context().
     require_parent: bool = struct.field(pytree_node=False)
+    # Whether to copy the argument pytrees to prevent method_fn from mutating the original.
+    copy_args_tree: bool = struct.field(pytree_node=False, default=True)
 
     def __call__(self, *args, **kwargs) -> tuple[Any, OutputCollection]:
         """Invokes method_fn in a pure functional fashion.
@@ -1024,13 +1026,14 @@ class _Functional:
         call = getattr(self.method_fn, "__qualname__", None) or getattr(self.method_fn, "__name__")
         logging.vlog(1, "functional: %s.%s (*%s, **%s)", call, self.method_fn, args, kwargs)
 
-        # Copy to prevent method_fn from mutating the original.
         # Some badly behaved tests call F() with an InvocationContext.state that contains
         # circular references.
         # This results in a cryptic error that doesn't make the root cause obvious.
         # So we raise a clearer error explicitly.
         raise_for_cycles(dict(context=self.context, args=args, kwargs=kwargs))
-        context, args, kwargs = jax.tree.map(lambda x: x, (self.context, args, kwargs))
+        context = self.context
+        if self.copy_args_tree:
+            context, args, kwargs = jax.tree.map(lambda x: x, (self.context, args, kwargs))
 
         with set_current_context(context, require_parent=self.require_parent):
             # pylint: disable-next=not-an-iterable,not-a-mapping,not-callable
@@ -1047,6 +1050,7 @@ def functional(
     method: str = "forward",
     is_training: bool,
     drop_output_collections: Sequence[str] = ("module_outputs",),
+    copy_args_tree: bool = True,
 ) -> tuple[Any, OutputCollection]:
     """Invokes <module>.<method> in a pure functional fashion.
 
@@ -1065,6 +1069,8 @@ def functional(
         is_training: Whether the invocation should run in the training mode.
         drop_output_collections: The output collection types to drop.
             Defaults to dropping all module outputs.
+        copy_args_tree: Whether to copy the `inputs` pytree to prevent method_fn from mutating the
+            original. Defaults to True.
 
     Returns:
         (method_outputs, output_collection), where
@@ -1092,7 +1098,9 @@ def functional(
         args = inputs
     method_fn = getattr(module, method)
 
-    fn = _Functional(context=context, method_fn=method_fn, require_parent=True)
+    fn = _Functional(
+        context=context, method_fn=method_fn, require_parent=True, copy_args_tree=copy_args_tree
+    )
     method_outputs, output_collection = fn(*args, **kwargs)
 
     for output_collection_type in drop_output_collections:

--- a/axlearn/common/multiway_transformer.py
+++ b/axlearn/common/multiway_transformer.py
@@ -96,6 +96,7 @@ class MultiwayTransformerLayer(BaseTransformerLayer):
         cross_attention_logit_biases: Optional[Tensor] = None,
         cached_states: Optional[NestedTensor] = None,
         return_aux: Optional[set[str]] = None,
+        page_pool: Optional[Nested[Tensor]] = None,
     ) -> tuple[Optional[Nested[Tensor]], Optional[Tensor]]:
         """Computes transformer layer outputs and self/cross-attention probabilities.
 
@@ -110,6 +111,7 @@ class MultiwayTransformerLayer(BaseTransformerLayer):
                 biases.
             cached_states: Optional NestedTensor as produced by `prefill_states`.
             return_aux: See comments on BaseTransformerLayer.forward.
+            page_pool: See file-level docstring of `attention.py`.
 
         Returns:
             An optional NestedTensor of cache states, depending on `mode`.
@@ -120,6 +122,7 @@ class MultiwayTransformerLayer(BaseTransformerLayer):
         Raises:
             ValueError: If `mode` is unsupported.
         """
+        assert page_pool is None  # Not supported.
         cfg = self.config
         if isinstance(data, Tensor):
             self.vlog(3, "transformer.input=%s", data.sum())

--- a/axlearn/common/rattention/rattention.py
+++ b/axlearn/common/rattention/rattention.py
@@ -606,6 +606,7 @@ class RAttention(FlashAttention):
         query_positions: Optional[Tensor] = None,
         cached_states: Optional[NestedTensor] = None,
         return_aux: Optional[set[str]] = None,
+        page_pool: Optional[Nested[Tensor]] = None,
     ) -> tuple[Nested[Tensor], Optional[FlashAttention.Output]]:
         """Forward function for RAttention.
 
@@ -661,6 +662,7 @@ class RAttention(FlashAttention):
                         v_proj=v_proj,
                         key_positions=query_positions,
                         live_step_len=live_step_len,
+                        page_pool=page_pool,
                     )
                     if mode == ForwardMode.EXTEND_STEP:
                         full_k_proj, full_v_proj, key_positions, _ = swa_cache_output

--- a/axlearn/common/rattention/rattention.py
+++ b/axlearn/common/rattention/rattention.py
@@ -377,8 +377,10 @@ class ResidualLinearAttention(BaseLayer):
         query: Union[Tensor, TensorSpec],
         qkv_proj: Optional[BaseQKVLinear.Output] = None,
         cached_states: Optional[NestedTensor] = None,
+        page_pool: Optional[Nested[Tensor]] = None,
     ) -> tuple[Nested[Optional[Tensor]], Tensor]:
         """Forward function for linear attention."""
+        assert page_pool is None
         # Initialize states.
         cfg = self.config
         if qkv_proj is None:
@@ -453,12 +455,14 @@ class ResidualLinearAttention(BaseLayer):
         cached_states: Nested[Tensor],
         query: Tensor,
         qkv_proj: BaseQKVLinear.Output,
+        **kwargs,
     ) -> tuple[Nested[Tensor], Tensor]:
         return self._forward_for_mode(
             mode=ForwardMode.EXTEND_STEP,
             query=query,
             qkv_proj=qkv_proj,
             cached_states=cached_states,
+            **kwargs,
         )
 
 


### PR DESCRIPTION
The motivation is that sometimes different layers need to share the same paged kv cache pool. For example, layers with varying demand for pages (e.g., sliding window and global attn layer) should share the same page pool for memory efficiency. Additionally, page updates done by different layers should be reflected in the same page pool.

This is challenging in Jax since aliased arrays become copies across the boundary of functional transformations (e.g. `vmap`, `scan`, `jit`). To solve this problem, we add a `page_pool` argument that stores the unique page pools. Each layer's cache_states now store indices that can be used to index into this page pool. This solved the aliasing problem.

However, we still need the updates from different layers to be done on the same page pool. Therefore, we update the references stored in `page_pool`. Across the boundaries of functional transformations, we first output `page_pool` as a separate output, and then we update the original `page_pool` in-place. `functional` is updated to support mutating original arguments.