### PR TITLE
[JAX API] Updating `TransferToMemoryKind` and `jax.experimental.pallas.triton`

### DIFF
--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -304,8 +304,14 @@ async def _async_serialize(
         and jax.process_count() > 1
         and arr_inp.is_fully_addressable
     )
-    # pylint: disable-next=protected-access
-    if not serialization.ts_impl._spec_has_metadata(tensorstore_spec):
+    # pylint: disable=protected-access
+    if jax.__version__.startswith("0.8.0") or jax.__version__ == "0.6.2":
+        spec_has_metadata = serialization.ts_impl._spec_has_metadata
+    elif jax.__version__ == "0.5.3":
+        spec_has_metadata = serialization._spec_has_metadata
+    else:
+        raise ValueError(f"Unsupported JAX version for spec_has_metadata: {jax.__version__}")
+    if not spec_has_metadata(tensorstore_spec):
         # pylint: disable-next=protected-access
         tensorstore_spec["metadata"] = serialization._get_metadata(arr_inp)
     if "dtype" not in tensorstore_spec:

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -305,7 +305,7 @@ async def _async_serialize(
         and arr_inp.is_fully_addressable
     )
     # pylint: disable=protected-access
-    if jax.__version__.startswith("0.8.0") or jax.__version__ == "0.6.2":
+    if jax.__version__.startswith("0.8.") or jax.__version__ == "0.6.2":
         spec_has_metadata = serialization.ts_impl._spec_has_metadata
     elif jax.__version__ == "0.5.3":
         spec_has_metadata = serialization._spec_has_metadata

--- a/axlearn/common/flash_attention/gpu_attention.py
+++ b/axlearn/common/flash_attention/gpu_attention.py
@@ -44,7 +44,6 @@ from jax._src.cudnn.fused_attention_stablehlo import (
 )
 from jax.ad_checkpoint import checkpoint_name
 from jax.experimental import pallas as pl
-from jax.experimental.pallas.triton import CompilerParams as TritonCompilerParams
 
 from axlearn.common.attention_bias import (
     NEG_INF,
@@ -69,7 +68,14 @@ from axlearn.common.flash_attention.remat import FLASH_ATTN_RESIDUAL_NAME
 from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
 from axlearn.common.kv_cache.kv_cache import KVCache
 from axlearn.common.layers import get_dropout_mask
-from axlearn.common.utils import Nested, Tensor
+from axlearn.common.utils import _JAX_MEMORY_SPACE_SUPPORT, Nested, Tensor
+
+# pylint: disable=ungrouped-imports
+if _JAX_MEMORY_SPACE_SUPPORT:
+    from jax.experimental.pallas.triton import CompilerParams as TritonCompilerParams
+else:
+    from jax.experimental.pallas.triton import TritonCompilerParams
+# pylint: disable=ungrouped-imports
 
 
 def _segment_mask(

--- a/axlearn/common/flash_attention/gpu_decoding.py
+++ b/axlearn/common/flash_attention/gpu_decoding.py
@@ -49,7 +49,6 @@ from absl import logging
 from jax import lax
 from jax._src.cudnn.fused_attention_stablehlo import check_compute_capability
 from jax.experimental import pallas as pl
-from jax.experimental.pallas.triton import CompilerParams as TritonCompilerParams
 
 from axlearn.common.attention_bias import (
     NEG_INF,
@@ -61,7 +60,14 @@ from axlearn.common.attention_bias import (
 from axlearn.common.flash_attention.common import BaseSingleStepDecoding, get_gpu_dot_precision
 from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
 from axlearn.common.kv_cache.kv_cache import KVCache
-from axlearn.common.utils import Nested, Tensor
+from axlearn.common.utils import _JAX_MEMORY_SPACE_SUPPORT, Nested, Tensor
+
+# pylint: disable=ungrouped-imports
+if _JAX_MEMORY_SPACE_SUPPORT:
+    from jax.experimental.pallas.triton import CompilerParams as TritonCompilerParams
+else:
+    from jax.experimental.pallas.triton import TritonCompilerParams
+# pylint: enable=ungrouped-imports
 
 
 # Note: split_k_seq_len must be a multiple of block_k.

--- a/axlearn/common/flash_attention/gpu_paged_attention.py
+++ b/axlearn/common/flash_attention/gpu_paged_attention.py
@@ -19,7 +19,6 @@ import jax
 import jax.numpy as jnp
 from jax import lax
 from jax.experimental import pallas as pl
-from jax.experimental.pallas.triton import CompilerParams as TritonCompilerParams
 
 from axlearn.common.attention_bias import (
     NEG_INF,
@@ -31,7 +30,16 @@ from axlearn.common.attention_bias import (
 from axlearn.common.flash_attention.common import BasePagedAttention, get_gpu_dot_precision
 from axlearn.common.flash_attention.gpu_decoding import _get_sm_count as get_sm_count
 from axlearn.common.kv_cache.base_kv_cache import BaseKVCache
-from axlearn.common.utils import Nested, Tensor
+from axlearn.common.utils import _JAX_MEMORY_SPACE_SUPPORT, Nested, Tensor
+
+# pylint: disable=ungrouped-imports
+if _JAX_MEMORY_SPACE_SUPPORT:
+    from jax.experimental.pallas.triton import CompilerParams as TritonCompilerParams
+else:
+    from jax.experimental.pallas.triton import (  # isort: skip
+        TritonCompilerParams,
+    )
+# pylint: enable=ungrouped-imports
 
 
 def _paged_attention_kernel(

--- a/axlearn/common/kv_cache/paged_kv_cache_gpu_kernel.py
+++ b/axlearn/common/kv_cache/paged_kv_cache_gpu_kernel.py
@@ -8,9 +8,15 @@ This kernel is a temporary workaround of occasional performance problems with
 import jax
 import jax.numpy as jnp
 from jax.experimental import pallas as pl
-from jax.experimental.pallas.triton import CompilerParams as TritonCompilerParams
 
-from axlearn.common.utils import Tensor
+from axlearn.common.utils import _JAX_MEMORY_SPACE_SUPPORT, Tensor
+
+# pylint: disable=ungrouped-imports
+if _JAX_MEMORY_SPACE_SUPPORT:
+    from jax.experimental.pallas.triton import CompilerParams as TritonCompilerParams
+else:
+    from jax.experimental.pallas.triton import TritonCompilerParams
+# pylint: enable=ungrouped-imports
 
 
 def _scatter_pages_kernel(

--- a/axlearn/experiments/text/gpt/c4_trainer.py
+++ b/axlearn/experiments/text/gpt/c4_trainer.py
@@ -49,11 +49,8 @@ from axlearn.common.config import (
 from axlearn.common.input_lm import lm_text_preprocessor
 from axlearn.common.utils import get_data_dir
 from axlearn.experiments.text.common import DataMixtureComponent, vocab
-from axlearn.experiments.text.gpt import envy, fuji, gspmd, qwen  # pytype: disable=pyi-error
-from axlearn.experiments.text.gpt.common import (  # pytype: disable=pyi-error
-    mixture_train_input_source,
-    tfds_input,
-)
+from axlearn.experiments.text.gpt import fuji, gspmd
+from axlearn.experiments.text.gpt.common import mixture_train_input_source, tfds_input
 from axlearn.experiments.text.gpt.vocabulary_fuji_v3 import FujiV3Vocabulary
 
 
@@ -114,6 +111,4 @@ def named_trainer_configs() -> dict[str, TrainerConfigFn]:
     config_map = {}
     config_map.update(fuji.trainer_configs(_train_input_source, _eval_input_sources))
     config_map.update(gspmd.trainer_configs(_train_input_source, _eval_input_sources))
-    config_map.update(envy.trainer_configs(_train_input_source, _eval_input_sources))
-    config_map.update(qwen.trainer_configs(_train_input_source, _eval_input_sources))
     return config_map


### PR DESCRIPTION
@matthew-e-hopkins 
Hey people, this is a huge update, to allow us to use JAX > 0.5.3 (we're currently testing AXLearn with JAX 0.7.2). 
I've implemented the following changes: 
- I've created a back compatibility option `_JAX_MEMORY_SPACE_SUPPORT` so that  all these changes can work with different versions of JAX 
- In `utils.py` JAX' `from jax._src.sharding_impls import TransferToMemoryKind` has been substituted with its correspondent version for JAX 0.7 (`jax.memory.Space.*`). I am preserving the previous option by checking the jax version: 
```python 
if _JAX_MEMORY_SPACE_SUPPORT:
    MemoryKind = [jax.memory.Space.Device, jax.memory.Space.Host]
    DEVICE_MEMORY = jax.memory.Space.Device
    HOST_MEMORY = jax.memory.Space.Host

    def transfer_to_memory_kind(tensor: Tensor, memory_kind: MemoryKind) -> Tensor:
        return jax.device_put(tensor, memory_kind)

else:
    from jax._src.sharding_impls import TransferToMemoryKind  # pylint: disable=ungrouped-imports

    MemoryKind = Literal["device", "pinned_host"]
    DEVICE_MEMORY = "device"
    HOST_MEMORY = "pinned_host" 
```
- These changes have been propagated to `optimizers_test.py` and `optimizers.py` 
- `jax.experimental.pallas.triton.TritonCompilerParams` has now changed in `.CompilerParams`, so `gpu_attention.py`, `gpu_decoding.py`, `gpu_paged_attention.py` and `paged_kv_cache_gpu_kernel.py` have been changed accordingly. Again, as before, I'm importing `_JAX_MEMORY_SPACE_SUPPORT` to check the JAX version and preserving the previous code.

I've tested the changes with Fuji models, it would be great to find an optimal solution for this, as we'd like to support AXLearn in JAX-Toolbox again newer JAX versions. 
Please, let me know if you want some changes. Thank you 
