### PR TITLE
Upgrade with Step Degradation Fix + Re-enable Goodput Monitoring

### DIFF
--- a/axlearn/cloud/gcp/measurement.py
+++ b/axlearn/cloud/gcp/measurement.py
@@ -59,10 +59,8 @@ class GoodputRecorder(measurement.Recorder):
         upload_interval: Required[int] = REQUIRED
         rolling_window_size: Sequence[int] = []
         jax_backend: Optional[str] = None
-        # Disabled by default because of performance degradation. This doesn't disable goodput
-        # recording.
-        # TODO (apolloreno): once the performance degradation is fixed, will change default to True
-        enable_monitoring: bool = False
+        # Enable or disable monitoring. Recording is always enabled.
+        enable_monitoring: bool = True
 
     @classmethod
     def from_flags(cls, fv: flags.FlagValues) -> "GoodputRecorder":
@@ -77,7 +75,7 @@ class GoodputRecorder(measurement.Recorder):
         - rolling_window_size: Comma-separated list of integers representing rolling window
             sizes in seconds.
         - jax_backend: The type of jax backend.
-        - enable_monitoring: Boolean to enable/disable goodput monitoring (default: false).
+        - enable_monitoring: Boolean to enable/disable goodput monitoring (default: true).
         """
         cfg: measurement.Recorder.Config = cls.default_config()
         parsed_flags = parse_kv_flags(fv.recorder_spec, delimiter="=")

--- a/axlearn/cloud/gcp/measurement_test.py
+++ b/axlearn/cloud/gcp/measurement_test.py
@@ -65,7 +65,7 @@ class GoodputRecorderTest(parameterized.TestCase):
         recorder_spec,
         expected_rolling_window_size,
         expected_jax_backend,
-        expected_enable_monitoring=False,
+        expected_enable_monitoring=True,
     ):
         """Tests that flags are correctly parsed into the config."""
         mock_fv = mock.MagicMock(spec=flags.FlagValues)
@@ -403,35 +403,35 @@ class GoodputRecorderTest(parameterized.TestCase):
                 mock_monitor_instance.stop_rolling_window_goodput_uploader.assert_not_called()
 
     @mock.patch("jax.process_index", return_value=0)
-    def test_enable_monitoring_disabled_by_default(self, _):
-        """Tests that monitoring is disabled by default (enable_monitoring=False)."""
+    def test_enable_monitoring_enabled_by_default(self, _):
+        """Tests that monitoring is enabled by default (enable_monitoring=True)."""
         cfg = GoodputRecorder.default_config().set(
-            name="test-disabled",
+            name="test-default-enabled",
             upload_dir="/test",
             upload_interval=30,
-            # enable_monitoring defaults to False
+            # Enable_monitoring defaults to True.
             rolling_window_size=[10, 20],
         )
         recorder = GoodputRecorder(cfg)
 
-        # Verify the flag defaults to False
-        self.assertFalse(recorder.config.enable_monitoring)
+        # Verify the flag defaults to True
+        self.assertTrue(recorder.config.enable_monitoring)
 
         with mock.patch("ml_goodput_measurement.monitoring.GoodputMonitor") as mock_monitor_cls:
-            # Test that cumulative goodput monitoring is skipped
+            # Test that cumulative goodput monitoring is active by default.
             with recorder._maybe_monitor_goodput():
                 pass
-            mock_monitor_cls.assert_not_called()
+            mock_monitor_cls.assert_called()
 
-            # Test that rolling window monitoring is skipped
+            # Test that rolling window monitoring is active by default.
             with recorder._maybe_monitor_rolling_window_goodput():
                 pass
-            mock_monitor_cls.assert_not_called()
+            mock_monitor_cls.assert_called()
 
             # Test that maybe_monitor_all is skipped
             with recorder.maybe_monitor_all():
                 pass
-            mock_monitor_cls.assert_not_called()
+            mock_monitor_cls.assert_called()
 
     @mock.patch("jax.process_index", return_value=0)
     def test_enable_monitoring_explicitly_disabled(self, _):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ gcp = [
     "google-cloud-compute==1.19.2", # Needed for region discovery for CloudBuild API access.
     "google-cloud-core==2.3.3",
     "google-cloud-build==3.24.1",
-    "ml-goodput-measurement==0.0.14",
+    "ml-goodput-measurement==0.0.15",
     "pika==1.3.2",  # used by event queue
     "pyOpenSSL>=22.1.0",  # compat with cryptography version.
     "tpu-info==0.2.0", # For TPU monitoring from libtpu. https://github.com/AI-Hypercomputer/cloud-accelerator-diagnostics/tree/main/tpu_info


### PR DESCRIPTION
This PR bumps the `ml-goodput-measurement` package version to 0.0.15 to integrate a critical performance fix for the GoodputMonitor.

Context
This release contains a major refactor GoodputMonitor to use multiprocessing throughout all APIs, instead of multithreading. 

A step time degradation caused on a previous run caused by Python's Global Interpreter Lock (GIL) starving the main process due to the GoodputMonitor's tight-computation loops when there are multiple restarts is resolved with this fix. 

Tests:
- Example runs [1](https://cloudlogging.app.goo.gl/6wvrmByBYWsbrBui7), [2](https://cloudlogging.app.goo.gl/7mPJJfhQi7d64fX7A)
- Dashboards for run 1: 
<img width="1515" height="732" alt="image" src="https://github.com/user-attachments/assets/139b2ba3-458b-4ff4-879f-1a650a2551c5" />
<img width="1513" height="821" alt="image" src="https://github.com/user-attachments/assets/03d9aae4-470e-4576-8460-bd66400408f7" />
