### PR TITLE
Improve pathways checkpoint load times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,12 +91,20 @@ ENTRYPOINT ["/opt/apache/beam/boot"]
 FROM base AS tpu
 
 ARG EXTRAS=
+# Install a custom jaxlib that includes backport of Pathways shared memory feature.
+# PR: https://github.com/openxla/xla/pull/31417
+# Needed until Jax is upgraded to 0.8.0 or newer.
+ARG INSTALL_PATHWAYS_JAXLIB=false
 
 ENV UV_FIND_LINKS=https://storage.googleapis.com/jax-releases/libtpu_releases.html
 # Ensure we install the TPU version, even if building locally.
 # Jax will fallback to CPU when run on a machine without TPU.
 RUN uv pip install -qq --prerelease=allow .[core,tpu] && uv cache clean
 RUN if [ -n "$EXTRAS" ]; then uv pip install -qq .[$EXTRAS] && uv cache clean; fi
+RUN if [ "$INSTALL_PATHWAYS_JAXLIB" = "true" ]; then \
+      uv pip install --prerelease=allow "jaxlib==0.5.3.dev20250918" \
+        --find-links https://storage.googleapis.com/axlearn-wheels/wheels.html; \
+    fi
 COPY . .
 
 ################################################################################

--- a/axlearn/cloud/gcp/pathways_utils.py
+++ b/axlearn/cloud/gcp/pathways_utils.py
@@ -48,7 +48,7 @@ _PATHWAYS_WORKER_PORT = 29001
 # There is no guarantee that this image will work with newer Jax releases.
 # This image version extends GRPC timeout for long context models, based on jax-0.5.3-patch060625
 # This image extends GRPC timeout for long context models.
-_PATHWAYS_IMAGE_TAG = "disable_settings_20250701"
+_PATHWAYS_IMAGE_TAG = "shm_proxy"
 # The docker image used by pathways proxy container.
 _PATHWAYS_PROXY_IMAGE = (
     f"us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:{_PATHWAYS_IMAGE_TAG}"
@@ -275,7 +275,12 @@ class PathwaysReplicatedJob(BaseReplicatedJob):
         # In Jax 0.6.2 and beyond this flag can be renamed to
         # IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS as well.
         self._update_env_list(env_list, "TEST_UNDECLARED_OUTPUTS_DIR", "true")
-
+        # Threshold for using shared memory between Jax client and Pathways proxy.
+        # Setting it to 1 byte so effectively all Jax device_put use shared memory.
+        self._update_env_list(env_list, "IFRT_PROXY_LARGE_TRANSFER_THRESHOLD", "1")
+        self._update_env_list(
+            env_list, "IFRT_PROXY_LARGE_TRANSFER_OPTIMIZATION_DIRECTORY", "/tmp/ifrt_proxy"
+        )
         env_list.append(
             {
                 "name": "HOST_ADDRESS",
@@ -315,9 +320,12 @@ class PathwaysReplicatedJob(BaseReplicatedJob):
         mem_req = f"{self.config.pathways_head_mem}Gi"
         resources = {
             "requests": {"cpu": cpu_req, "memory": mem_req},
-            "limits": {"cpu": cpu_req, "memory": mem_req},
         }
         head_container["resources"] = resources
+
+        volume_mounts = head_container.get("volumeMounts", [])
+        volume_mounts.append(dict(name="shared-memory", mountPath="/tmp/ifrt_proxy"))
+        head_container["volumeMounts"] = volume_mounts
 
         return head_container
 
@@ -363,9 +371,16 @@ class PathwaysReplicatedJob(BaseReplicatedJob):
                     # TODO(samos123): Remove this once this becomes the default.
                     {"name": "IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS", "value": "true"},
                     {"name": "XLA_FLAGS", "value": f"--xla_dump_to=/output/{cfg.name}/xla"},
+                    {
+                        "name": "IFRT_PROXY_LARGE_TRANSFER_OPTIMIZATION_DIRECTORY",
+                        "value": "/tmp/ifrt_proxy",
+                    },
                 ],
                 ports=[dict(containerPort=_PATHWAYS_PROXY_PORT)],
-                volumeMounts=[dict(name="shared-output", mountPath="/output")],
+                volumeMounts=[
+                    dict(name="shared-output", mountPath="/output"),
+                    dict(name="shared-memory", mountPath="/tmp/ifrt_proxy"),
+                ],
             ),
             dict(
                 name=_PATHWAYS_RESOURCE_MANAGER_CONTAINER_NAME,
@@ -403,6 +418,7 @@ class PathwaysReplicatedJob(BaseReplicatedJob):
             labels.update({BASTION_JOB_VERSION_LABEL: os.environ.get(BASTION_JOB_VERSION_ENV_VAR)})
 
         volumes.append(dict(name="shared-output", emptyDir={}))
+        volumes.append(dict(name="shared-memory", emptyDir=dict(medium="Memory")))
 
         if cfg.gcsfuse_mount:
             annotations.update(
@@ -537,6 +553,12 @@ class PathwaysReplicatedJob(BaseReplicatedJob):
             f"--resource_manager_address={pathways_head_address}:"
             + f"{_PATHWAYS_RESOURCE_MANAGER_PORT}",
             f"--gcs_scratch_location={cfg.output_dir}/pathways-staging",
+            # Recycling host memory gives a slight increase in performance.
+            "--tpu_pinned_host_allocation_recycle=true",
+            # The flag below is needed for better H2D performance.
+            # Rule of thumb: 3x the shard size. So 128GB to be safe.
+            # Decrease if you start running out of host memory on TPU VMs.
+            "--tpu_premapped_buffer_size=137438953472",
         ]
         mega_scale_args = xla_flags_from_options(self._mxla_options).split()
         worker_container["args"].extend(mega_scale_args)
@@ -936,9 +958,9 @@ class PathwaysLeaderWorkerTemplate(BaseLeaderWorkerTemplate):
             ],
             imagePullPolicy="Always",
             resources=resources,
-            ports=[dict(containerPort=self.config.target_port)]
-            if self.config.enable_service
-            else [],
+            ports=(
+                [dict(containerPort=self.config.target_port)] if self.config.enable_service else []
+            ),
         )
 
     def build_leader_pod(self) -> Nested[Any]:

--- a/axlearn/common/array_serialization.py
+++ b/axlearn/common/array_serialization.py
@@ -205,8 +205,7 @@ def _fix_metadata(tspec: dict[str, Any], shard_infos: list[_ShardInfo]):
 
 
 class TensorstoreSpecModifier:
-    def __call__(self, spec: dict[str, Any], *, shard_infos: list[_ShardInfo]):
-        ...
+    def __call__(self, spec: dict[str, Any], *, shard_infos: list[_ShardInfo]): ...
 
 
 async def _async_serialize(
@@ -362,6 +361,7 @@ async def _async_deserialize(
     h2d_limiter: serialization._LimitInFlightBytes,
     byte_limiter: serialization._LimitInFlightBytes,
     single_thread_pool: ThreadPoolExecutor,
+    multi_thread_pool: ThreadPoolExecutor,
 ):
     """Modified from
     https://github.com/jax-ml/jax/blob/e7ec418eba9ada336f755613948cbdf4a9e97d59/jax/experimental/array_serialization/serialization.py#L345
@@ -404,12 +404,22 @@ async def _async_deserialize(
             f" an instance of `jax.sharding.Sharding`. Got {in_sharding}"
         )
     dll = user_in_sharding.device_local_layout if isinstance(user_in_sharding, Layout) else None
-    t = await ts.open(
-        tensorstore_spec,
-        open=True,
-        assume_metadata=False,
-        context=serialization.TS_CONTEXT,
-    )
+
+    # gcs_grpc provides 2x to 4x better read performance.
+    if tensorstore_spec.get("kvstore", {}).get("driver") == "gcs":
+        tensorstore_spec["kvstore"]["driver"] = "gcs_grpc"
+
+    context = serialization.TS_CONTEXT
+    if "gcs" in tensorstore_spec.get("kvstore", {}).get("driver", ""):
+        context = ts.Context(
+            {
+                "cache_pool": {"total_bytes_limit": 0},
+                "data_copy_concurrency": {"limit": "shared"},
+                # TODO(samos123): Make this dynamic based on number of CPUs.
+                "gcs_request_concurrency": {"limit": 480},
+            }
+        )
+    t = await ts.open(tensorstore_spec, open=True, assume_metadata=False, context=context)
     shape = tuple(t.shape if global_shape is None else global_shape)
     new_shard_shape = in_sharding.shard_shape(shape)
     loop = asyncio.get_running_loop()
@@ -434,10 +444,15 @@ async def _async_deserialize(
             # the extra values will be filled with 0s.
             out = np.zeros(new_shard_shape, read_ts.dtype.numpy_dtype)
 
+        ts_read_start_time = time.time()
         await ts.array(out)[ts.d[:].translate_to[requested_domain.origin]][restricted_domain].write(
             read_ts
         )
-
+        logging.debug(
+            "Reading %d MB from tensorstore took %.4f seconds.",
+            requested_bytes // 1024 // 1024,
+            time.time() - ts_read_start_time,
+        )
         # Convert to jnp array so that layouts are initialized properly for
         # sub-byte dtypes.
         # TODO(yashkatariya): This is a band-aid fix. Figure out a better way to
@@ -454,9 +469,16 @@ async def _async_deserialize(
             dll, jax.sharding.SingleDeviceSharding(device, memory_kind=in_sharding.memory_kind)
         )
         try:
-            await h2d_limiter.wait_for_bytes(out_size)
-            result = await loop.run_in_executor(None, _blocking_device_put, out, layout)
-            await h2d_limiter.release_bytes(out_size)
+            # Pathways checkpoint loading does not require h2d limiter.
+            # The h2d_limiter hurts the performance of checkpoint reads for pathways.
+            if os.getenv("JAX_PLATFORMS") == "proxy":
+                result = await loop.run_in_executor(
+                    multi_thread_pool, _blocking_device_put, out, layout
+                )
+            else:
+                await h2d_limiter.wait_for_bytes(out_size)
+                result = await loop.run_in_executor(None, _blocking_device_put, out, layout)
+                await h2d_limiter.release_bytes(out_size)
         except ValueError as e:
             if "Requested more bytes than we reserved" not in str(e):
                 raise e  # Raise if it's not the type of error we expect.
@@ -532,7 +554,8 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
         self._loop = asyncio.new_event_loop()
         self._loop_thread = threading.Thread(target=self._loop.run_forever, daemon=True)
         self._loop_thread.start()
-        self._single_thread_pool = ThreadPoolExecutor(1)
+        self._single_thread_pool = ThreadPoolExecutor(max_workers=1)
+        self._multi_thread_pool = ThreadPoolExecutor(max_workers=192)
 
     def stop(self):
         """Cleans up any internal threads."""
@@ -589,6 +612,7 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
         concurrent_gb: int = 32,
     ):
         self.wait_until_finished()
+        start_time = time.time()
 
         concurrent_bytes = concurrent_gb * 10**9
 
@@ -604,6 +628,7 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
                     byte_limiter=byte_limiter,
                     h2d_limiter=h2d_limiter,
                     single_thread_pool=self._single_thread_pool,
+                    multi_thread_pool=self._multi_thread_pool,
                 ),
                 shardings,
                 tensorstore_specs,
@@ -613,7 +638,9 @@ class GlobalAsyncCheckpointManager(serialization.GlobalAsyncCheckpointManager):
             return await asyncio.gather(*future_arrays)
 
         fut = asyncio.run_coroutine_threadsafe(_run_deserializer(), self._loop)
-        return fut.result()
+        result = fut.result()
+        logging.info("deserialize took %.4f seconds.", time.time() - start_time)
+        return result
 
 
 class BoundedDataShardedAsyncCheckpointManager(GlobalAsyncCheckpointManager):


### PR DESCRIPTION
* Utilize a shared memory between the Jax client and pathways proxy for data heavy transfers e.g. device_puts.
* Increase threads of ThreadPoolExecutor from 32 (python default) to 192.
* Remove memory limit from pathways head main container.

Callers of deserialize should utilize a concurrent_restore_gb as large as possible until OOM. Otherwise GCS read and device_put won't happen in parallel. The default of 32GB is too low to achieve optimal performance with Pathways.