### PR TITLE
Block Sparse TPU Paged Attention Kernel for Sliding Window 

### DIFF
--- a/axlearn/common/flash_attention/common.py
+++ b/axlearn/common/flash_attention/common.py
@@ -314,6 +314,12 @@ class BaseSingleStepDecoding(BaseFlashAttention):
 class BasePagedAttention(BaseSingleStepDecoding):
     """Base class for paged attention."""
 
+    @config_class
+    class Config(BaseSingleStepDecoding.Config):
+        """Configures Paged Attention."""
+
+        sparse_ratio: float = 0.8  # Whether to apply sparse mode kernel
+
     def _validate_input_batch(self, input_batch: Nested[Tensor | BaseAttentionBias]):
         super()._validate_input_batch(input_batch)
         validate_contains_paths(input_batch, paths=["page_tables"])

--- a/axlearn/common/flash_attention/tpu_attention_benchmark.py
+++ b/axlearn/common/flash_attention/tpu_attention_benchmark.py
@@ -1,6 +1,17 @@
 # Copyright © 2023 Apple Inc.
 
 """Benchmark TPU FlashAttention kernels.
+For fast running kernel, python benchmark time may not be accurate.
+Therefore, we tyically would enable jax profiler checking trace.
+Example run:
+    python tpu_attention_benchmark.py
+            --config=134b \
+            --run_reference=False \
+            --enable_trace_profiling=True \
+            --batch_size=8 \
+            --seq_len=65536 \
+            --page_size=128
+    Traced log dir can be specified with --trace-dir.
 
 Sample outputs: (v5p)
 CMD: python \
@@ -30,6 +41,7 @@ import time
 from typing import Callable, Optional
 
 import jax
+from absl import app, flags
 
 from axlearn.common.attention_bias import causal_mask
 from axlearn.common.flash_attention.common import ReferenceMHA
@@ -41,6 +53,17 @@ from axlearn.common.flash_attention.utils import flash_attention_implementation
 from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
 from axlearn.common.kv_cache.kv_cache import KVCache
 from axlearn.common.kv_cache.paged_kv_cache import PagedKVCache
+
+flags.DEFINE_boolean("enable_trace_profiling", False, "Whether to enable JAX trace profiling.")
+flags.DEFINE_string("trace_dir", "/tmp/axlearn_profiler", "Directory to save profiler traces.")
+flags.DEFINE_boolean("run_reference", True, "Whether to run the reference implementation.")
+flags.DEFINE_string("config", None, "Configuration to run benchmark.")
+flags.DEFINE_integer("batch_size", 2, "Batch size for running benchmark.")
+flags.DEFINE_integer("seq_len", 8192, "Sequence length to run benchmark.")
+flags.DEFINE_integer("page_size", None, "Page size for paged attention.")
+flags.DEFINE_integer("sliding_window_size", None, "Sliding window size for attention.")
+FLAGS = flags.FLAGS
+
 
 _BENCHMARK_CONFIGS = {
     "1.2b": dict(
@@ -69,10 +92,10 @@ _BENCHMARK_CONFIGS = {
         per_head_dim=128,
     ),
     # OOM in mha_reference.
-    # "539.5b": dict(
-    #     num_heads=140,
-    #     per_head_dim=128,
-    # ),
+    "539.5b": dict(
+        num_heads=140,
+        per_head_dim=128,
+    ),
 }
 
 
@@ -80,8 +103,12 @@ def _time_call(fn: Callable, *, num_iters: int = 5) -> float:
     """Times average execution time for fn call over num_iters after warmup."""
     fn().block_until_ready()
     tic = time.perf_counter()
+    if FLAGS.enable_trace_profiling:
+        jax.profiler.start_trace(FLAGS.trace_dir)
     for _ in range(num_iters):
         fn().block_until_ready()
+    if FLAGS.enable_trace_profiling:
+        jax.profiler.stop_trace()
     toc = time.perf_counter()
     return (toc - tic) / num_iters
 
@@ -103,7 +130,8 @@ def _benchmark(
     """Benchmarks TPU FlashAttention vs reference impl."""
     if not (kv_cache_type is None or kv_cache_type in (KVCache, PagedKVCache)):
         raise NotImplementedError(f"This benchmark doesn't support {kv_cache_type=} yet.")
-    if kv_cache_type == PagedKVCache:
+    if page_size is not None:
+        kv_cache_type = PagedKVCache
         assert page_size is not None
         q, k, v, page_tables, bias = generate_paged_attention_data(
             batch_size=batch_size,
@@ -154,39 +182,61 @@ def _benchmark(
     )
 
     input_batch = dict(query=q, key=k, value=v, bias=bias, page_tables=page_tables)
-    ref_fwd_time = _time_call(lambda: ref_mha_impl(input_batch))
+    if FLAGS.run_reference:
+        ref_mha_impl = (
+            ReferenceMHA.default_config()
+            .set(softmax_scale=softmax_scale, tpu_block_size=block_size)
+            .instantiate()
+        )
+        ref_fwd_time = _time_call(lambda: ref_mha_impl(input_batch))
+        print(f"ref_fwd: {ref_fwd_time:.4f}s")
+
     flash_fwd_time = _time_call(lambda: mha_impl(input_batch))
-    print(f"ref_fwd:{ref_fwd_time:.4f}s, flash_fwd:{flash_fwd_time:.4f}s")
+    print(f"flash_fwd:{flash_fwd_time:.4f}s")
 
     if kv_cache_type is None:
-
-        def grad_ref(float_inputs, aux_inputs):
-            full_batch = {**float_inputs, **aux_inputs}
-            return ref_mha_impl(full_batch).mean()
 
         def grad_test(float_inputs, aux_inputs):
             full_batch = {**float_inputs, **aux_inputs}
             return mha_impl(full_batch).mean()
 
+        if FLAGS.run_reference:
+
+            def grad_ref(float_inputs, aux_inputs):
+                full_batch = {**float_inputs, **aux_inputs}
+                return ref_mha_impl(full_batch).mean()
+
+            ref_grad_fn = jax.jit(jax.grad(grad_ref, argnums=0))
+            ref_bwd_time = _time_call(lambda: ref_grad_fn(float_inputs, aux_inputs)["query"])
+            print(f"ref_bwd:{ref_bwd_time:.4f}s")
+
         float_inputs = dict(query=q, key=k, value=v)
         aux_inputs = dict(bias=bias)
-        ref_grad_fn = jax.jit(jax.grad(grad_ref, argnums=0))
-        ref_bwd_time = _time_call(lambda: ref_grad_fn(float_inputs, aux_inputs)["query"])
         flash_grad_fn = jax.jit(jax.grad(grad_test, argnums=0))
         flash_bwd_time = _time_call(lambda: flash_grad_fn(float_inputs, aux_inputs)["query"])
-        print(f"ref_bwd:{ref_bwd_time:.4f}s, flash_bwd:{flash_bwd_time:.4f}s\n")
+        print(f"flash_bwd:{flash_bwd_time:.4f}s")
 
 
-if __name__ == "__main__":
+def main(_):
     assert jax.default_backend() == "tpu", "Benchmarking requires a TPU backend."
     device_kind = jax.devices()[0].device_kind
-    for name, cfg in _BENCHMARK_CONFIGS.items():
+    if FLAGS.config is not None:
+        config_list = [(FLAGS.config, _BENCHMARK_CONFIGS[FLAGS.config])]
+    else:
+        # Run Sweep without benchmarking 539.5b
+        config_list = [(k, v) for k, v in _BENCHMARK_CONFIGS.items() if k != "539.5b"]
+    for name, cfg in config_list:
         print(f"Benchmarking attention representative of {name} model layer on {device_kind}.")
         _benchmark(
-            batch_size=2,
-            seq_len=1024 * 8,
+            batch_size=FLAGS.batch_size,
+            seq_len=FLAGS.seq_len,
             block_size=4 * 128,
-            sliding_window_size=4096,
+            sliding_window_size=FLAGS.sliding_window_size,
+            page_size=FLAGS.page_size,
             kv_cache_type=KVCache,
             **cfg,
         )
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/axlearn/common/flash_attention/tpu_decoding.py
+++ b/axlearn/common/flash_attention/tpu_decoding.py
@@ -36,16 +36,10 @@ from axlearn.common.attention_bias import (
     BaseAttentionBias,
     MaskFn,
     MaskFnAttentionBias,
-    SlidingWindowAttentionBias,
     split,
 )
-from axlearn.common.flash_attention.common import (
-    BaseSingleStepDecoding,
-    build_mask,
-    build_sliding_window_mask,
-    get_tpu_dot_precision,
-    query_iterator_indices,
-)
+from axlearn.common.flash_attention.common import BaseSingleStepDecoding, get_tpu_dot_precision
+from axlearn.common.flash_attention.tpu_paged_attention_kernel import prepare_block_sparse_map
 from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
 from axlearn.common.kv_cache.kv_cache import KVCache
 from axlearn.common.utils import Nested, Tensor
@@ -202,43 +196,12 @@ class TPUDecoding(BaseSingleStepDecoding):
         v = jnp.einsum("bsnh->bnhs", value)
         bs, kv_heads, head_dim, padded_kv_seq_len = k.shape
         kv_seq_len = jnp.broadcast_to(jnp.asarray(kv_seq_len), (bs,))
-        # Computes a full block map num_kv_blocks * num_kv_blocks.
-        # Use a padding to ensure padding blocks aren't counted towards `kv_block_offset_size`.
-        padding = -1
-        with jax.ensure_compile_time_eval():
-            if mask_fn is not None:
-                mask_args = dict(
-                    q_seq_len=padded_kv_seq_len,
-                    kv_seq_len=padded_kv_seq_len,
-                    block_q=block_size,
-                    block_k=block_size,
-                )
-                if isinstance(mask, SlidingWindowAttentionBias):
-                    bool_mask = build_sliding_window_mask(
-                        **mask_args, sliding_window_size=mask.sliding_window_size
-                    )
-                else:
-                    bool_mask = build_mask(mask_fn, **mask_args)
-                offset, _ = query_iterator_indices(bool_mask, padding=padding)
-            else:
-                padded_num_kv_blocks = pl.cdiv(padded_kv_seq_len, block_size)
-                offset = lax.broadcasted_iota(
-                    jnp.int32, (padded_num_kv_blocks, padded_num_kv_blocks), 1
-                )
-
-        # Dynamically slice the rows according to the query position (which is kv_seq_len - 1).
-        kv_block_offset = offset[(kv_seq_len - 1) // block_size]
-        # Count the number of blocks with position < kv_seq_len.
-        kv_block_offset_size = jnp.count_nonzero(
-            (kv_block_offset != padding) & (kv_block_offset * block_size < kv_seq_len[:, None]),
-            axis=1,
+        kv_block_offset, kv_block_offset_size = prepare_block_sparse_map(
+            mask,
+            lengths=kv_seq_len,
+            block_size=block_size,
+            seq_len=padded_kv_seq_len,
         )
-        # Replace padding with the last valid kv block's index. See
-        # https://docs.jax.dev/en/latest/pallas/tpu/sparse.html#sparse-access-patterns-on-dense-data
-        kv_block_offset = jnp.where(
-            kv_block_offset == padding, kv_block_offset.max(axis=1, keepdims=True), kv_block_offset
-        )
-
         q = q.reshape(bs, kv_heads, -1, head_dim)
         q_seq_head = q.shape[-2]  # = q_seq_len * num_q_heads_per_kv_head
         assert q_seq_head <= 512

--- a/axlearn/common/flash_attention/tpu_paged_attention.py
+++ b/axlearn/common/flash_attention/tpu_paged_attention.py
@@ -5,30 +5,37 @@
 # Copyright 2023 The JAX Authors.
 # Licensed under the Apache License, Version 2.0 (the "License").
 
-"""Implements PagedAttention for TPU in JAX with logit bias and mask_fn support.
+"""Implements PagedAttention for TPU.
 
-This implementation is ported from
+Compared to base implementation
 https://github.com/jax-ml/jax/blob/jax-v0.6.0/jax/experimental/pallas/ops/tpu/paged_attention/paged_attention_kernel.py
+We added block-sparse kernel for long context with masking
+(particularly for sliding window attention),
+we also supports arbitrary logit bias and mask_fn.
 """
 
 import functools
-from typing import Literal, Optional, Sequence, Tuple
+from typing import Literal, Optional, Sequence
 
 import jax
 import jax.numpy as jnp
 from absl import logging
-from jax import lax
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
 from axlearn.common.attention_bias import (
-    NEG_INF,
     BaseAttentionBias,
-    MaskFn,
     MaskFnAttentionBias,
+    SlidingWindowAttentionBias,
     split,
 )
 from axlearn.common.flash_attention.common import BasePagedAttention
+from axlearn.common.flash_attention.tpu_paged_attention_kernel import (
+    _make_index_map,
+    _paged_flash_attention_kernel,
+    _paged_flash_attention_sparse_kernel,
+    prepare_block_sparse_map,
+)
 from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
 from axlearn.common.utils import Nested, Tensor
 
@@ -59,323 +66,6 @@ def _get_tpu_cores_per_chip(interpret: bool = False) -> int:
         raise
 
 
-class MultiPageAsyncCopyDescriptor:
-    """Descriptor for async copy of multiple K/V pages from HBM.
-
-    Ported from
-    https://github.com/jax-ml/jax/blob/127aa7621868cb77e552b5d1f90e4a42b09c13fa/jax/experimental/pallas/ops/tpu/paged_attention/paged_attention_kernel.py#L33
-    """
-
-    def __init__(
-        self,
-        pages_hbm_ref,
-        vmem_buffer,
-        sem,
-        page_indices,
-        page_indices_start_offset: int,
-        num_pages_to_load: int,
-        head_index: int,
-    ):
-        self._vmem_buffer = vmem_buffer
-        self._num_pages_to_load = num_pages_to_load
-        if head_index is not None:
-            self._pages_hbm_ref = pages_hbm_ref.at[head_index]
-        else:
-            self._pages_hbm_ref = pages_hbm_ref
-        self._sem = sem
-        self._page_indices = page_indices
-        self._page_indices_start_offset = page_indices_start_offset
-        self._async_copies = [self._make_async_copy(i) for i in range(self._num_pages_to_load)]
-
-    def _make_async_copy(self, i):
-        page_index = self._page_indices[self._page_indices_start_offset + i]
-        return pltpu.make_async_copy(
-            self._pages_hbm_ref.at[page_index],
-            self._vmem_buffer.at[i],
-            self._sem,
-        )
-
-    def start(self):
-        """Starts the async copies."""
-        for async_copy in self._async_copies:
-            async_copy.start()
-
-    def wait_and_get_loaded(self) -> Tensor:
-        """Wait async copies and gets the loaded buffer as a Tensor."""
-        for async_copy in self._async_copies:
-            async_copy.wait()
-        head_dim = self._vmem_buffer.shape[-1]
-        tensor = self._vmem_buffer[...].astype(jnp.float32)
-        return tensor.reshape(-1, head_dim)
-
-
-def _paged_flash_attention_kernel(
-    # inputs
-    lengths_ref,  # (batch_size,)
-    page_indices_ref,  # (batch_size * pages_per_sequence,)
-    buffer_index_ref,  # (1,)
-    init_flag_ref,  # (1,)
-    q_ref,  # (n_groups, head_dim)
-    k_pages_hbm_ref,  # (num_kv_heads, batch_size * pages_per_sequence, page_size, head_dim)
-    v_pages_hbm_ref,  # (num_kv_heads, batch_size * pages_per_sequence, page_size, head_dim)
-    bias_ref,  # (n_groups, pages_per_compute_block * page_size)
-    # outputs
-    o_ref,  # (n_groups, head_dim)
-    # scratchs
-    m_i,  # (n_groups, 1)
-    l_i,  # (n_groups, 1)
-    k_vmem_buffer,  # (2, pages_per_compute_block, page_size, head_dim)
-    v_vmem_buffer,  # (2, pages_per_compute_block, page_size, head_dim)
-    sem,  # (1, )
-    *,
-    batch_size: int,
-    pages_per_compute_block: int,
-    pages_per_sequence: int,
-    softmax_scale: float,
-    mask_fn: Optional[MaskFn] = None,
-    megacore_mode: Optional[str] = None,
-    program_id: Optional[Tuple[int, int, int, int]] = None,
-):
-    """Compute paged flash attention.
-
-    Ported from
-    https://github.com/jax-ml/jax/blob/127aa7621868cb77e552b5d1f90e4a42b09c13fa/jax/experimental/pallas/ops/tpu/paged_attention/paged_attention_kernel.py#L113
-    Compared to original implementation, we
-    1. accept customized bias and mask,
-    2. move m_i, l_i from outputs to scratchs memory,
-    3. rearrange some of the operations for better performance.
-    """
-
-    if program_id:
-        core_index, b, h, i = program_id
-    else:
-        core_index, b, h, i = (
-            pl.program_id(0),
-            pl.program_id(1),
-            pl.program_id(2),
-            pl.program_id(3),
-        )
-    num_kv_heads, _, page_size, _ = k_pages_hbm_ref.shape
-    bk = page_size * pages_per_compute_block
-    num_cores = pl.num_programs(0)
-
-    b_step, b_start = 1, 0
-    if megacore_mode == "batch":
-        b_step, b_start = num_cores, core_index
-    h_step, h_start = 1, 0
-    if megacore_mode == "kv_head":
-        h_step, h_start = num_cores, core_index
-
-    h = h * h_step + h_start
-    b = b * b_step + b_start
-    length = lengths_ref[b]
-
-    def compute_block_indices(b, h, i):
-        """Given current block indices, get (next_b, next_h, next_i) for pre-fetching.
-
-        Order of the increment is inner-to-outer, i.e. (k_split, head_split, batch_split).
-        """
-
-        def advance_b():
-            next_b = b + b_step
-
-            def advance_to_next_non_zero_length():
-                next_next_b = next_b + b_step
-                return lax.fori_loop(
-                    lax.div(next_next_b, b_step),
-                    lax.div(batch_size, b_step),
-                    lambda _, b: jnp.where(lengths_ref[b] == 0, b + b_step, b),
-                    next_next_b,
-                )
-
-            return (
-                lax.cond(
-                    jnp.logical_and(next_b < batch_size, lengths_ref[next_b] == 0),
-                    advance_to_next_non_zero_length,
-                    lambda: next_b,
-                ),
-                h_start,
-                0,
-            )
-
-        def advance_h():
-            next_h = h + h_step
-            return lax.cond(next_h < num_kv_heads, lambda: (b, next_h, 0), advance_b)
-
-        return lax.cond(i * bk < lengths_ref[b], lambda: (b, h, i), advance_h)
-
-    def create_kv_async_copy_descriptors(b, h, i, buffer_index):
-        page_offset = b * pages_per_sequence + i * pages_per_compute_block
-        pages_to_load = pages_per_compute_block
-        async_copy_k = MultiPageAsyncCopyDescriptor(
-            k_pages_hbm_ref,
-            k_vmem_buffer.at[buffer_index],
-            sem,
-            page_indices_ref,
-            page_offset,
-            pages_to_load,
-            h,
-        )
-        async_copy_v = MultiPageAsyncCopyDescriptor(
-            v_pages_hbm_ref,
-            v_vmem_buffer.at[buffer_index],
-            sem,
-            page_indices_ref,
-            page_offset,
-            pages_to_load,
-            h,
-        )
-        return async_copy_k, async_copy_v
-
-    @pl.when(i * bk < length)
-    def flash_attention():
-        init_flag = init_flag_ref[0]
-        init_flag_ref[0] = 0
-        buffer_index = buffer_index_ref[0]
-        next_b, next_h, next_i = compute_block_indices(b, h, i + 1)
-
-        @pl.when(init_flag)
-        def prefetch_first_block():
-            async_copy_k, async_copy_v = create_kv_async_copy_descriptors(
-                b,
-                h,
-                i,
-                buffer_index,
-            )
-            async_copy_k.start()
-            async_copy_v.start()
-
-        @pl.when(i == 0)
-        def init():
-            m_i[...] = jnp.full_like(m_i, NEG_INF)
-            l_i[...] = jnp.zeros_like(l_i)
-            o_ref[...] = jnp.zeros_like(o_ref)
-
-        @pl.when(next_b < batch_size)
-        def prefetch_next_block():
-            next_buffer_index = jnp.where(buffer_index == 0, 1, 0)
-            async_copy_next_k, async_copy_next_v = create_kv_async_copy_descriptors(
-                next_b,
-                next_h,
-                next_i,
-                next_buffer_index,
-            )
-            async_copy_next_k.start()
-            async_copy_next_v.start()
-            buffer_index_ref[0] = next_buffer_index
-
-        async_copy_k, async_copy_v = create_kv_async_copy_descriptors(
-            b,
-            h,
-            i,
-            buffer_index,
-        )
-        q = q_ref[...].astype(jnp.float32)
-        k = async_copy_k.wait_and_get_loaded()
-        # Note: Using HIGHEST here would cause numerical
-        # instability for query_step > 1
-        precision = jax.lax.Precision.DEFAULT
-        qk = pl.dot(q, k.T, precision=precision)
-        if softmax_scale != 0:
-            qk *= softmax_scale
-        if bias_ref is not None:
-            qk += bias_ref[...]
-            qk = jnp.maximum(qk, NEG_INF)
-
-        block_kv_indices = i * bk + jax.lax.broadcasted_iota(jnp.int32, qk.shape, 1)
-        mask = block_kv_indices < length
-        if mask_fn is not None:
-            mask = mask & mask_fn(length - 1, block_kv_indices)
-        # (n_groups, block_k)
-        qk = jnp.where(mask, qk, NEG_INF)
-        m_prev, l_prev = m_i[...], l_i[...]
-
-        m_curr = qk.max(axis=-1, keepdims=True)
-        m_next = jnp.maximum(m_prev, m_curr)
-
-        s_curr = jnp.exp(qk - m_next)
-        l_curr = s_curr.sum(axis=-1, keepdims=True)
-
-        alpha = jnp.exp(m_prev - m_next)
-        l_prev_corr = alpha * l_prev
-        beta = jnp.exp(m_curr - m_next)
-        l_curr_corr = beta * l_curr
-        l_next = l_prev_corr + l_curr_corr
-
-        m_i[...], l_i[...] = m_next, l_next
-
-        v = async_copy_v.wait_and_get_loaded()
-        o_curr = pl.dot(s_curr, v, precision=precision)
-
-        o_ref[...] = ((l_prev_corr * o_ref[...] + beta * o_curr) / l_next).astype(o_ref.dtype)
-
-
-def _paged_flash_attention_kernel_inline_seq_dim(
-    # inputs
-    lengths_ref,  # (batch_size,)
-    page_indices_ref,  # (batch_size * pages_per_sequence,)
-    buffer_index_ref,  # (1,)
-    init_flag_ref,  # (1,)
-    q_ref,  # (n_groups, head_dim)
-    k_pages_hbm_ref,  # (num_kv_heads, batch_size * pages_per_sequence, page_size, head_dim)
-    v_pages_hbm_ref,  # (num_kv_heads, batch_size * pages_per_sequence, page_size, head_dim)
-    bias_ref,  # (n_groups, pages_per_compute_block * page_size)
-    # outputs
-    o_ref,  # (n_groups, head_dim)
-    # scratchs
-    m_i,  # (n_groups, 1)
-    l_i,  # (n_groups, 1)
-    k_vmem_buffer,  # (2, pages_per_compute_block, page_size, head_dim)
-    v_vmem_buffer,  # (2, pages_per_compute_block, page_size, head_dim)
-    sem,  # (1, )
-    *,
-    batch_size: int,
-    pages_per_compute_block: int,
-    pages_per_sequence: int,
-    softmax_scale: float,
-    mask_fn: Optional[MaskFn] = None,
-    megacore_mode: Optional[str] = None,
-):
-    core_index, b, h = pl.program_id(0), pl.program_id(1), pl.program_id(2)
-
-    o_ref[...] = jnp.zeros_like(o_ref)
-
-    def body(i, _):
-        _paged_flash_attention_kernel(
-            lengths_ref,
-            page_indices_ref,
-            buffer_index_ref,
-            init_flag_ref,
-            q_ref,
-            k_pages_hbm_ref,
-            v_pages_hbm_ref,
-            bias_ref,
-            o_ref,
-            m_i,
-            l_i,
-            k_vmem_buffer,
-            v_vmem_buffer,
-            sem,
-            batch_size=batch_size,
-            pages_per_compute_block=pages_per_compute_block,
-            pages_per_sequence=pages_per_sequence,
-            softmax_scale=softmax_scale,
-            mask_fn=mask_fn,
-            megacore_mode=megacore_mode,
-            program_id=(core_index, b, h, i),
-        )
-        return ()
-
-    bk = pages_per_compute_block * k_pages_hbm_ref.shape[-2]
-    if megacore_mode == "batch":
-        num_cores = pl.num_programs(0)
-        length = lengths_ref[b * num_cores + core_index]
-    else:
-        length = lengths_ref[b]
-
-    lax.fori_loop(0, lax.div(length + bk - 1, bk), body, ())
-
-
 class TPUPagedAttention(BasePagedAttention):
     """Wraps TPU paged flash attention kernel."""
 
@@ -383,8 +73,7 @@ class TPUPagedAttention(BasePagedAttention):
         self,
         input_batch: Nested[Tensor | BaseAttentionBias],
     ) -> Literal["kv_head", "batch", None]:
-        """
-        Simple heuristic to enable megacore parallelism on TPUs with 2 cores
+        """Simple heuristic to enable megacore parallelism on TPUs with 2 cores.
 
         It prioritizes parallelizing the 'batch' dimension if the batch size
         is divisible by 2. If not, it attempts to parallelize the 'kv_head'
@@ -402,26 +91,21 @@ class TPUPagedAttention(BasePagedAttention):
                     megacore_mode = "kv_head"
         return megacore_mode
 
-    def inline_seq_dim_heuristic(
+    def sparse_mode_heuristic(
         self,
-        input_batch: Nested[Tensor | BaseAttentionBias],
+        mask: BaseAttentionBias,
+        max_length: int,
     ) -> bool:
-        """Always use inline sequence dim kernel except when we set bias.
+        """Simple heuristic of whether to use block-sparse kernel.
 
-        Inline Seq Dim mode fuses the sequence-block axis into an internal loop
-        otherwise, we keep it as an explicit grid dimension.
-        By default, we trade a bit of parallelism for lighter
-        compilation and launch overhead.
+        True if we are using sliding window attention and sliding window
+        size is smaller than max seq len by sparse ratio specified in config.
         """
-        bias: BaseAttentionBias = input_batch["bias"]
-        _, explicit_bias = split(bias, MaskFnAttentionBias)
-        bias_val = explicit_bias.value()
-        # TODO(senyut): To enable inline kernel with bias, we need to specifically
-        #               update index map and bias block spec.
-        if bias_val is not None:
-            return False
-
-        return True
+        if isinstance(mask, SlidingWindowAttentionBias):
+            size = mask.sliding_window_size
+            if size < max_length * self.cfg.sparse_ratio:
+                return True
+        return False
 
     def is_supported(
         self,
@@ -463,7 +147,6 @@ class TPUPagedAttention(BasePagedAttention):
 
         num_groups = num_q_heads // num_kv_heads
         megacore_mode = self.megacore_mode_heuristic(input_batch)
-        inline_seq_dim = self.inline_seq_dim_heuristic(input_batch)
 
         num_cores = _get_tpu_cores_per_chip(self.cfg.interpret)
         assert num_cores in (1, 2), f"Got unexpected number of TPU cores {num_cores}"
@@ -472,8 +155,8 @@ class TPUPagedAttention(BasePagedAttention):
         per_core_kv_heads = (
             num_kv_heads // num_cores if megacore_mode == "kv_head" else num_kv_heads
         )
-        pages_per_compute_block = self.cfg.tpu_block_size // page_size
 
+        pages_per_compute_block = self.cfg.tpu_block_size // page_size
         mask, explicit_bias = split(bias, MaskFnAttentionBias)
         mask_fn, lengths = None, None
         if mask is None or not hasattr(mask, "target_positions") or mask.target_positions is None:
@@ -485,108 +168,66 @@ class TPUPagedAttention(BasePagedAttention):
         # Length going out-of-bound may trigger a device halt.
         lengths = jnp.minimum(lengths, pages_per_sequence * page_size)
 
+        sparse_mode = self.sparse_mode_heuristic(mask, page_size * pages_per_sequence)
+
         bias = explicit_bias.value()
         bias_spec = None
+        q_block_spec = pl.BlockSpec(
+            (None, num_groups, head_dim),
+            _make_index_map(megacore_mode, num_cores, is_rearranged=False, is_query=True),
+        )
+        q_dtype_for_kernel_launch = query.dtype
         if bias is not None:
             block_k = pages_per_compute_block * page_size
             # TODO(senyut): we don't necessarily need to broadcast 2D bias
             #               (target_len, kv_len) to 4D for.
             bias = jnp.broadcast_to(bias, (batch_size, num_q_heads, 1, bias.shape[-1])).squeeze(2)
-            # TODO(senyut): handle bias index map for inline kernel and remove this assertion
-            assert not inline_seq_dim
-            if megacore_mode == "batch":
-                bias_spec = pl.BlockSpec(
-                    (None, num_groups, block_k),
-                    lambda core_index, b, h, i, *_: (b * num_cores + core_index, h, i),
-                )
-            elif megacore_mode == "kv_head":
-                bias_spec = pl.BlockSpec(
-                    (None, num_groups, block_k),
-                    lambda core_index, b, h, i, *_: (b, h * num_cores + core_index, i),
-                )
-            else:
-                bias_spec = pl.BlockSpec(
-                    (None, num_groups, block_k),
-                    lambda core_index, b, h, i, *_: (b, h, i),
-                )
-
+            bias_spec = pl.BlockSpec(
+                (None, num_groups, block_k),
+                _make_index_map(
+                    megacore_mode,
+                    num_cores,
+                    is_rearranged=False,
+                    is_query=False,
+                    is_sparse=sparse_mode,
+                ),
+            )
         if num_groups % 8 != 0:
             # Reshape q to hint XLA to pick a <1x128> layout otherwise
             # it will pick a <8x128> layout for a <1x128> memref inside
             # the kernel and error out.
             query = query.reshape(batch_size, num_q_heads, 1, head_dim)
-            rearrange_bias_spec = False
+            q_block_spec = pl.BlockSpec(
+                (None, num_groups, None, head_dim),
+                _make_index_map(megacore_mode, num_cores, is_rearranged=True, is_query=True),
+            )
+
             if bias is not None:
                 bias = bias.reshape(batch_size, num_q_heads, 1, bias.shape[-1]).astype(jnp.float32)
                 block_k = pages_per_compute_block * page_size
-                rearrange_bias_spec = True
-            if megacore_mode == "kv_head":
-                q_block_spec = pl.BlockSpec(
-                    (None, num_groups, None, head_dim),
-                    lambda core_index, b, h, *_: (b, h * num_cores + core_index, 0, 0),
+                bias_spec = pl.BlockSpec(
+                    (None, num_groups, None, block_k),
+                    _make_index_map(
+                        megacore_mode,
+                        num_cores,
+                        is_rearranged=True,
+                        is_query=False,
+                        is_sparse=sparse_mode,
+                    ),
                 )
-                if rearrange_bias_spec:
-                    bias_spec = pl.BlockSpec(
-                        (None, num_groups, None, block_k),
-                        lambda core_index, b, h, i, *_: (b, h * num_cores + core_index, 0, i),
-                    )
-            elif megacore_mode == "batch":
-                q_block_spec = pl.BlockSpec(
-                    (None, num_groups, None, head_dim),
-                    lambda core_index, b, h, *_: (b * num_cores + core_index, h, 0, 0),
-                )
-                if rearrange_bias_spec:
-                    bias_spec = pl.BlockSpec(
-                        (None, num_groups, None, block_k),
-                        lambda core_index, b, h, i, *_: (b * num_cores + core_index, h, 0, i),
-                    )
-            else:
-                q_block_spec = pl.BlockSpec(
-                    (None, num_groups, None, head_dim),
-                    lambda core_index, b, h, *_: (b, h, 0, 0),
-                )
-                if rearrange_bias_spec:
-                    bias_spec = pl.BlockSpec(
-                        (None, num_groups, None, block_k),
-                        lambda core_index, b, h, i, *_: (b, h, 0, i),
-                    )
             q_dtype_for_kernel_launch = jnp.float32
-        else:
-            if megacore_mode == "kv_head":
-                q_block_spec = pl.BlockSpec(
-                    (None, num_groups, head_dim),
-                    lambda core_index, b, h, *_: (b, h * num_cores + core_index, 0),
-                )
-            elif megacore_mode == "batch":
-                q_block_spec = pl.BlockSpec(
-                    (None, num_groups, head_dim),
-                    lambda core_index, b, h, *_: (b * num_cores + core_index, h, 0),
-                )
-            else:
-                q_block_spec = pl.BlockSpec(
-                    (None, num_groups, head_dim),
-                    lambda core_index, b, h, *_: (b, h, 0),
-                )
-            q_dtype_for_kernel_launch = query.dtype
 
         dimension_semantics: Sequence[Literal["parallel", "arbitrary"]]
-        if inline_seq_dim:
-            kernel = _paged_flash_attention_kernel_inline_seq_dim
-            grid = (
-                num_cores,
-                per_core_batch,
-                per_core_kv_heads,
-            )
-            dimension_semantics = ("parallel", "arbitrary", "arbitrary")
-        else:
-            kernel = _paged_flash_attention_kernel
-            grid = (
-                num_cores,
-                per_core_batch,
-                per_core_kv_heads,
-                pages_per_sequence // pages_per_compute_block,
-            )
-            dimension_semantics = ("parallel", "arbitrary", "arbitrary", "arbitrary")
+        kernel = (
+            _paged_flash_attention_sparse_kernel if sparse_mode else _paged_flash_attention_kernel
+        )
+        grid = (
+            num_cores,
+            per_core_batch,
+            per_core_kv_heads,
+            pages_per_sequence // pages_per_compute_block,
+        )
+        dimension_semantics = ("parallel", "arbitrary", "arbitrary", "arbitrary")
 
         in_specs = [
             q_block_spec,  # Query
@@ -617,6 +258,26 @@ class TPUPagedAttention(BasePagedAttention):
             ),  # v_mem_buffer
             pltpu.SemaphoreType.DMA,  # sem
         )
+        args = (
+            lengths,
+            page_tables.reshape(-1),
+            jnp.zeros((1,), jnp.int32),
+            jnp.ones((1,), jnp.int32),
+            query.astype(q_dtype_for_kernel_launch),
+            key,
+            value,
+            bias,
+        )
+        num_scalars = 4
+        if sparse_mode:
+            kv_block_offset, kv_block_offset_size = prepare_block_sparse_map(
+                mask,
+                lengths=lengths,
+                block_size=self.cfg.tpu_block_size,
+                seq_len=page_size * pages_per_sequence,
+            )
+            args = (kv_block_offset, kv_block_offset_size) + args
+            num_scalars = 6
 
         out = pl.pallas_call(
             functools.partial(
@@ -629,7 +290,7 @@ class TPUPagedAttention(BasePagedAttention):
                 megacore_mode=megacore_mode,
             ),
             grid_spec=pltpu.PrefetchScalarGridSpec(
-                num_scalar_prefetch=4,
+                num_scalar_prefetch=num_scalars,
                 in_specs=in_specs,
                 out_specs=q_block_spec,
                 grid=grid,
@@ -640,14 +301,5 @@ class TPUPagedAttention(BasePagedAttention):
             ),
             out_shape=jax.ShapeDtypeStruct(query.shape, q_dtype_for_kernel_launch),
             interpret=self.cfg.interpret,
-        )(
-            lengths,
-            page_tables.reshape(-1),
-            jnp.zeros((1,), jnp.int32),
-            jnp.ones((1,), jnp.int32),
-            query.astype(q_dtype_for_kernel_launch),
-            key,
-            value,
-            bias,
-        )
+        )(*args)
         return out.reshape(batch_size, 1, num_q_heads, head_dim).astype(query.dtype)

--- a/axlearn/common/flash_attention/tpu_paged_attention_kernel.py
+++ b/axlearn/common/flash_attention/tpu_paged_attention_kernel.py
@@ -1,0 +1,590 @@
+# Copyright © 2025 Apple Inc.
+#
+# Some of the code in this file is adapted from:
+# jax-ml/jax:
+# Copyright 2023 The JAX Authors.
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""Implements PagedAttention for TPU Pallas kernel with logit bias and mask_fn support.
+
+Base implementation is ported from
+https://github.com/jax-ml/jax/blob/jax-v0.6.0/jax/experimental/pallas/ops/tpu/paged_attention/paged_attention_kernel.py
+
+Added Block Sparse kernel to avoid unnecessary loads,
+particularly for sliding window with long context, where we
+1. Pre-compute a block-sparse mask with offset of shape (n_kv_blocks, n_kv_blocks)
+2. We only load from the offset pointed to unmasked blocks in the kernel.
+"""
+
+from typing import Any, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+from axlearn.common.attention_bias import (
+    NEG_INF,
+    BaseAttentionBias,
+    MaskFn,
+    SlidingWindowAttentionBias,
+)
+from axlearn.common.flash_attention.common import (
+    build_mask,
+    build_sliding_window_mask,
+    query_iterator_indices,
+)
+from axlearn.common.utils import Tensor
+
+
+class MultiPageAsyncCopyDescriptor:
+    """Descriptor for async copy of multiple K/V pages from HBM.
+
+    Ported from
+    https://github.com/jax-ml/jax/blob/127aa7621868cb77e552b5d1f90e4a42b09c13fa/jax/experimental/pallas/ops/tpu/paged_attention/paged_attention_kernel.py#L33
+    """
+
+    def __init__(
+        self,
+        pages_hbm_ref,
+        vmem_buffer,
+        sem,
+        page_indices,
+        page_indices_start_offset: int,
+        num_pages_to_load: int,
+        head_index: int,
+    ):
+        self._vmem_buffer = vmem_buffer
+        self._num_pages_to_load = num_pages_to_load
+        if head_index is not None:
+            self._pages_hbm_ref = pages_hbm_ref.at[head_index]
+        else:
+            self._pages_hbm_ref = pages_hbm_ref
+        self._sem = sem
+        self._page_indices = page_indices
+        self._page_indices_start_offset = page_indices_start_offset
+        self._async_copies = [self._make_async_copy(i) for i in range(self._num_pages_to_load)]
+
+    def _make_async_copy(self, i):
+        page_index = self._page_indices[self._page_indices_start_offset + i]
+        return pltpu.make_async_copy(
+            self._pages_hbm_ref.at[page_index],
+            self._vmem_buffer.at[i],
+            self._sem,
+        )
+
+    def start(self):
+        """Starts the async copies."""
+        for async_copy in self._async_copies:
+            async_copy.start()
+
+    def wait_and_get_loaded(self) -> Tensor:
+        """Wait async copies and gets the loaded buffer as a Tensor."""
+        for async_copy in self._async_copies:
+            async_copy.wait()
+        head_dim = self._vmem_buffer.shape[-1]
+        tensor = self._vmem_buffer[...].astype(jnp.float32)
+        return tensor.reshape(-1, head_dim)
+
+
+def prepare_block_sparse_map(
+    mask: BaseAttentionBias,
+    lengths: Tensor,
+    block_size: int,
+    seq_len: int,
+) -> Tuple[Any, Any]:
+    """
+    Computes a full block map num_kv_blocks * num_kv_blocks.
+    """
+    # Use a padding to ensure padding blocks aren't counted towards `kv_block_offset_size`.
+    padding = -1
+    mask_fn = mask.mask
+
+    with jax.ensure_compile_time_eval():
+        if mask_fn is not None:
+            mask_args = dict(
+                q_seq_len=seq_len,
+                kv_seq_len=seq_len,
+                block_q=block_size,
+                block_k=block_size,
+            )
+            if isinstance(mask, SlidingWindowAttentionBias):
+                bool_mask = build_sliding_window_mask(
+                    **mask_args, sliding_window_size=mask.sliding_window_size
+                )
+            else:
+                bool_mask = build_mask(mask_fn, **mask_args)
+            offset, _ = query_iterator_indices(bool_mask, padding=padding)
+        else:
+            padded_num_kv_blocks = pl.cdiv(seq_len, block_size)
+            offset = lax.broadcasted_iota(
+                jnp.int32, (padded_num_kv_blocks, padded_num_kv_blocks), 1
+            )
+
+    kv_block_offset = offset[(lengths - 1) // block_size]
+    # Count the number of blocks with position < kv_seq_len.
+    kv_block_offset_size = jnp.count_nonzero(
+        (kv_block_offset != padding) & (kv_block_offset * block_size < lengths[:, None]),
+        axis=1,
+    )
+    # Replace padding with the last valid kv block's index. See
+    # https://docs.jax.dev/en/latest/pallas/tpu/sparse.html#sparse-access-patterns-on-dense-data
+    kv_block_offset = jnp.where(
+        kv_block_offset == padding, kv_block_offset.max(axis=1, keepdims=True), kv_block_offset
+    )
+    return kv_block_offset, kv_block_offset_size
+
+
+def _make_index_map(
+    megacore_mode: Optional[str] = None,
+    num_cores: int = 2,
+    is_rearranged: bool = False,
+    is_query: bool = False,
+    is_sparse: bool = False,
+):
+    """Creates an index map function for query/bias tensor."""
+
+    def dense_index_map(core_index, b, h, i, *_):
+        if megacore_mode is None:
+            batch_idx = b
+            head_idx = h
+        elif megacore_mode == "batch":
+            batch_idx = b * num_cores + core_index
+            head_idx = h
+        elif megacore_mode == "kv_head":
+            batch_idx = b
+            head_idx = h * num_cores + core_index
+        else:
+            raise ValueError("Unsupported megacore mode")
+
+        if is_query:
+            i = 0
+        if is_rearranged:
+            return (batch_idx, head_idx, 0, i)
+        return (batch_idx, head_idx, i)
+
+    def sparse_index_map(core_index, b, h, i, kv_block_offset, *_):
+        if megacore_mode is None:
+            batch_idx = b
+            head_idx = h
+        elif megacore_mode == "batch":
+            batch_idx = b * num_cores + core_index
+            head_idx = h
+        elif megacore_mode == "kv_head":
+            batch_idx = b
+            head_idx = h * num_cores + core_index
+        else:
+            raise ValueError("Unsupported megacore mode")
+
+        i = kv_block_offset[batch_idx, i]
+        if is_rearranged:
+            return (batch_idx, head_idx, 0, i)
+        return (batch_idx, head_idx, i)
+
+    if is_sparse and not is_query:
+        return sparse_index_map
+    return dense_index_map
+
+
+def _paged_flash_attention_sparse_kernel(
+    # Scalars
+    kv_block_offset,  # (batch_size, num_kv_blocks)
+    kv_block_offset_size,  # (batch_size,)
+    lengths_ref,  # (batch_size,)
+    page_indices_ref,  # (batch_size * pages_per_sequence,)
+    buffer_index_ref,  # (1,)
+    init_flag_ref,  # (1,)
+    # Inputs
+    q_ref,  # (n_groups, head_dim)
+    k_pages_hbm_ref,  # (n_kv_heads, batch_size * pages_per_sequence, page_size, head_dim)
+    v_pages_hbm_ref,  # (n_kv_heads, batch_size * pages_per_sequence, page_size, head_dim)
+    bias_ref,  # (n_groups, pages_per_compute_block * page_size)
+    # Outputs
+    o_ref,  # (n_groups, head_dim)
+    # scratches
+    m_i,  # (n_groups, 1)
+    l_i,  # (n_groups, 1)
+    k_vmem_buffer,  # (2, pages_per_compute_block, page_size, head_dim)
+    v_vmem_buffer,  # (2, pages_per_compute_block, page_size, head_dim)
+    sem,  # (1, )
+    # Compile time args
+    *,
+    batch_size: int,
+    pages_per_compute_block: int,
+    pages_per_sequence: int,
+    softmax_scale: float,
+    mask_fn: Optional[MaskFn] = None,
+    megacore_mode: Optional[str] = None,
+):
+    core_index, batch_index, head_index, valid_block_index = (
+        pl.program_id(0),
+        pl.program_id(1),
+        pl.program_id(2),
+        pl.program_id(3),
+    )
+    num_cores = pl.num_programs(0)
+    num_kv_heads, _, page_size, _ = k_pages_hbm_ref.shape
+    block_k = pages_per_compute_block * page_size
+
+    b_step, b_start = 1, 0
+    if megacore_mode == "batch":
+        b_step, b_start = num_cores, core_index
+    h_step, h_start = 1, 0
+    if megacore_mode == "kv_head":
+        h_step, h_start = num_cores, core_index
+    h = head_index * h_step + h_start
+    b = batch_index * b_step + b_start
+
+    length = lengths_ref[b]
+    num_valid_kv_blocks = kv_block_offset_size[b]
+
+    def compute_block_indices(b, h, i):
+        """Given current block indices prefetch next block.
+
+        Args:
+            b: batch index.
+            h: head index.
+            i: valid kv block index from block-sparse kv mask.
+
+        Returns:
+            Next valid kernel block indices.
+        """
+
+        def advance_b():
+            next_b = b + b_step
+
+            def advance_to_next_non_zero_length():
+                next_next_b = next_b + b_step
+                cond = (lengths_ref[b] == 0) | (kv_block_offset_size[b] == 0)
+                return lax.fori_loop(
+                    lax.div(next_next_b, b_step),
+                    lax.div(batch_size, b_step),
+                    lambda _, b: jnp.where(cond, b + b_step, b),
+                    next_next_b,
+                )
+
+            return (
+                lax.cond(
+                    jnp.logical_and(
+                        next_b < batch_size,
+                        jnp.logical_or(
+                            lengths_ref[next_b] == 0,
+                            kv_block_offset_size[next_b] == 0,
+                        ),
+                    ),
+                    advance_to_next_non_zero_length,
+                    lambda: next_b,
+                ),
+                h_start,
+                0,
+            )
+
+        def advance_h():
+            next_h = h + h_step
+            return lax.cond(next_h < num_kv_heads, lambda: (b, next_h, 0), advance_b)
+
+        return lax.cond(i < num_valid_kv_blocks, lambda: (b, h, i), advance_h)
+
+    def create_kv_async_copy_descriptors(b, h, i, buffer_index):
+        block_offset = kv_block_offset[b, i]
+        page_offset = b * pages_per_sequence + block_offset * pages_per_compute_block
+        pages_to_load = pages_per_compute_block
+        async_copy_k = MultiPageAsyncCopyDescriptor(
+            k_pages_hbm_ref,
+            k_vmem_buffer.at[buffer_index],
+            sem,
+            page_indices_ref,
+            page_offset,
+            pages_to_load,
+            h,
+        )
+        async_copy_v = MultiPageAsyncCopyDescriptor(
+            v_pages_hbm_ref,
+            v_vmem_buffer.at[buffer_index],
+            sem,
+            page_indices_ref,
+            page_offset,
+            pages_to_load,
+            h,
+        )
+        return async_copy_k, async_copy_v
+
+    # Traverse each batch's valid KV blocks
+    @pl.when(valid_block_index < num_valid_kv_blocks)
+    def flash_attention():
+        init_flag = init_flag_ref[0]
+        init_flag_ref[0] = 0
+        buffer_index = buffer_index_ref[0]
+        block_offset = kv_block_offset[b, valid_block_index]
+        next_b, next_h, next_valid_block_index = compute_block_indices(b, h, valid_block_index + 1)
+
+        @pl.when(valid_block_index == 0)
+        def init():
+            m_i[...] = jnp.full_like(m_i, NEG_INF)
+            l_i[...] = jnp.zeros_like(l_i)
+            o_ref[...] = jnp.zeros_like(o_ref)
+
+        @pl.when(init_flag)
+        def prefetch_first_block():
+            async_copy_k, async_copy_v = create_kv_async_copy_descriptors(
+                b,
+                h,
+                valid_block_index,
+                buffer_index,
+            )
+            async_copy_k.start()
+            async_copy_v.start()
+
+        @pl.when(next_b < batch_size)
+        def prefetch_next_block():
+            next_buffer_index = jnp.where(buffer_index == 0, 1, 0)
+            async_copy_next_k, async_copy_next_v = create_kv_async_copy_descriptors(
+                next_b,
+                next_h,
+                next_valid_block_index,
+                next_buffer_index,
+            )
+            async_copy_next_k.start()
+            async_copy_next_v.start()
+            buffer_index_ref[0] = next_buffer_index
+
+        async_copy_k, async_copy_v = create_kv_async_copy_descriptors(
+            b,
+            h,
+            valid_block_index,
+            buffer_index,
+        )
+        q = q_ref[...].astype(jnp.float32)
+        k = async_copy_k.wait_and_get_loaded()
+        precision = jax.lax.Precision.DEFAULT
+        qk = pl.dot(q, k.T, precision=precision)
+        if softmax_scale != 0:
+            qk *= softmax_scale
+        if bias_ref is not None:
+            qk += bias_ref[...]
+            qk = jnp.maximum(qk, NEG_INF)
+
+        block_kv_indices = block_offset * block_k + lax.broadcasted_iota(jnp.int32, qk.shape, 1)
+        mask = block_kv_indices < length
+        if mask_fn is not None:
+            mask = mask & mask_fn(length - 1, block_kv_indices)
+
+        qk = jnp.where(mask, qk, NEG_INF)
+        m_prev, l_prev = m_i[...], l_i[...]
+        m_curr = qk.max(axis=-1, keepdims=True)
+        m_next = jnp.maximum(m_prev, m_curr)
+        s_curr = jnp.exp(qk - m_next)
+        l_curr = s_curr.sum(axis=-1, keepdims=True)
+
+        alpha = jnp.exp(m_prev - m_next)
+        l_prev_corr = alpha * l_prev
+        beta = jnp.exp(m_curr - m_next)
+        l_curr_corr = beta * l_curr
+        l_next = l_prev_corr + l_curr_corr
+
+        m_i[...], l_i[...] = m_next, l_next
+        v = async_copy_v.wait_and_get_loaded()
+        o_curr = pl.dot(s_curr, v, precision=precision)
+
+        o_ref[...] = ((l_prev_corr * o_ref[...] + beta * o_curr) / l_next).astype(o_ref.dtype)
+
+
+def _paged_flash_attention_kernel(
+    # inputs
+    lengths_ref,  # (batch_size,)
+    page_indices_ref,  # (batch_size * pages_per_sequence,)
+    buffer_index_ref,  # (1,)
+    init_flag_ref,  # (1,)
+    q_ref,  # (n_groups, head_dim)
+    k_pages_hbm_ref,  # (num_kv_heads, batch_size * pages_per_sequence, page_size, head_dim)
+    v_pages_hbm_ref,  # (num_kv_heads, batch_size * pages_per_sequence, page_size, head_dim)
+    bias_ref,  # (n_groups, pages_per_compute_block * page_size)
+    # outputs
+    o_ref,  # (n_groups, head_dim)
+    # scratchs
+    m_i,  # (n_groups, 1)
+    l_i,  # (n_groups, 1)
+    k_vmem_buffer,  # (2, pages_per_compute_block, page_size, head_dim)
+    v_vmem_buffer,  # (2, pages_per_compute_block, page_size, head_dim)
+    sem,  # (1, )
+    *,
+    batch_size: int,
+    pages_per_compute_block: int,
+    pages_per_sequence: int,
+    softmax_scale: float,
+    mask_fn: Optional[MaskFn] = None,
+    megacore_mode: Optional[str] = None,
+    program_id: Optional[Tuple[int, int, int, int]] = None,
+):
+    """Compute paged flash attention.
+
+    Ported from
+    https://github.com/jax-ml/jax/blob/127aa7621868cb77e552b5d1f90e4a42b09c13fa/jax/experimental/pallas/ops/tpu/paged_attention/paged_attention_kernel.py#L113
+    Compared to original implementation, we
+    1. accept customized bias and mask,
+    2. move m_i, l_i from outputs to scratchs memory,
+    3. rearrange some of the operations for better performance.
+    """
+
+    if program_id:
+        core_index, b, h, i = program_id
+    else:
+        core_index, b, h, i = (
+            pl.program_id(0),
+            pl.program_id(1),
+            pl.program_id(2),
+            pl.program_id(3),
+        )
+    num_kv_heads, _, page_size, _ = k_pages_hbm_ref.shape
+    bk = page_size * pages_per_compute_block
+    num_cores = pl.num_programs(0)
+
+    b_step, b_start = 1, 0
+    if megacore_mode == "batch":
+        b_step, b_start = num_cores, core_index
+    h_step, h_start = 1, 0
+    if megacore_mode == "kv_head":
+        h_step, h_start = num_cores, core_index
+
+    h = h * h_step + h_start
+    b = b * b_step + b_start
+    length = lengths_ref[b]
+
+    def compute_block_indices(b, h, i):
+        """Given current block indices, get (next_b, next_h, next_i) for pre-fetching.
+
+        Order of the increment is inner-to-outer, i.e. (k_split, head_split, batch_split).
+        """
+
+        def advance_b():
+            next_b = b + b_step
+
+            def advance_to_next_non_zero_length():
+                next_next_b = next_b + b_step
+                return lax.fori_loop(
+                    lax.div(next_next_b, b_step),
+                    lax.div(batch_size, b_step),
+                    lambda _, b: jnp.where(lengths_ref[b] == 0, b + b_step, b),
+                    next_next_b,
+                )
+
+            return (
+                lax.cond(
+                    jnp.logical_and(next_b < batch_size, lengths_ref[next_b] == 0),
+                    advance_to_next_non_zero_length,
+                    lambda: next_b,
+                ),
+                h_start,
+                0,
+            )
+
+        def advance_h():
+            next_h = h + h_step
+            return lax.cond(next_h < num_kv_heads, lambda: (b, next_h, 0), advance_b)
+
+        return lax.cond(i * bk < lengths_ref[b], lambda: (b, h, i), advance_h)
+
+    def create_kv_async_copy_descriptors(b, h, i, buffer_index):
+        page_offset = b * pages_per_sequence + i * pages_per_compute_block
+        pages_to_load = pages_per_compute_block
+        async_copy_k = MultiPageAsyncCopyDescriptor(
+            k_pages_hbm_ref,
+            k_vmem_buffer.at[buffer_index],
+            sem,
+            page_indices_ref,
+            page_offset,
+            pages_to_load,
+            h,
+        )
+        async_copy_v = MultiPageAsyncCopyDescriptor(
+            v_pages_hbm_ref,
+            v_vmem_buffer.at[buffer_index],
+            sem,
+            page_indices_ref,
+            page_offset,
+            pages_to_load,
+            h,
+        )
+        return async_copy_k, async_copy_v
+
+    @pl.when(i * bk < length)
+    def flash_attention():
+        init_flag = init_flag_ref[0]
+        init_flag_ref[0] = 0
+        buffer_index = buffer_index_ref[0]
+        next_b, next_h, next_i = compute_block_indices(b, h, i + 1)
+
+        @pl.when(init_flag)
+        def prefetch_first_block():
+            async_copy_k, async_copy_v = create_kv_async_copy_descriptors(
+                b,
+                h,
+                i,
+                buffer_index,
+            )
+            async_copy_k.start()
+            async_copy_v.start()
+
+        @pl.when(i == 0)
+        def init():
+            m_i[...] = jnp.full_like(m_i, NEG_INF)
+            l_i[...] = jnp.zeros_like(l_i)
+            o_ref[...] = jnp.zeros_like(o_ref)
+
+        @pl.when(next_b < batch_size)
+        def prefetch_next_block():
+            next_buffer_index = jnp.where(buffer_index == 0, 1, 0)
+            async_copy_next_k, async_copy_next_v = create_kv_async_copy_descriptors(
+                next_b,
+                next_h,
+                next_i,
+                next_buffer_index,
+            )
+            async_copy_next_k.start()
+            async_copy_next_v.start()
+            buffer_index_ref[0] = next_buffer_index
+
+        async_copy_k, async_copy_v = create_kv_async_copy_descriptors(
+            b,
+            h,
+            i,
+            buffer_index,
+        )
+        q = q_ref[...].astype(jnp.float32)
+        k = async_copy_k.wait_and_get_loaded()
+        # Note: Using HIGHEST here would cause numerical
+        # instability for query_step > 1
+        precision = jax.lax.Precision.DEFAULT
+        qk = pl.dot(q, k.T, precision=precision)
+        if softmax_scale != 0:
+            qk *= softmax_scale
+        if bias_ref is not None:
+            qk += bias_ref[...]
+            qk = jnp.maximum(qk, NEG_INF)
+
+        block_kv_indices = i * bk + jax.lax.broadcasted_iota(jnp.int32, qk.shape, 1)
+        mask = block_kv_indices < length
+        if mask_fn is not None:
+            mask = mask & mask_fn(length - 1, block_kv_indices)
+        # (n_groups, block_k)
+        qk = jnp.where(mask, qk, NEG_INF)
+        m_prev, l_prev = m_i[...], l_i[...]
+
+        m_curr = qk.max(axis=-1, keepdims=True)
+        m_next = jnp.maximum(m_prev, m_curr)
+
+        s_curr = jnp.exp(qk - m_next)
+        l_curr = s_curr.sum(axis=-1, keepdims=True)
+
+        alpha = jnp.exp(m_prev - m_next)
+        l_prev_corr = alpha * l_prev
+        beta = jnp.exp(m_curr - m_next)
+        l_curr_corr = beta * l_curr
+        l_next = l_prev_corr + l_curr_corr
+
+        m_i[...], l_i[...] = m_next, l_next
+
+        v = async_copy_v.wait_and_get_loaded()
+        o_curr = pl.dot(s_curr, v, precision=precision)
+
+        o_ref[...] = ((l_prev_corr * o_ref[...] + beta * o_curr) / l_next).astype(o_ref.dtype)


### PR DESCRIPTION
This PR adds block-sparse kernel for TPU paged attention, optimizing for long context with sliding window attention.
Following flash attention block sparse approach, we also pre-build `kv_block_offset` map and retrieve unmasked blocks only, to avoid unnecessary loads.
We also use double-buffering for prefetching next unmasked block.

We refactor previous implementation by moving all kernels and kernel utils to `axlearn/common/flash_attention/tpu_paged_attention_kernel.py`, and we've cleaned up how we construct bias/query input spec for better readability. We also updated benchmark script for finer grained profiling for fast-running kernel.

Testing: Unit tested by `axlearn/common/flash_attention/decoding_test.py` and `axlearn/common/flash_attention/layer_test.py`

Results: Make the gap with flash decoding closer, 1.6x speedup for non-sparse paged kernel for higher batch size (128), medium context (8k), and 7x speedup for non-sparse paged kernel for BS16, Context 65K.
Following results measured on v5p-8
```
Model Size	 Kernel	              BS128 + CTX8K	BS16 + CTX64K
12.6B	         Flash Decoding       14.890ms	        1.851ms
                 Sparse Paged	      19.770ms	        4.579ms
                 Paged	              31.808ms	        31.684ms
29.6B - 1kv	 Flash Decoding	      380.626us	        47.465us
                 Sparse Paged	      525.437us	        131.7us
                 Paged	              794.662us	        789.615us
65.2B	         Flash Decoding	      26.833ms	        3.368ms
                 Sparse Paged	      35.713ms	        8.237ms
                 Paged	              57.282ms	        57.073ms
134B	         Flash Decoding	      33.1ms	        4.083ms
                 Sparse Paged	      43.638ms	        10.073ms
                 Paged	              70.047ms	        70.073ms

Large Model	                                     BS8 + CTX8K
261.7B	         Flash Decoding	                          2.57ms
                 Sparse Paged	                         3.631ms
                 Paged	                                 5.458ms
```