### PR TITLE
Use ast.literal_eval to parse checkpoint shape in colocated_python_benchmark

### DIFF
--- a/axlearn/cloud/gcp/examples/colocated_python_benchmark.py
+++ b/axlearn/cloud/gcp/examples/colocated_python_benchmark.py
@@ -19,6 +19,7 @@ Usage:
 """
 
 import argparse
+import ast
 import os
 import time
 from contextlib import contextmanager
@@ -82,8 +83,11 @@ def create_state_spec_from_checkpoint(ckpt_path: str):
             continue
 
         if isinstance(value, dict) and "shape" in value and "dtype" in value:
-            # pylint: disable=eval-used
-            shape = eval(value["shape"]) if isinstance(value["shape"], str) else value["shape"]
+            shape = (
+                ast.literal_eval(value["shape"])
+                if isinstance(value["shape"], str)
+                else value["shape"]
+            )
             dtype_str = value["dtype"]
 
             # Convert dtype string to jax dtype


### PR DESCRIPTION
Fixes #1364.

`create_state_spec_from_checkpoint` in `colocated_python_benchmark.py` reads the per-tensor `shape` from the checkpoint index returned by `read_index_file`, and when that value is a string it passes it to `eval()`:

```python
shape = eval(value["shape"]) if isinstance(value["shape"], str) else value["shape"]
```

The index file is loaded from the checkpoint path, which can come from an external or shared location, so this evaluates code from data that is not necessarily trusted.

The `shape` is only ever a literal tuple or list of integers, so `ast.literal_eval` parses it to the same value while rejecting anything that is not a Python literal. This removes the code-execution path and lets the `# pylint: disable=eval-used` suppression go away.

`ast.literal_eval` round-trips the shapes this code sees (`"(2, 3)"`, `"(1024,)"`, `"[2, 3, 4]"`, `"()"`), so behavior is unchanged for valid checkpoints.
