### PR TITLE
Fix pre-commit error due to the build/lib directory

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -33,4 +33,4 @@ jobs:
             echo "Manually stopping monitor process..."
             kill $MONITOR_PID || true
           fi
-      - run: pytype -j auto .
+      - run: pytype -j auto axlearn


### PR DESCRIPTION
### Problem

pre-commit has been failing due to 

```
ninja: error: build.ninja:778: multiple rules generate  ...
```

### Debug

By enabling verbose logs `--verbosity=2`, I saw:

```
2025-10-03T01:43:13.1288761Z   /home/runner/work/axlearn/axlearn/axlearn/common/ops/_optimization_barrier.py
...
2025-10-03T01:43:13.2068195Z /home/runner/work/axlearn/axlearn/build/lib/axlearn/common/ops/_optimization_barrier.py
...
2025-10-03T01:43:13.2423522Z source: /home/runner/work/axlearn/axlearn/axlearn/common/ops/_optimization_barrier.py
...
2025-10-03T01:43:13.2613822Z source: /home/runner/work/axlearn/axlearn/build/lib/axlearn/common/ops/_optimization_barrier.py

...
ninja: error: build.ninja:778: multiple rules generate /home/runner/work/axlearn/axlearn/.pytype/pyi/axlearn/common/ops/_optimization_barrier.pyi

```

The error was due to a `/home/runner/work/axlearn/axlearn/build/lib/` directory created by below step:

```
- run: pip install '.[core,audio,orbax,dev,gcp,vertexai_tensorboard,open_api]'
```

See a test: https://github.com/apple/axlearn/actions/runs/18216452533/job/51866623326 to show that the pip install step created the `build/lib` directory

<img width="300" height="1179" alt="Screenshot 2025-10-03 at 1 18 12 AM" src="https://github.com/user-attachments/assets/455d1f8d-f994-460a-921d-778ceefe5117" />


### When did it start to create "build/lib" folder?

By intersect on previous commits, I found it started since https://github.com/apple/axlearn/commit/dc06158ae72ec5cf7c0a21dfab6f239273cb766c

Tested locally by

```
git checkout dc06158ae72ec5cf7c0a21dfab6f239273cb766c
pip install '.[core,audio,orbax,dev,gcp,vertexai_tensorboard,open_api]' --force-reinstall
ls build/lib/
```

